### PR TITLE
Create alias for response union type

### DIFF
--- a/arbeitszeit_flask/company/blueprint.py
+++ b/arbeitszeit_flask/company/blueprint.py
@@ -1,9 +1,10 @@
 from functools import wraps
 from typing import Any, Callable
 
-from flask import Blueprint, Response, redirect, session, url_for
+from flask import Blueprint, redirect, session, url_for
 from flask_login import current_user, login_required
 
+from arbeitszeit_flask import types
 from arbeitszeit_flask.dependency_injection import CompanyModule, with_injection
 
 main_company = Blueprint(
@@ -19,11 +20,11 @@ class CompanyRoute:
         else:
             self.methods = methods
 
-    def __call__(self, view_function: Callable[..., Response]):
+    def __call__(self, view_function: Callable[..., types.Response]):
         @wraps(view_function)
-        def _wrapper(*args: Any, **kwargs: Any) -> Response:
+        def _wrapper(*args: Any, **kwargs: Any) -> types.Response:
             if not user_is_company():
-                return redirect(url_for("auth.zurueck"))  # type: ignore
+                return redirect(url_for("auth.zurueck"))
             return view_function(*args, **kwargs)
 
         return self._apply_decorators(_wrapper)

--- a/arbeitszeit_flask/member/blueprint.py
+++ b/arbeitszeit_flask/member/blueprint.py
@@ -1,9 +1,10 @@
 from functools import wraps
 from typing import Any, Callable
 
-from flask import Blueprint, Response, redirect, session, url_for
+from flask import Blueprint, redirect, session, url_for
 from flask_login import current_user, login_required
 
+from arbeitszeit_flask import types
 from arbeitszeit_flask.dependency_injection import MemberModule, with_injection
 
 main_member = Blueprint(
@@ -19,11 +20,11 @@ class MemberRoute:
         else:
             self.methods = methods
 
-    def __call__(self, view_function: Callable[..., Response]):
+    def __call__(self, view_function: Callable[..., types.Response]):
         @wraps(view_function)
-        def _wrapper(*args: Any, **kwargs: Any) -> Response:
+        def _wrapper(*args: Any, **kwargs: Any) -> types.Response:
             if not user_is_member():
-                return redirect(url_for("auth.zurueck"))  # type: ignore
+                return redirect(url_for("auth.zurueck"))
             return view_function(*args, **kwargs)
 
         return self._apply_decorators(_wrapper)

--- a/arbeitszeit_flask/types.py
+++ b/arbeitszeit_flask/types.py
@@ -1,0 +1,6 @@
+from typing import Union
+
+import flask
+import werkzeug.wrappers.response
+
+Response = Union[flask.Response, werkzeug.wrappers.response.Response]

--- a/arbeitszeit_flask/views/end_cooperation_view.py
+++ b/arbeitszeit_flask/views/end_cooperation_view.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
-from flask import Response, redirect
+from flask import redirect
 
 from arbeitszeit.use_cases.end_cooperation import EndCooperation
+from arbeitszeit_flask import types
 from arbeitszeit_flask.views.http_404_view import Http404View
 from arbeitszeit_web.controllers.end_cooperation_controller import (
     EndCooperationController,
@@ -17,7 +18,7 @@ class EndCooperationView:
     presenter: EndCooperationPresenter
     http_404_view: Http404View
 
-    def respond_to_get(self) -> Response:
+    def respond_to_get(self) -> types.Response:
         use_case_request = self.controller.process_request_data()
         if use_case_request is None:
             return self.http_404_view.get_response()
@@ -25,4 +26,4 @@ class EndCooperationView:
         view_model = self.presenter.present(use_case_response)
         if view_model.show_404:
             return self.http_404_view.get_response()
-        return redirect(view_model.redirect_url)  # type: ignore
+        return redirect(view_model.redirect_url)


### PR DESCRIPTION
Before this change it was difficult to annotate view functions that would return a redirect. This issue came from an oversight in the type hints for `flask` itself. The `flask.redirect` method does not return a `flask.Response` object but instead an object of type `werkzeug.wrappers.response.Response`.

This issue was "resolved" by creating a type alias for `Union[flask.Response, werkzeug.wrappers.response.Response]`. Programmers are encouraged to uses this new type alias when annotating functions.