### PR TITLE
Prevent payment of negative amounts of consumer products

### DIFF
--- a/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
+++ b/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
@@ -7,17 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-03 21:38+0100\n"
+"POT-Creation-Date: 2022-03-13 12:23+0100\n"
 "PO-Revision-Date: 2022-03-03 21:41+0100\n"
 "Last-Translator: Sebastian Jordan <sebastian.jordan.mail@googlemail.com>\n"
 "Language: de\n"
 "Language-Team: de <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
-"X-Generator: Poedit 3.0\n"
 
 #: arbeitszeit_flask/forms.py:16
 msgid "Invalid ID."
@@ -140,9 +139,9 @@ msgid ""
 msgstr ""
 "Eine Kooperation beinhaltet ähnliche Produkte.  Um Konkurrenz zu "
 "reduzieren, wird der Durchschnittspreis aller Produkte innerhalb der "
-"Kooperation berechnet.  Alle Produzenten erhalten bei der Warenweitergabe "
-"die von ihnen ursprünglich geplante Anzahl von Arbeitsstunden. Das heißt "
-"insbesondere, dass Produzenten die selbe Gutschrift erhalten unabhängig "
+"Kooperation berechnet.  Alle Produzenten erhalten bei der Warenweitergabe"
+" die von ihnen ursprünglich geplante Anzahl von Arbeitsstunden. Das heißt"
+" insbesondere, dass Produzenten die selbe Gutschrift erhalten unabhängig "
 "davon, ob sie in einer Kooperation sind, oder nicht."
 
 #: arbeitszeit_flask/templates/company/create_cooperation.html:23
@@ -268,8 +267,8 @@ msgstr "Dein Arbeitsplatz"
 
 #: arbeitszeit_flask/templates/member/profile.html:82
 msgid ""
-"You are not registered with any company. Tell your company your member ID "
-"so that they register you."
+"You are not registered with any company. Tell your company your member ID"
+" so that they register you."
 msgstr ""
 "Du bist bei keinem Betrieb angemeldet. Teile deinem Betrieb deine "
 "Mitglieds-ID mit, so dass sie dich anmelden können."
@@ -330,6 +329,38 @@ msgid_plural "%(num).2f days"
 msgstr[0] "%(num).2f Tag"
 msgstr[1] "%(num).2f Tage"
 
+#: arbeitszeit_web/pay_consumer_product.py:57
+#: tests/controllers/test_pay_consumer_product_controller.py:32
+msgid "Plan ID is invalid."
+msgstr "Plan-ID ist ungültig."
+
+#: arbeitszeit_web/pay_consumer_product.py:63
+#: tests/controllers/test_pay_consumer_product_controller.py:40
+msgid "This is not an integer."
+msgstr "Das ist keine ganze Zahl."
+
+#: arbeitszeit_web/pay_consumer_product.py:67
+#: tests/controllers/test_pay_consumer_product_controller.py:48
+msgid "Negative numbers are not allowed."
+msgstr "Die Zahl darf nicht negativ sein."
+
+#: arbeitszeit_web/pay_consumer_product.py:89
+#: tests/presenters/test_pay_consumer_product_presenter.py:26
+msgid "Product successfully paid."
+msgstr "Produkt erfolgreich bezahlt."
+
+#: arbeitszeit_web/pay_consumer_product.py:94
+#: tests/presenters/test_pay_consumer_product_presenter.py:34
+msgid ""
+"The specified plan has been expired. Please contact the selling company "
+"to provide you with an up-to-date plan ID."
+msgstr "Der angegebene Plan ist nicht aktuell. Bitte wende dich an den Verkäufer, um eine aktuelle Plan-ID zu erhalten."
+
+#: arbeitszeit_web/pay_consumer_product.py:101
+#: tests/presenters/test_pay_consumer_product_presenter.py:45
+msgid "There is no plan with the specified ID in the database."
+msgstr "Die Plan-ID existiert nicht im System."
+
 #: arbeitszeit_web/plan_summary_service.py:48
 #: tests/presenters/test_plan_summary_service.py:68
 msgid "Planning company"
@@ -349,8 +380,8 @@ msgstr "Beschreibung des Produkts"
 #: arbeitszeit_web/presenters/show_company_work_invite_details_presenter.py:27
 #, python-format
 msgid ""
-"The company \"%(company_name)s\" invites you to join them. Do you want to "
-"accept this invitation?"
+"The company \"%(company_name)s\" invites you to join them. Do you want to"
+" accept this invitation?"
 msgstr ""
 "Der Betrieb \"%(company_name)s\" hat dich zum Beitritt eingeladen. "
 "Möchtest du die Einladung annehmen?"

--- a/arbeitszeit_flask/translations/en/LC_MESSAGES/messages.po
+++ b/arbeitszeit_flask/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-03 21:38+0100\n"
+"POT-Creation-Date: 2022-03-13 12:23+0100\n"
 "PO-Revision-Date: 2022-01-16 19:09+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -316,6 +316,38 @@ msgid "%(num).2f day"
 msgid_plural "%(num).2f days"
 msgstr[0] ""
 msgstr[1] ""
+
+#: arbeitszeit_web/pay_consumer_product.py:57
+#: tests/controllers/test_pay_consumer_product_controller.py:32
+msgid "Plan ID is invalid."
+msgstr ""
+
+#: arbeitszeit_web/pay_consumer_product.py:63
+#: tests/controllers/test_pay_consumer_product_controller.py:40
+msgid "This is not an integer."
+msgstr ""
+
+#: arbeitszeit_web/pay_consumer_product.py:67
+#: tests/controllers/test_pay_consumer_product_controller.py:48
+msgid "Negative numbers are not allowed."
+msgstr ""
+
+#: arbeitszeit_web/pay_consumer_product.py:89
+#: tests/presenters/test_pay_consumer_product_presenter.py:26
+msgid "Product successfully paid."
+msgstr ""
+
+#: arbeitszeit_web/pay_consumer_product.py:94
+#: tests/presenters/test_pay_consumer_product_presenter.py:34
+msgid ""
+"The specified plan has been expired. Please contact the selling company "
+"to provide you with an up-to-date plan ID."
+msgstr ""
+
+#: arbeitszeit_web/pay_consumer_product.py:101
+#: tests/presenters/test_pay_consumer_product_presenter.py:45
+msgid "There is no plan with the specified ID in the database."
+msgstr ""
 
 #: arbeitszeit_web/plan_summary_service.py:48
 #: tests/presenters/test_plan_summary_service.py:68

--- a/arbeitszeit_web/pay_consumer_product.py
+++ b/arbeitszeit_web/pay_consumer_product.py
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases.pay_consumer_product import (
     PayConsumerProductResponse,
     RejectionReason,
 )
+from arbeitszeit_web.translator import Translator
 
 from .notification import Notifier
 
@@ -36,11 +37,15 @@ class PayConsumerProductForm(Protocol):
         ...
 
 
+@inject
+@dataclass
 class PayConsumerProductController:
     @dataclass
     class MalformedInputData:
         field: str
         message: str
+
+    translator: Translator
 
     def import_form_data(
         self, current_user: UUID, form: PayConsumerProductForm
@@ -48,11 +53,19 @@ class PayConsumerProductController:
         try:
             uuid = UUID(form.get_plan_id_field())
         except ValueError:
-            return self.MalformedInputData("plan_id", "Plan-ID ist ungültig")
+            return self.MalformedInputData(
+                "plan_id", self.translator.gettext("Plan ID is invalid.")
+            )
         try:
             amount = int(form.get_amount_field())
         except ValueError:
-            return self.MalformedInputData("amount", "Das ist keine ganze Zahl")
+            return self.MalformedInputData(
+                "amount", self.translator.gettext("This is not an integer.")
+            )
+        if amount < 0:
+            return self.MalformedInputData(
+                "amount", self.translator.gettext("Negative numbers are not allowed.")
+            )
         return PayConsumerProductRequestImpl(current_user, uuid, amount)
 
 
@@ -66,20 +79,27 @@ class PayConsumerProductViewModel:
 @dataclass
 class PayConsumerProductPresenter:
     user_notifier: Notifier
+    translator: Translator
 
     def present(
         self, use_case_response: PayConsumerProductResponse
     ) -> PayConsumerProductViewModel:
         if use_case_response.rejection_reason is None:
-            self.user_notifier.display_info("Produkt erfolgreich bezahlt.")
+            self.user_notifier.display_info(
+                self.translator.gettext("Product successfully paid.")
+            )
             return PayConsumerProductViewModel(status_code=200)
         elif use_case_response.rejection_reason == RejectionReason.plan_inactive:
             self.user_notifier.display_warning(
-                "Der angegebene Plan ist nicht aktuell. Bitte wende dich an den Verkäufer, um eine aktuelle Plan-ID zu erhalten."
+                self.translator.gettext(
+                    "The specified plan has been expired. Please contact the selling company to provide you with an up-to-date plan ID."
+                )
             )
             return PayConsumerProductViewModel(status_code=410)
         else:
             self.user_notifier.display_warning(
-                "Ein Plan mit der angegebene ID existiert nicht im System."
+                self.translator.gettext(
+                    "There is no plan with the specified ID in the database."
+                )
             )
             return PayConsumerProductViewModel(status_code=404)


### PR DESCRIPTION
fixes #319

What this PR does:
1) prevent payment of negative amounts of consumer products
2) make arbeitszeit_web/pay_consumer_product.py translatable
3) translate it to German

My Plan-ID: e8e5c56f-9e2d-497d-a896-a26bc41e1c16