### PR TITLE
Add product (prd) account details

### DIFF
--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -161,6 +161,10 @@ from .show_company_work_invite_details import (
 )
 from .show_my_plans import ShowMyPlansRequest, ShowMyPlansResponse, ShowMyPlansUseCase
 from .show_p_account_details import ShowPAccountDetails, ShowPAccountDetailsResponse
+from .show_prd_account_details import (
+    ShowPRDAccountDetails,
+    ShowPRDAccountDetailsResponse,
+)
 from .show_r_account_details import ShowRAccountDetails, ShowRAccountDetailsResponse
 from .show_work_invites import ShowWorkInvites, ShowWorkInvitesRequest
 from .toggle_product_availablity import (
@@ -300,6 +304,8 @@ __all__ = [
     "ShowMyPlansUseCase",
     "ShowPAccountDetails",
     "ShowPAccountDetailsResponse",
+    "ShowPRDAccountDetails",
+    "ShowPRDAccountDetailsResponse",
     "ShowRAccountDetails",
     "ShowRAccountDetailsResponse",
     "ShowWorkInvites",

--- a/arbeitszeit/use_cases/show_prd_account_details.py
+++ b/arbeitszeit/use_cases/show_prd_account_details.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+from uuid import UUID
+
+from injector import inject
+
+from arbeitszeit.entities import AccountTypes, Company, Transaction
+from arbeitszeit.repositories import AccountRepository, CompanyRepository
+from arbeitszeit.transactions import TransactionTypes, UserAccountingService
+
+
+@dataclass
+class TransactionInfo:
+    transaction_type: TransactionTypes
+    date: datetime
+    transaction_volume: Decimal
+    purpose: str
+
+
+@dataclass
+class ShowPRDAccountDetailsResponse:
+    transactions: List[TransactionInfo]
+    account_balance: Decimal
+
+
+@inject
+@dataclass
+class ShowPRDAccountDetails:
+    accounting_service: UserAccountingService
+    company_repository: CompanyRepository
+    account_repository: AccountRepository
+
+    def __call__(self, company_id: UUID) -> ShowPRDAccountDetailsResponse:
+        company = self.company_repository.get_by_id(company_id)
+        assert company
+        transactions = [
+            self._create_info(company, transaction)
+            for transaction in self.accounting_service.get_account_transactions_sorted(
+                company, AccountTypes.prd
+            )
+        ]
+        account_balance = self.account_repository.get_account_balance(
+            company.product_account
+        )
+        return ShowPRDAccountDetailsResponse(
+            transactions=transactions, account_balance=account_balance
+        )
+
+    def _create_info(
+        self,
+        company: Company,
+        transaction: Transaction,
+    ) -> TransactionInfo:
+        user_is_sender = self.accounting_service.user_is_sender(transaction, company)
+        transaction_type = self.accounting_service.get_transaction_type(
+            transaction, user_is_sender
+        )
+        transaction_volume = self.accounting_service.get_transaction_volume(
+            transaction,
+            user_is_sender,
+        )
+        return TransactionInfo(
+            transaction_type,
+            transaction.date,
+            transaction_volume,
+            transaction.purpose,
+        )

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -84,6 +84,9 @@ from arbeitszeit_web.list_plans import ListPlansPresenter
 from arbeitszeit_web.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
 )
+from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
+    ShowPRDAccountDetailsPresenter,
+)
 from arbeitszeit_web.query_companies import (
     QueryCompaniesController,
     QueryCompaniesPresenter,
@@ -417,6 +420,21 @@ def account_a(
 
     return template_renderer.render_template(
         "company/account_a.html",
+        context=dict(view_model=view_model),
+    )
+
+
+@CompanyRoute("/company/my_accounts/account_prd")
+def account_prd(
+    show_prd_account_details: use_cases.ShowPRDAccountDetails,
+    template_renderer: UserTemplateRenderer,
+    presenter: ShowPRDAccountDetailsPresenter,
+):
+    response = show_prd_account_details(UUID(current_user.id))
+    view_model = presenter.present(response)
+
+    return template_renderer.render_template(
+        "company/account_prd.html",
         context=dict(view_model=view_model),
     )
 

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -108,6 +108,9 @@ from arbeitszeit_web.presenters.send_confirmation_email_presenter import (
 from arbeitszeit_web.presenters.show_company_work_invite_details_presenter import (
     ShowCompanyWorkInviteDetailsPresenter,
 )
+from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
+    ShowPRDAccountDetailsPresenter,
+)
 from arbeitszeit_web.query_companies import QueryCompaniesPresenter
 from arbeitszeit_web.query_plans import QueryPlansPresenter
 from arbeitszeit_web.read_message import ReadMessageController, ReadMessagePresenter
@@ -328,6 +331,12 @@ class CompanyModule(Module):
         self, url_index: CompanyUrlIndex
     ) -> AnswerCompanyWorkInviteUrlIndex:
         return url_index
+
+    @provider
+    def provide_show_prd_account_details_presenter(
+        self, translator: Translator
+    ) -> ShowPRDAccountDetailsPresenter:
+        return ShowPRDAccountDetailsPresenter(translator=translator)
 
 
 class FlaskModule(Module):

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -1,0 +1,56 @@
+{% extends "base_company.html" %}
+{% from 'macros/show_notifications.html' import show_notifications %}
+
+{% block content2 %}
+
+
+<h1 class="title">
+    <a href="{{ url_for('main_company.my_accounts') }}">Accounts</a> > Account prd
+</h1>
+<div class="box has-background-info-light has-text-info-dark">
+    <div class="icon"><i class="fas fa-info-circle"></i></div>
+    <p>Your account for product transfers (sales).</p>
+</div>
+
+{{ show_notifications() }}
+
+<p>Balance:</p>
+<p
+    class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
+    {{ view_model.account_balance }}</p>
+
+
+<div class="table-container">
+    <table class="table is-fullwidth">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Type</th>
+                <th>Details</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+
+            {% if view_model.transactions is defined and view_model.transactions|length %}
+            {% for trans_info in view_model.transactions %}
+            <tr>
+                <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>
+                <td>
+                    {{ trans_info.transaction_type }}
+                </td>
+                <td>{{ trans_info.purpose }}</td>
+                <td
+                    class="has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
+                    {{
+                    trans_info.transaction_volume }}
+                </td>
+            </tr>
+            {% endfor %}
+            {% endif %}
+
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -19,7 +19,6 @@
     class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
     {{ view_model.account_balance }}</p>
 
-
 <div class="table-container">
     <table class="table is-fullwidth">
         <thead>
@@ -32,7 +31,7 @@
         </thead>
         <tbody>
 
-            {% if view_model.transactions is defined and view_model.transactions|length %}
+            {% if view_model.show_transactions %}
             {% for trans_info in view_model.transactions %}
             <tr>
                 <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -5,16 +5,16 @@
 
 
 <h1 class="title">
-    <a href="{{ url_for('main_company.my_accounts') }}">Accounts</a> > Account prd
+    <a href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a> > {{ gettext("Account prd") }}
 </h1>
 <div class="box has-background-info-light has-text-info-dark">
     <div class="icon"><i class="fas fa-info-circle"></i></div>
-    <p>Your account for product transfers (sales).</p>
+    <p>{{ gettext("Your account for product transfers (sales).") }}</p>
 </div>
 
 {{ show_notifications() }}
 
-<p>Balance:</p>
+<p>{{ gettext("Balance:") }}</p>
 <p
     class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
     {{ view_model.account_balance }}</p>
@@ -24,8 +24,8 @@
         <thead>
             <tr>
                 <th></th>
-                <th>Type</th>
-                <th>Details</th>
+                <th>{{ gettext("Type") }}</th>
+                <th>{{ gettext("Details") }}</th>
                 <th></th>
             </tr>
         </thead>

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -60,7 +60,8 @@
 
                     </tr>
                     <tr>
-                        <td class="py-2 has-text-left">Account prd</td>
+                        <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">Account
+                                prd</a></td>
                         <td><i class="fas fa-exchange-alt"></i></td>
                         <td class="is-italic has-text-left">Account for product transfers (sales)</td>
                         <td

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -5,11 +5,11 @@
 
 
 <h1 class="title">
-    Accounts
+    {{ gettext("Accounts") }}
 </h1>
 <div class="box has-background-info-light has-text-info-dark">
     <div class="icon"><i class="fas fa-info-circle"></i></div>
-    <p>You have four different accounts.</p>
+    <p>{{ gettext("You have four different accounts.") }}</p>
 </div>
 
 {{ show_notifications() }}
@@ -30,40 +30,43 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_p') }}">Account p</a>
+                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_p') }}">{{
+                                gettext("Account p") }}</a>
                         </td>
                         <td><i class="fas fa-industry"></i></td>
-                        <td class="is-italic has-text-left">Account for fixed means of production</td>
+                        <td class="is-italic has-text-left">{{ gettext("Account for fixed means of production") }}</td>
                         <td
                             class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
                             {{ view_model.balance_fixed }}</td>
 
                     </tr>
                     <tr>
-                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_r') }}">Account r</a>
+                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_r') }}">{{
+                                gettext("Account r") }}</a>
                         </td>
                         <td><i class="fas fa-oil-can"></i></td>
-                        <td class="is-italic has-text-left">Account for liquid means of production</td>
+                        <td class="is-italic has-text-left">{{ gettext("Account for liquid means of production")}}</td>
                         <td
                             class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
                             {{ view_model.balance_liquid }}</td>
 
                     </tr>
                     <tr>
-                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_a') }}">Account a</a>
+                        <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_a') }}">{{
+                                gettext("Account a") }}</a>
                         </td>
                         <td><i class="fas fa-users"></i></td>
-                        <td class="is-italic has-text-left">Account for work certificates (wages)</td>
+                        <td class="is-italic has-text-left">{{ gettext("Account for work certificates (wages)") }}</td>
                         <td
                             class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
                             {{ view_model.balance_work }}</td>
 
                     </tr>
                     <tr>
-                        <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">Account
-                                prd</a></td>
+                        <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">{{
+                                gettext("Account prd") }}</a></td>
                         <td><i class="fas fa-exchange-alt"></i></td>
-                        <td class="is-italic has-text-left">Account for product transfers (sales)</td>
+                        <td class="is-italic has-text-left">{{ gettext("Account for product transfers (sales)") }}</td>
                         <td
                             class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
                             {{ view_model.balance_product }}</td>
@@ -73,7 +76,7 @@
 
             </table>
         </div>
-        <p><a href="{{ url_for('main_company.list_all_transactions') }}">List all transactions</a></p>
+        <p><a href="{{ url_for('main_company.list_all_transactions') }}">{{ gettext("List all transactions") }}</a></p>
     </div>
     <div class="column"></div>
 </div>

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -7,6 +7,7 @@ from arbeitszeit.use_cases.show_prd_account_details import (
     ShowPRDAccountDetailsResponse,
     TransactionInfo,
 )
+from arbeitszeit_web.translator import Translator
 
 
 @dataclass
@@ -24,7 +25,10 @@ class ShowPRDAccountDetailsResponseViewModel:
     account_balance: str
 
 
+@dataclass
 class ShowPRDAccountDetailsPresenter:
+    translator: Translator
+
     def present(
         self, use_case_response: ShowPRDAccountDetailsResponse
     ) -> ShowPRDAccountDetailsResponseViewModel:
@@ -46,9 +50,9 @@ class ShowPRDAccountDetailsPresenter:
             TransactionTypes.expected_sales,
         ]
         transaction_type = (
-            "Debit expected sales"
+            self.translator.gettext("Debit expected sales")
             if transaction.transaction_type == TransactionTypes.expected_sales
-            else "Sale"
+            else self.translator.gettext("Sale")
         )
         return ViewModelTransactionInfo(
             transaction_type,

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -20,6 +20,7 @@ class ViewModelTransactionInfo:
 @dataclass
 class ShowPRDAccountDetailsResponseViewModel:
     transactions: List[ViewModelTransactionInfo]
+    show_transactions: bool
     account_balance: str
 
 
@@ -33,6 +34,7 @@ class ShowPRDAccountDetailsPresenter:
         ]
         return ShowPRDAccountDetailsResponseViewModel(
             transactions=transactions,
+            show_transactions=bool(transactions),
             account_balance=str(round(use_case_response.account_balance, 2)),
         )
 

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from arbeitszeit.transactions import TransactionTypes
+from arbeitszeit.use_cases.show_prd_account_details import (
+    ShowPRDAccountDetailsResponse,
+    TransactionInfo,
+)
+
+
+@dataclass
+class ViewModelTransactionInfo:
+    transaction_type: str
+    date: datetime
+    transaction_volume: str
+    purpose: str
+
+
+@dataclass
+class ShowPRDAccountDetailsResponseViewModel:
+    transactions: List[ViewModelTransactionInfo]
+    account_balance: str
+
+
+class ShowPRDAccountDetailsPresenter:
+    def present(
+        self, use_case_response: ShowPRDAccountDetailsResponse
+    ) -> ShowPRDAccountDetailsResponseViewModel:
+        transactions = [
+            self._create_info(transaction)
+            for transaction in use_case_response.transactions
+        ]
+        return ShowPRDAccountDetailsResponseViewModel(
+            transactions=transactions,
+            account_balance=str(round(use_case_response.account_balance, 2)),
+        )
+
+    def _create_info(self, transaction: TransactionInfo) -> ViewModelTransactionInfo:
+        assert transaction.transaction_type in [
+            TransactionTypes.sale_of_consumer_product,
+            TransactionTypes.sale_of_fixed_means,
+            TransactionTypes.sale_of_liquid_means,
+            TransactionTypes.expected_sales,
+        ]
+        transaction_type = (
+            "Debit expected sales"
+            if transaction.transaction_type == TransactionTypes.expected_sales
+            else "Sale"
+        )
+        return ViewModelTransactionInfo(
+            transaction_type,
+            transaction.date,
+            str(round(transaction.transaction_volume, 2)),
+            transaction.purpose,
+        )

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -39,6 +39,13 @@ class CompanyTransactionsPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.transactions, [])
 
+    def test_do_not_show_transactions_if_no_transactions_took_place(self):
+        response = ShowPRDAccountDetailsResponse(
+            transactions=[], account_balance=Decimal(0)
+        )
+        view_model = self.presenter.present(response)
+        self.assertFalse(view_model.show_transactions)
+
     def test_return_correct_info_when_one_transaction_of_granting_credit_took_place(
         self,
     ):

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from decimal import Decimal
+from unittest import TestCase
+
+from arbeitszeit.transactions import TransactionTypes
+from arbeitszeit.use_cases.show_prd_account_details import (
+    ShowPRDAccountDetailsResponse,
+    TransactionInfo,
+)
+from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
+    ShowPRDAccountDetailsPresenter,
+)
+from tests.use_cases.dependency_injection import get_dependency_injector
+
+DEFAULT_INFO1 = TransactionInfo(
+    transaction_type=TransactionTypes.expected_sales,
+    date=datetime.now(),
+    transaction_volume=Decimal(10.007),
+    purpose="Test purpose",
+)
+
+DEFAULT_INFO2 = TransactionInfo(
+    transaction_type=TransactionTypes.sale_of_consumer_product,
+    date=datetime.now(),
+    transaction_volume=Decimal(20),
+    purpose="Test purpose",
+)
+
+
+class CompanyTransactionsPresenterTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(ShowPRDAccountDetailsPresenter)
+
+    def test_return_empty_list_when_no_transactions_took_place(self):
+        response = ShowPRDAccountDetailsResponse(
+            transactions=[], account_balance=Decimal(0)
+        )
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.transactions, [])
+
+    def test_return_correct_info_when_one_transaction_of_granting_credit_took_place(
+        self,
+    ):
+        response = ShowPRDAccountDetailsResponse(
+            transactions=[DEFAULT_INFO1], account_balance=Decimal(100.007)
+        )
+        view_model = self.presenter.present(response)
+        self.assertTrue(len(view_model.transactions), 1)
+        self.assertEqual(view_model.account_balance, "100.01")
+        trans = view_model.transactions[0]
+        self.assertEqual(trans.transaction_type, "Debit expected sales")
+        self.assertIsInstance(trans.date, datetime)
+        self.assertEqual(trans.transaction_volume, "10.01")
+        self.assertIsInstance(trans.purpose, str)
+
+    def test_return_correct_info_when_one_transaction_of_selling_consumer_product_took_place(
+        self,
+    ):
+        response = ShowPRDAccountDetailsResponse(
+            transactions=[DEFAULT_INFO2], account_balance=Decimal(100.007)
+        )
+        view_model = self.presenter.present(response)
+        self.assertTrue(len(view_model.transactions), 1)
+        self.assertEqual(view_model.account_balance, "100.01")
+        trans = view_model.transactions[0]
+        self.assertEqual(trans.transaction_type, "Sale")
+        self.assertIsInstance(trans.date, datetime)
+        self.assertEqual(trans.transaction_volume, "20.00")
+        self.assertIsInstance(trans.purpose, str)
+
+    def test_return_two_transactions_when_two_transactions_took_place(self):
+        response = ShowPRDAccountDetailsResponse(
+            transactions=[DEFAULT_INFO1, DEFAULT_INFO2], account_balance=Decimal(100)
+        )
+        view_model = self.presenter.present(response)
+        self.assertTrue(len(view_model.transactions), 2)

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -10,7 +10,7 @@ from arbeitszeit.use_cases.show_prd_account_details import (
 from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
 )
-from tests.use_cases.dependency_injection import get_dependency_injector
+from tests.translator import FakeTranslator
 
 DEFAULT_INFO1 = TransactionInfo(
     transaction_type=TransactionTypes.expected_sales,
@@ -29,8 +29,8 @@ DEFAULT_INFO2 = TransactionInfo(
 
 class CompanyTransactionsPresenterTests(TestCase):
     def setUp(self) -> None:
-        self.injector = get_dependency_injector()
-        self.presenter = self.injector.get(ShowPRDAccountDetailsPresenter)
+        self.translator = FakeTranslator()
+        self.presenter = ShowPRDAccountDetailsPresenter(translator=self.translator)
 
     def test_return_empty_list_when_no_transactions_took_place(self):
         response = ShowPRDAccountDetailsResponse(
@@ -56,7 +56,9 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertTrue(len(view_model.transactions), 1)
         self.assertEqual(view_model.account_balance, "100.01")
         trans = view_model.transactions[0]
-        self.assertEqual(trans.transaction_type, "Debit expected sales")
+        self.assertEqual(
+            trans.transaction_type, self.translator.gettext("Debit expected sales")
+        )
         self.assertIsInstance(trans.date, datetime)
         self.assertEqual(trans.transaction_volume, "10.01")
         self.assertIsInstance(trans.purpose, str)
@@ -71,7 +73,7 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertTrue(len(view_model.transactions), 1)
         self.assertEqual(view_model.account_balance, "100.01")
         trans = view_model.transactions[0]
-        self.assertEqual(trans.transaction_type, "Sale")
+        self.assertEqual(trans.transaction_type, self.translator.gettext("Sale"))
         self.assertIsInstance(trans.date, datetime)
         self.assertEqual(trans.transaction_volume, "20.00")
         self.assertIsInstance(trans.purpose, str)

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -1,0 +1,221 @@
+from datetime import datetime
+from decimal import Decimal
+
+from arbeitszeit.entities import SocialAccounting
+from arbeitszeit.transactions import TransactionTypes
+from arbeitszeit.use_cases import ShowPRDAccountDetails
+from tests.data_generators import (
+    CompanyGenerator,
+    MemberGenerator,
+    TransactionGenerator,
+)
+
+from .dependency_injection import injection_test
+
+
+@injection_test
+def test_no_transactions_returned_when_no_transactions_took_place(
+    show_prd_account_details: ShowPRDAccountDetails,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+):
+    member_generator.create_member()
+    company = company_generator.create_company()
+
+    response = show_prd_account_details(company.id)
+    assert not response.transactions
+
+
+@injection_test
+def test_balance_is_zero_when_no_transactions_took_place(
+    show_prd_account_details: ShowPRDAccountDetails,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+):
+    member_generator.create_member()
+    company = company_generator.create_company()
+
+    response = show_prd_account_details(company.id)
+    assert response.account_balance == 0
+
+
+@injection_test
+def test_that_no_info_is_generated_after_company_buying_p(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company1 = company_generator.create_company()
+    company2 = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=company1.means_account,
+        receiving_account=company2.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+
+    response = show_prd_account_details(company1.id)
+    assert len(response.transactions) == 0
+
+
+@injection_test
+def test_that_no_info_is_generated_after_company_buying_r(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company1 = company_generator.create_company()
+    company2 = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=company1.raw_material_account,
+        receiving_account=company2.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+
+    response = show_prd_account_details(company1.id)
+    assert len(response.transactions) == 0
+
+
+@injection_test
+def test_that_no_info_is_generated_when_credit_for_r_is_granted(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+    social_accounting: SocialAccounting,
+):
+    company = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=social_accounting.account,
+        receiving_account=company.raw_material_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+    response = show_prd_account_details(company.id)
+    assert len(response.transactions) == 0
+
+
+@injection_test
+def test_that_no_info_is_generated_when_credit_for_p_is_granted(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+    social_accounting: SocialAccounting,
+):
+    company = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=social_accounting.account,
+        receiving_account=company.means_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+    response = show_prd_account_details(company.id)
+    assert len(response.transactions) == 0
+
+
+@injection_test
+def test_that_no_info_is_generated_when_credit_for_a_is_granted(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+    social_accounting: SocialAccounting,
+):
+    company = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=social_accounting.account,
+        receiving_account=company.work_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+    response = show_prd_account_details(company.id)
+    assert len(response.transactions) == 0
+
+
+@injection_test
+def test_that_correct_info_is_generated_after_selling_of_consumer_product(
+    show_prd_account_details: ShowPRDAccountDetails,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    member = member_generator.create_member()
+    company = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=member.account,
+        receiving_account=company.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+
+    response = show_prd_account_details(company.id)
+    assert len(response.transactions) == 1
+    assert response.transactions[0].transaction_volume == Decimal(8.5)
+    assert response.transactions[0].purpose is not None
+    assert isinstance(response.transactions[0].date, datetime)
+    assert (
+        response.transactions[0].transaction_type
+        == TransactionTypes.sale_of_consumer_product
+    )
+    assert response.account_balance == Decimal(8.5)
+
+
+@injection_test
+def test_that_correct_info_is_generated_after_selling_of_means_of_production(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company1 = company_generator.create_company()
+    company2 = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=company1.means_account,
+        receiving_account=company2.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+
+    response = show_prd_account_details(company2.id)
+    assert len(response.transactions) == 1
+    assert response.transactions[0].transaction_volume == Decimal(8.5)
+    assert response.transactions[0].purpose is not None
+    assert isinstance(response.transactions[0].date, datetime)
+    assert (
+        response.transactions[0].transaction_type
+        == TransactionTypes.sale_of_fixed_means
+    )
+    assert response.account_balance == Decimal(8.5)
+
+
+@injection_test
+def test_that_correct_info_is_generated_after_selling_of_raw_material(
+    show_prd_account_details: ShowPRDAccountDetails,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company1 = company_generator.create_company()
+    company2 = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=company1.raw_material_account,
+        receiving_account=company2.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(8.5),
+    )
+
+    response = show_prd_account_details(company2.id)
+    assert len(response.transactions) == 1
+    assert response.transactions[0].transaction_volume == Decimal(8.5)
+    assert response.transactions[0].purpose is not None
+    assert isinstance(response.transactions[0].date, datetime)
+    assert (
+        response.transactions[0].transaction_type
+        == TransactionTypes.sale_of_liquid_means
+    )
+    assert response.account_balance == Decimal(8.5)


### PR DESCRIPTION
In the overview page of company's accounts, links to the detail pages of p, r and a accounts have already been implemented, but the prd-account was still missing. 

This PR is resolving this by adding the missing detail page for the product account.