### PR TITLE
Avoid running unittests in CI twice

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,7 +20,8 @@ jobs:
     - uses: cachix/install-nix-action@v16
     - run: nix flake check --print-build-logs
     - run: nix build --print-build-logs
-    - run: nix develop --command './run-checks'
+    # We don't need to run this unittests since they are run as part of 'nix build'
+    - run: nix develop --command ./run-checks --no-unittests
 
   build-pip:
     runs-on: ubuntu-latest

--- a/run-checks
+++ b/run-checks
@@ -1,8 +1,37 @@
 #!/usr/bin/env python
 
+import argparse
 import shlex
 import subprocess
+from dataclasses import dataclass
 from typing import List
+
+
+def main():
+    configuration = get_configuration()
+    autoformatted_paths = read_autoformat_target_paths()
+    run_check_command(["black", "--check"] + autoformatted_paths)
+    run_check_command(["flake8"])
+    run_check_command(["mypy"])
+    if configuration.is_unittests_requested:
+        run_check_command(["pytest"])
+    run_check_command(["isort", "--check"] + autoformatted_paths)
+
+
+@dataclass
+class Configuration:
+    is_unittests_requested: bool
+
+
+def get_configuration() -> Configuration:
+    parser = argparse.ArgumentParser(
+        description="Run automated checks on the code for Arbeitszeitapp"
+    )
+    parser.add_argument(
+        "--no-unittests", dest="unittests", default=True, action="store_false"
+    )
+    arguments = parser.parse_args()
+    return Configuration(is_unittests_requested=arguments.unittests)
 
 
 def run_check_command(command: List[str]) -> None:
@@ -13,15 +42,6 @@ def run_check_command(command: List[str]) -> None:
 def read_autoformat_target_paths() -> List[str]:
     with open(".autoformattingrc") as handle:
         return [line.strip() for line in handle.read().splitlines() if line.strip()]
-
-
-def main():
-    autoformatted_paths = read_autoformat_target_paths()
-    run_check_command(["black", "--check"] + autoformatted_paths)
-    run_check_command(["flake8"])
-    run_check_command(["mypy"])
-    run_check_command(["pytest"])
-    run_check_command(["isort", "--check"] + autoformatted_paths)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before this change the CI pipeline steps using the `nix` build tool were running the unittests twice: Once as part of `nix build` and then again as part of `./run-checks`. To avoid this I introduced an optional argument to the `./run-checks` program that disables unittests.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c