### PR TITLE
show action section only if current user is planner

### DIFF
--- a/arbeitszeit/use_cases/get_plan_summary_company.py
+++ b/arbeitszeit/use_cases/get_plan_summary_company.py
@@ -4,14 +4,20 @@ from uuid import UUID
 
 from injector import inject
 
+from arbeitszeit.entities import Company, Plan
 from arbeitszeit.plan_summary import BusinessPlanSummary
 from arbeitszeit.price_calculator import calculate_price
-from arbeitszeit.repositories import PlanCooperationRepository, PlanRepository
+from arbeitszeit.repositories import (
+    CompanyRepository,
+    PlanCooperationRepository,
+    PlanRepository,
+)
 
 
 @dataclass
 class PlanSummaryCompanySuccess:
     plan_summary: BusinessPlanSummary
+    current_user_is_planner: bool
 
 
 PlanSummaryCompanyResponse = Optional[PlanSummaryCompanySuccess]
@@ -21,12 +27,16 @@ PlanSummaryCompanyResponse = Optional[PlanSummaryCompanySuccess]
 @dataclass
 class GetPlanSummaryCompany:
     plan_repository: PlanRepository
+    company_repository: CompanyRepository
     plan_cooperation_repository: PlanCooperationRepository
 
-    def __call__(self, plan_id: UUID) -> PlanSummaryCompanyResponse:
+    def __call__(self, plan_id: UUID, company_id: UUID) -> PlanSummaryCompanyResponse:
         plan = self.plan_repository.get_plan_by_id(plan_id)
+        company = self.company_repository.get_by_id(company_id)
         if plan is None:
             return None
+        assert company
+        current_user_is_planner = self.check_if_current_user_is_planner(plan, company)
         price_per_unit = calculate_price(
             self.plan_cooperation_repository.get_cooperating_plans(plan.id)
         )
@@ -49,5 +59,9 @@ class GetPlanSummaryCompany:
                 is_available=plan.is_available,
                 is_cooperating=bool(plan.cooperation),
                 cooperation=plan.cooperation or None,
-            )
+            ),
+            current_user_is_planner=current_user_is_planner,
         )
+
+    def check_if_current_user_is_planner(self, plan: Plan, company: Company) -> bool:
+        return plan.planner == company

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -487,12 +487,12 @@ def statistics(
 @CompanyRoute("/company/plan_summary/<uuid:plan_id>")
 def plan_summary(
     plan_id: UUID,
-    get_plan_summary_member: use_cases.GetPlanSummaryCompany,
+    get_plan_summary_company: use_cases.GetPlanSummaryCompany,
     template_renderer: UserTemplateRenderer,
     presenter: GetPlanSummaryCompanySuccessPresenter,
     http_404_view: Http404View,
 ):
-    use_case_response = get_plan_summary_member(plan_id)
+    use_case_response = get_plan_summary_company(plan_id, UUID(current_user.id))
     if isinstance(use_case_response, use_cases.PlanSummaryCompanySuccess):
         view_model = presenter.present(use_case_response)
         return template_renderer.render_template(

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -4,6 +4,9 @@
 {% from 'macros.html' import plan_summary %}
 {{ plan_summary(view_model) }}
 
+
+{% if view_model.show_action_section %}
+
 <div>Verfügbarkeit ändern:</div>
 <div>
     <span class="{{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}"><a
@@ -17,6 +20,8 @@
 <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
     <span>Beenden</span>
 </a>
+{% endif %}
+
 {% endif %}
 
 {% endblock %}

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -19,6 +19,7 @@ class Action:
 @dataclass
 class GetPlanSummaryCompanyViewModel:
     summary: PlanSummary
+    show_action_section: bool
     action: Action
 
     def to_dict(self) -> Dict[str, Any]:
@@ -39,6 +40,7 @@ class GetPlanSummaryCompanySuccessPresenter:
             summary=self.plan_summary_service.get_plan_summary_member(
                 response.plan_summary
             ),
+            show_action_section=response.current_user_is_planner,
             action=Action(
                 is_available=response.plan_summary.is_available,
                 toggle_availability_url=self.toggle_availability_url_index.get_toggle_availability_url(

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -30,7 +30,8 @@ TESTING_RESPONSE_MODEL = PlanSummaryCompanySuccess(
         is_available=True,
         is_cooperating=True,
         cooperation=uuid4(),
-    )
+    ),
+    current_user_is_planner=True,
 )
 
 
@@ -47,6 +48,15 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
             self.translator,
             self.plan_summary_service,
         )
+
+    def test_action_section_is_shown_when_current_user_is_planner(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertTrue(view_model.show_action_section)
+
+    def test_action_section_is_not_shown_when_current_user_is_not_planner(self):
+        response = replace(TESTING_RESPONSE_MODEL, current_user_is_planner=False)
+        view_model = self.presenter.present(response)
+        self.assertFalse(view_model.show_action_section)
 
     def test_url_for_changing_availability_is_displayed_correctly(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
@@ -84,7 +94,9 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         plan_summary = replace(
             TESTING_RESPONSE_MODEL.plan_summary, is_cooperating=False, cooperation=None
         )
-        response = PlanSummaryCompanySuccess(plan_summary=plan_summary)
+        response = PlanSummaryCompanySuccess(
+            plan_summary=plan_summary, current_user_is_planner=True
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.action.is_cooperating, response.plan_summary.is_cooperating

--- a/tests/use_cases/test_get_plan_summary_company.py
+++ b/tests/use_cases/test_get_plan_summary_company.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 from typing import Callable
+from unittest import TestCase
 from uuid import uuid4
 
 from arbeitszeit.entities import ProductionCosts
@@ -12,245 +13,156 @@ from arbeitszeit.use_cases import (
 )
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
 
-from .dependency_injection import injection_test
+from .dependency_injection import get_dependency_injector
 
 
-@injection_test
-def test_that_current_user_is_correctly_shown_as_planner(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    planner_and_current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(planner=planner_and_current_user)
-    response = get_plan_summary_company(plan.id, planner_and_current_user.id)
-    assert isinstance(response, PlanSummaryCompanySuccess)
-    assert response.current_user_is_planner
+class Tests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.get_plan_summary_company = self.injector.get(GetPlanSummaryCompany)
+        self.company_generator = self.injector.get(CompanyGenerator)
 
+    def test_that_current_user_is_correctly_shown_as_planner(self):
+        planner_and_current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=planner_and_current_user)
+        response = self.get_plan_summary_company(plan.id, planner_and_current_user.id)
+        assert isinstance(response, PlanSummaryCompanySuccess)
+        assert response.current_user_is_planner
 
-@injection_test
-def test_that_current_user_is_correctly_shown_as_non_planner(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan()
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert isinstance(response, PlanSummaryCompanySuccess)
-    assert not response.current_user_is_planner
+    def test_that_current_user_is_correctly_shown_as_non_planner(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan()
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert isinstance(response, PlanSummaryCompanySuccess)
+        assert not response.current_user_is_planner
 
+    def test_that_correct_planner_id_is_shown(self):
+        planner = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=planner)
+        response = self.get_plan_summary_company(plan.id, planner.id)
+        assert_success(response, lambda s: s.planner_id == plan.planner.id)
 
-@injection_test
-def test_that_correct_planner_id_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    planner = company_generator.create_company()
-    plan = plan_generator.create_plan(planner=planner)
-    response = get_plan_summary_company(plan.id, planner.id)
-    assert_success(response, lambda s: s.planner_id == plan.planner.id)
+    def test_that_correct_active_status_is_shown_when_plan_is_inactive(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(activation_date=None)
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_active == False)
 
+    def test_that_correct_active_status_is_shown_when_plan_is_active(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(activation_date=datetime.min)
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_active == True)
 
-@injection_test
-def test_that_correct_active_status_is_shown_when_plan_is_inactive(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(activation_date=None)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_active == False)
-
-
-@injection_test
-def test_that_correct_active_status_is_shown_when_plan_is_active(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(activation_date=datetime.min)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_active == True)
-
-
-@injection_test
-def test_that_correct_production_costs_are_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
+    def test_that_correct_production_costs_are_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            )
         )
-    )
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(
-        response,
-        lambda s: all(
-            [
-                s.means_cost == Decimal(1),
-                s.labour_cost == Decimal(2),
-                s.resources_cost == Decimal(3),
-            ]
-        ),
-    )
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(
+            response,
+            lambda s: all(
+                [
+                    s.means_cost == Decimal(1),
+                    s.labour_cost == Decimal(2),
+                    s.resources_cost == Decimal(3),
+                ]
+            ),
+        )
 
+    def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.price_per_unit == Decimal(0))
 
-@injection_test
-def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(
-        is_public_service=True,
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
-        ),
-    )
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.price_per_unit == Decimal(0))
+    def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            is_public_service=False,
+            amount=2,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.price_per_unit == Decimal(3))
 
+    def test_that_correct_product_name_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(product_name="test product")
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.product_name == "test product")
 
-@injection_test
-def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(
-        is_public_service=False,
-        amount=2,
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
-        ),
-    )
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.price_per_unit == Decimal(3))
+    def test_that_correct_product_description_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(description="test description")
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.description == "test description")
 
+    def test_that_correct_product_unit_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(production_unit="test unit")
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.production_unit == "test unit")
 
-@injection_test
-def test_that_correct_product_name_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(product_name="test product")
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.product_name == "test product")
+    def test_that_correct_amount_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(amount=123)
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.amount == 123)
 
+    def test_that_correct_public_service_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(is_public_service=True)
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_public_service == True)
 
-@injection_test
-def test_that_correct_product_description_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(description="test description")
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.description == "test description")
+    def test_that_none_is_returned_when_plan_does_not_exist(self) -> None:
+        current_user = self.company_generator.create_company()
+        assert self.get_plan_summary_company(uuid4(), current_user.id) is None
 
+    def test_that_correct_availability_is_shown(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan()
+        assert plan.is_available
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_available == True)
 
-@injection_test
-def test_that_correct_product_unit_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(production_unit="test unit")
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.production_unit == "test unit")
+    def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=None
+        )
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_cooperating == False)
+        assert_success(response, lambda s: s.cooperation is None)
 
-
-@injection_test
-def test_that_correct_amount_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(amount=123)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.amount == 123)
-
-
-@injection_test
-def test_that_correct_public_service_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(is_public_service=True)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_public_service == True)
-
-
-@injection_test
-def test_that_none_is_returned_when_plan_does_not_exist(
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-) -> None:
-    current_user = company_generator.create_company()
-    assert get_plan_summary_company(uuid4(), current_user.id) is None
-
-
-@injection_test
-def test_that_correct_availability_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan()
-    assert plan.is_available
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_available == True)
-
-
-@injection_test
-def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=None)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_cooperating == False)
-    assert_success(response, lambda s: s.cooperation is None)
-
-
-@injection_test
-def test_that_correct_cooperation_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_company: GetPlanSummaryCompany,
-    coop_generator: CooperationGenerator,
-    company_generator: CompanyGenerator,
-):
-    current_user = company_generator.create_company()
-    coop = coop_generator.create_cooperation()
-    plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=coop)
-    response = get_plan_summary_company(plan.id, current_user.id)
-    assert_success(response, lambda s: s.is_cooperating == True)
-    assert_success(response, lambda s: s.cooperation == coop.id)
+    def test_that_correct_cooperation_is_shown(self):
+        coop_generator = self.injector.get(CooperationGenerator)
+        current_user = self.company_generator.create_company()
+        coop = coop_generator.create_cooperation()
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=coop
+        )
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.is_cooperating == True)
+        assert_success(response, lambda s: s.cooperation == coop.id)
 
 
 def assert_success(

--- a/tests/use_cases/test_get_plan_summary_company.py
+++ b/tests/use_cases/test_get_plan_summary_company.py
@@ -16,42 +16,74 @@ from .dependency_injection import injection_test
 
 
 @injection_test
+def test_that_current_user_is_correctly_shown_as_planner(
+    plan_generator: PlanGenerator,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
+):
+    planner_and_current_user = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=planner_and_current_user)
+    response = get_plan_summary_company(plan.id, planner_and_current_user.id)
+    assert isinstance(response, PlanSummaryCompanySuccess)
+    assert response.current_user_is_planner
+
+
+@injection_test
+def test_that_current_user_is_correctly_shown_as_non_planner(
+    plan_generator: PlanGenerator,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
+):
+    current_user = company_generator.create_company()
+    plan = plan_generator.create_plan()
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert isinstance(response, PlanSummaryCompanySuccess)
+    assert not response.current_user_is_planner
+
+
+@injection_test
 def test_that_correct_planner_id_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
     company_generator: CompanyGenerator,
 ):
     planner = company_generator.create_company()
     plan = plan_generator.create_plan(planner=planner)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.planner_id == plan.planner.id)
+    response = get_plan_summary_company(plan.id, planner.id)
+    assert_success(response, lambda s: s.planner_id == plan.planner.id)
 
 
 @injection_test
 def test_that_correct_active_status_is_shown_when_plan_is_inactive(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(activation_date=None)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_active == False)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_active == False)
 
 
 @injection_test
 def test_that_correct_active_status_is_shown_when_plan_is_active(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(activation_date=datetime.min)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_active == True)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_active == True)
 
 
 @injection_test
 def test_that_correct_production_costs_are_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(
         costs=ProductionCosts(
             means_cost=Decimal(1),
@@ -59,9 +91,9 @@ def test_that_correct_production_costs_are_shown(
             resource_cost=Decimal(3),
         )
     )
-    summary = get_plan_summary_member(plan.id)
+    response = get_plan_summary_company(plan.id, current_user.id)
     assert_success(
-        summary,
+        response,
         lambda s: all(
             [
                 s.means_cost == Decimal(1),
@@ -75,8 +107,10 @@ def test_that_correct_production_costs_are_shown(
 @injection_test
 def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(
         is_public_service=True,
         costs=ProductionCosts(
@@ -85,15 +119,17 @@ def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(
             resource_cost=Decimal(3),
         ),
     )
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.price_per_unit == Decimal(0))
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.price_per_unit == Decimal(0))
 
 
 @injection_test
 def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(
         is_public_service=False,
         amount=2,
@@ -103,100 +139,118 @@ def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(
             resource_cost=Decimal(3),
         ),
     )
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.price_per_unit == Decimal(3))
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.price_per_unit == Decimal(3))
 
 
 @injection_test
 def test_that_correct_product_name_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(product_name="test product")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.product_name == "test product")
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.product_name == "test product")
 
 
 @injection_test
 def test_that_correct_product_description_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(description="test description")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.description == "test description")
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.description == "test description")
 
 
 @injection_test
 def test_that_correct_product_unit_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(production_unit="test unit")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.production_unit == "test unit")
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.production_unit == "test unit")
 
 
 @injection_test
 def test_that_correct_amount_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(amount=123)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.amount == 123)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.amount == 123)
 
 
 @injection_test
 def test_that_correct_public_service_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(is_public_service=True)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_public_service == True)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_public_service == True)
 
 
 @injection_test
 def test_that_none_is_returned_when_plan_does_not_exist(
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ) -> None:
-    assert get_plan_summary_member(uuid4()) is None
+    current_user = company_generator.create_company()
+    assert get_plan_summary_company(uuid4(), current_user.id) is None
 
 
 @injection_test
 def test_that_correct_availability_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan()
     assert plan.is_available
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_available == True)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_available == True)
 
 
 @injection_test
 def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=None)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_cooperating == False)
-    assert_success(summary, lambda s: s.cooperation is None)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_cooperating == False)
+    assert_success(response, lambda s: s.cooperation is None)
 
 
 @injection_test
 def test_that_correct_cooperation_is_shown(
     plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryCompany,
+    get_plan_summary_company: GetPlanSummaryCompany,
     coop_generator: CooperationGenerator,
+    company_generator: CompanyGenerator,
 ):
+    current_user = company_generator.create_company()
     coop = coop_generator.create_cooperation()
     plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=coop)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_cooperating == True)
-    assert_success(summary, lambda s: s.cooperation == coop.id)
+    response = get_plan_summary_company(plan.id, current_user.id)
+    assert_success(response, lambda s: s.is_cooperating == True)
+    assert_success(response, lambda s: s.cooperation == coop.id)
 
 
 def assert_success(


### PR DESCRIPTION
fixes #298

After this PR companies can only see the "action section" (i.e. change visibility button and end cooperation button) of their own plan's summary pages. Consequently, they won't be able to see the action sections of other company's plans anymore.