### PR TITLE
Prevent-negative-plan-costs

### DIFF
--- a/arbeitszeit/use_cases/create_plan_draft.py
+++ b/arbeitszeit/use_cases/create_plan_draft.py
@@ -32,6 +32,11 @@ class CreatePlanDraft:
     datetime_service: DatetimeService
 
     def __call__(self, request: CreatePlanDraftRequest) -> CreatePlanDraftResponse:
+        assert request.costs.labour_cost >= 0
+        assert request.costs.means_cost >= 0
+        assert request.costs.resource_cost >= 0
+        assert request.production_amount >= 0
+        assert request.timeframe_in_days >= 0
         draft = self.plan_draft_repository.create_plan_draft(
             planner=request.planner,
             costs=request.costs,

--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -107,7 +107,7 @@
             <div class="field">
                 <label class="label">Kosten für Produktionsmittel</label>
                 <div class="control">
-                    <input class="input is-large" type="number" name="costs_p"
+                    <input class="input is-large" type="number" name="costs_p" min=0
                         value="{{ prefilled.means_cost if prefilled else 0 }}" required>
                 </div>
             </div>
@@ -117,7 +117,7 @@
             <div class="field">
                 <label class="label">Kosten für Roh- und Hilfsstoffe</label>
                 <div class="control">
-                    <input class="input is-large" type="number" name="costs_r"
+                    <input class="input is-large" type="number" name="costs_r" min=0
                         value="{{ prefilled.resources_cost if prefilled else 0 }}" required>
                 </div>
             </div>
@@ -127,7 +127,7 @@
             <div class="field">
                 <label class="label">Enthaltene Arbeitsstunden</label>
                 <div class="control">
-                    <input class="input is-large" type="number" name="costs_a"
+                    <input class="input is-large" type="number" name="costs_a" min=0
                         value="{{ prefilled.labour_cost if prefilled else 0 }}" required>
                 </div>
             </div>

--- a/arbeitszeit_web/get_prefilled_draft_data.py
+++ b/arbeitszeit_web/get_prefilled_draft_data.py
@@ -44,17 +44,27 @@ class PrefilledDraftDataController:
     def import_form_data(
         self, planner: UUID, draft_form: CreateDraftForm
     ) -> CreatePlanDraftRequest:
+        labour_costs = Decimal(draft_form.get_costs_a_string())
+        resource_cost = Decimal(draft_form.get_costs_r_string())
+        means_cost = Decimal(draft_form.get_costs_p_string())
+        production_amount = int(draft_form.get_prd_amount_string())
+        timeframe_in_days = int(draft_form.get_timeframe_string())
+        assert labour_costs >= 0
+        assert resource_cost >= 0
+        assert means_cost >= 0
+        assert production_amount >= 0
+        assert timeframe_in_days >= 0
         return CreatePlanDraftRequest(
             costs=ProductionCosts(
-                labour_cost=Decimal(draft_form.get_costs_a_string()),
-                resource_cost=Decimal(draft_form.get_costs_r_string()),
-                means_cost=Decimal(draft_form.get_costs_p_string()),
+                labour_cost=labour_costs,
+                resource_cost=resource_cost,
+                means_cost=means_cost,
             ),
             product_name=draft_form.get_prd_name_string(),
             production_unit=draft_form.get_prd_unit_string(),
-            production_amount=int(draft_form.get_prd_amount_string()),
+            production_amount=production_amount,
             description=draft_form.get_description_string(),
-            timeframe_in_days=int(draft_form.get_timeframe_string()),
+            timeframe_in_days=timeframe_in_days,
             is_public_service=True
             if draft_form.get_productive_or_public_string() == "public"
             else False,


### PR DESCRIPTION
fixes #321

This PR prevents that companies specify negative plan costs. It does this 1) in the html ``input`` element and 2) by assertions in the controller.

I refrained from refactoring the controller any further because I plan to propose some changes related to plan creation backend soon.

My Plan-ID: e8e5c56f-9e2d-497d-a896-a26bc41e1c16