### PR TITLE
Remove cryptography from dependecies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ certifi==2020.12.5
 cffi==1.14.6
 click==8.0.3
 coverage==5.5
-cryptography==3.3.1
 decorator==4.4.2
 dnspython==2.1.0
 email-validator==1.1.3


### PR DESCRIPTION
Cryptography is not required by us. This is why I removed it from our requirements file.

No payment needed.