### PR TITLE
Simplify plan renewal

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -139,7 +139,6 @@ class Plan:
     approval_reason: Optional[str]
     is_active: bool
     expired: bool
-    renewed: bool
     activation_date: Optional[datetime]
     expiration_relative: Optional[int]
     expiration_date: Optional[datetime]

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -71,10 +71,6 @@ class PlanRepository(ABC):
         pass
 
     @abstractmethod
-    def set_plan_as_renewed(self, plan: Plan) -> None:
-        pass
-
-    @abstractmethod
     def set_expiration_relative(self, plan: Plan, days: int) -> None:
         pass
 

--- a/arbeitszeit/use_cases/seek_approval.py
+++ b/arbeitszeit/use_cases/seek_approval.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from injector import inject
@@ -24,23 +23,14 @@ class SeekApproval:
     plan_repository: PlanRepository
     draft_repository: PlanDraftRepository
 
-    def __call__(
-        self, draft_id: UUID, expired_plan_id: Optional[UUID]
-    ) -> SeekApprovalResponse:
+    def __call__(self, draft_id: UUID) -> SeekApprovalResponse:
         draft = self.draft_repository.get_by_id(draft_id)
         assert draft is not None
-        if expired_plan_id:
-            self.set_expired_plan_as_renewed(expired_plan_id)
         new_plan = self.approve_plan_and_delete_draft(draft)
         assert new_plan.approval_reason
         return SeekApprovalResponse(
             is_approved=True, reason=new_plan.approval_reason, new_plan_id=new_plan.id
         )
-
-    def set_expired_plan_as_renewed(self, expired_plan_id: UUID) -> None:
-        expired_plan = self.plan_repository.get_plan_by_id(expired_plan_id)
-        assert expired_plan is not None
-        self.plan_repository.set_plan_as_renewed(expired_plan)
 
     def approve_plan_and_delete_draft(self, draft: PlanDraft) -> Plan:
         new_plan = self.plan_repository.approve_plan(draft, self.get_approval_date())

--- a/arbeitszeit/use_cases/show_my_plans.py
+++ b/arbeitszeit/use_cases/show_my_plans.py
@@ -26,7 +26,6 @@ class PlanInfo:
     expiration_date: Optional[datetime]
     expiration_relative: Optional[int]
     is_available: bool
-    renewed: bool
     is_cooperating: bool
     cooperation: Optional[UUID]
 
@@ -67,7 +66,6 @@ class ShowMyPlansUseCase:
                 expiration_date=plan.expiration_date,
                 expiration_relative=plan.expiration_relative,
                 is_available=plan.is_available,
-                renewed=plan.renewed,
                 is_cooperating=bool(plan.cooperation),
                 cooperation=plan.cooperation,
             )
@@ -87,7 +85,6 @@ class ShowMyPlansUseCase:
                 expiration_date=plan.expiration_date,
                 expiration_relative=plan.expiration_relative,
                 is_available=plan.is_available,
-                renewed=plan.renewed,
                 is_cooperating=bool(plan.cooperation),
                 cooperation=plan.cooperation,
             )
@@ -107,7 +104,6 @@ class ShowMyPlansUseCase:
                 expiration_date=plan.expiration_date,
                 expiration_relative=plan.expiration_relative,
                 is_available=plan.is_available,
-                renewed=plan.renewed,
                 is_cooperating=bool(plan.cooperation),
                 cooperation=plan.cooperation,
             )

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -17,7 +17,7 @@ from arbeitszeit.use_cases import (
     DenyCooperationResponse,
     GetCompanySummary,
     GetDraftSummary,
-    GetPlanSummaryMember,
+    GetPlanSummaryCompany,
     HidePlan,
     ListAllCooperations,
     ListCoordinations,
@@ -188,19 +188,20 @@ def my_purchases(
 @commit_changes
 def create_draft_from_expired_plan(
     create_draft: CreatePlanDraft,
-    get_plan_summary_member: GetPlanSummaryMember,
+    get_plan_summary_company: GetPlanSummaryCompany,
     get_prefilled_draft_data_presenter: GetPrefilledDraftDataPresenter,
-    controller: PrefilledDraftDataController,
+    prefilled_data_controller: PrefilledDraftDataController,
     template_renderer: UserTemplateRenderer,
+    http_404_view: Http404View,
 ):
+    """create draft from exired plan."""
     expired_plan_id: Optional[str] = request.args.get("expired_plan_id")
-    expired_plan_uuid: Optional[UUID] = (
-        UUID(expired_plan_id) if expired_plan_id else None
-    )
+    assert expired_plan_id
+    expired_plan_uuid = UUID(expired_plan_id)
 
     if request.method == "POST":
         draft_form = CreateDraftForm(request.form)
-        use_case_request = controller.import_form_data(
+        use_case_request = prefilled_data_controller.import_form_data(
             UUID(current_user.id), draft_form
         )
 
@@ -217,18 +218,18 @@ def create_draft_from_expired_plan(
                 )
             )
 
-    plan_summary_success = (
-        get_plan_summary_member(expired_plan_uuid) if expired_plan_uuid else None
+    plan_summary_success = get_plan_summary_company(
+        expired_plan_uuid, UUID(current_user.id)
     )
-
-    prefilled_draft_data = (
-        get_prefilled_draft_data_presenter.present(plan_summary_success.plan_summary)
-        if plan_summary_success
-        else None
-    )
-    return template_renderer.render_template(
-        "company/create_draft.html", context=dict(prefilled=prefilled_draft_data)
-    )
+    if isinstance(plan_summary_success, use_cases.PlanSummaryCompanySuccess):
+        prefilled_draft_data = get_prefilled_draft_data_presenter.present(
+            plan_summary_success.plan_summary
+        )
+        return template_renderer.render_template(
+            "company/create_draft.html", context=dict(prefilled=prefilled_draft_data)
+        )
+    else:
+        return http_404_view.get_response()
 
 
 @CompanyRoute("/company/create_draft", methods=["GET", "POST"])
@@ -237,15 +238,16 @@ def create_draft(
     create_draft: CreatePlanDraft,
     get_draft_summary: GetDraftSummary,
     get_prefilled_draft_data_presenter: GetPrefilledDraftDataPresenter,
-    controller: PrefilledDraftDataController,
+    prefilled_data_controller: PrefilledDraftDataController,
     template_renderer: UserTemplateRenderer,
 ):
+    """create draft. use data from saved draft if specified."""
     saved_draft_id: Optional[str] = request.args.get("saved_draft_id")
     saved_draft_uuid: Optional[UUID] = UUID(saved_draft_id) if saved_draft_id else None
 
     if request.method == "POST":
         draft_form = CreateDraftForm(request.form)
-        use_case_request = controller.import_form_data(
+        use_case_request = prefilled_data_controller.import_form_data(
             UUID(current_user.id), draft_form
         )
 
@@ -280,10 +282,9 @@ def create_plan(
     activate_plan_and_grant_credit: use_cases.ActivatePlanAndGrantCredit,
     template_renderer: UserTemplateRenderer,
 ):
+    """create plan from draft and seek approval."""
     draft_uuid: UUID = UUID(request.args.get("draft_uuid"))
-
     approval_response = seek_approval(draft_uuid)
-
     if approval_response.is_approved:
         flash("Plan erfolgreich erstellt und genehmigt.", "is-success")
         activate_plan_and_grant_credit(approval_response.new_plan_id)

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -214,7 +214,6 @@ def create_draft_from_expired_plan(
                 url_for(
                     "main_company.create_plan",
                     draft_uuid=response.draft_id,
-                    expired_plan_uuid=expired_plan_uuid,
                 )
             )
 
@@ -262,7 +261,6 @@ def create_draft(
                 url_for(
                     "main_company.create_plan",
                     draft_uuid=response.draft_id,
-                    expired_plan_uuid=None,
                 )
             )
 
@@ -287,14 +285,8 @@ def create_plan(
     template_renderer: UserTemplateRenderer,
 ):
     draft_uuid: UUID = UUID(request.args.get("draft_uuid"))
-    expired_plan_optional = request.args.get("expired_plan_uuid")
-    expired_plan_uuid: Optional[UUID] = (
-        UUID(expired_plan_optional.strip())
-        if expired_plan_optional is not None
-        else None
-    )
 
-    approval_response = seek_approval(draft_uuid, expired_plan_uuid)
+    approval_response = seek_approval(draft_uuid)
 
     if approval_response.is_approved:
         flash("Plan erfolgreich erstellt und genehmigt.", "is-success")

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -222,9 +222,7 @@ def create_draft_from_expired_plan(
     )
 
     prefilled_draft_data = (
-        get_prefilled_draft_data_presenter.present(
-            plan_summary_success.plan_summary, from_expired_plan=True
-        )
+        get_prefilled_draft_data_presenter.present(plan_summary_success.plan_summary)
         if plan_summary_success
         else None
     )
@@ -266,9 +264,7 @@ def create_draft(
 
     draft_summary = get_draft_summary(saved_draft_uuid) if saved_draft_uuid else None
     prefilled_draft_data = (
-        get_prefilled_draft_data_presenter.present(
-            draft_summary, from_expired_plan=False
-        )
+        get_prefilled_draft_data_presenter.present(draft_summary)
         if draft_summary
         else None
     )

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -479,7 +479,6 @@ class PlanRepository(repositories.PlanRepository):
             approval_reason=plan.approval_reason,
             is_active=plan.is_active,
             expired=plan.expired,
-            renewed=plan.renewed,
             expiration_relative=plan.expiration_relative,
             expiration_date=plan.expiration_date,
             activation_date=plan.activation_date,
@@ -555,12 +554,6 @@ class PlanRepository(repositories.PlanRepository):
         plan_orm = self.object_to_orm(plan)
         plan_orm.expired = True
         plan_orm.is_active = False
-
-    def set_plan_as_renewed(self, plan: entities.Plan) -> None:
-        plan.renewed = True
-
-        plan_orm = self.object_to_orm(plan)
-        plan_orm.renewed = True
 
     def set_expiration_date(
         self, plan: entities.Plan, expiration_date: datetime

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -105,7 +105,6 @@ class Plan(UserMixin, db.Model):
     is_active = db.Column(db.Boolean, nullable=False, default=False)
     activation_date = db.Column(db.DateTime, nullable=True)
     expired = db.Column(db.Boolean, nullable=False, default=False)
-    renewed = db.Column(db.Boolean, nullable=False, default=False)
     expiration_date = db.Column(db.DateTime, nullable=True)
     expiration_relative = db.Column(db.Integer, nullable=True)
     active_days = db.Column(db.Integer, nullable=True)

--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -1,22 +1,9 @@
 {% extends "base_company.html" %}
 {% block content2 %}
-
+{% from 'macros/show_notifications.html' import show_notifications %}
 
 <div class="columns is-centered">
     <div class="column is-three-fifths">
-
-        {% if prefilled.from_expired_plan %}
-
-        <div class="box has-background-info-light has-text-info-dark">
-            <div class="icon"><i class="fas fa-info-circle"></i></div>
-            <p>
-                Planerneuerung. <br><br>
-                Wenn du keine Änderungen vornimmst, wird der Plan automatisch erneuert, ansonsten wird eventuell ein
-                Genehmigungsprozess nötig.
-            </p>
-        </div>
-
-        {% endif %}
 
         <div class="box has-background-info-light has-text-info-dark">
             <div class="icon"><i class="fas fa-info-circle"></i></div>
@@ -35,13 +22,7 @@
 
 
 
-        {% with messages = get_flashed_messages() %}
-        {% if messages %}
-        {% for message in messages %}
-        <div class="notification is-danger">{{ message }} </div>
-        {% endfor %}
-        {% endif %}
-        {% endwith %}
+        {{ show_notifications() }}
 
         <form method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -107,16 +107,9 @@
         <td><a href="{{ plan.plan_summary_url }}">{{ plan.prd_name }}</a></td>
         <td>{{ plan.type_of_plan }}</td>
         <td>{{ plan.plan_creation_date }}</td>
-
-        {% if plan.renewed %}
-        <td>
-          <a><i class="{{ 'fas fa-redo not-active' }}"></i></a>
-        </td>
-        {% else %}
         <td>
           <a href="{{ plan.renew_plan_url }}"><i class="{{ 'fas fa-redo' }}"></i></a>
         </td>
-        {% endif %}
         <td>
           <a href="{{ plan.hide_plan_url }}"><i class="fas fa-trash"></i></a>
         </td>

--- a/arbeitszeit_web/get_prefilled_draft_data.py
+++ b/arbeitszeit_web/get_prefilled_draft_data.py
@@ -64,7 +64,6 @@ class PrefilledDraftDataController:
 
 @dataclass
 class PrefilledDraftData:
-    from_expired_plan: bool
     product_name: str
     description: str
     timeframe: str
@@ -78,12 +77,9 @@ class PrefilledDraftData:
 
 class GetPrefilledDraftDataPresenter:
     def present(
-        self,
-        summary_data: Union[BusinessPlanSummary, DraftSummarySuccess],
-        from_expired_plan: bool,
+        self, summary_data: Union[BusinessPlanSummary, DraftSummarySuccess]
     ) -> PrefilledDraftData:
         return PrefilledDraftData(
-            from_expired_plan=True if from_expired_plan else False,
             product_name=summary_data.product_name,
             description=summary_data.description,
             timeframe=f"{summary_data.timeframe}",

--- a/arbeitszeit_web/show_my_plans.py
+++ b/arbeitszeit_web/show_my_plans.py
@@ -52,7 +52,6 @@ class ExpiredPlansRow:
     prd_name: str
     type_of_plan: str
     plan_creation_date: str
-    renewed: bool
     renew_plan_url: str
     hide_plan_url: str
 
@@ -136,7 +135,6 @@ class ShowMyPlansPresenter:
                         prd_name=f"{plan.prd_name}",
                         type_of_plan=self.__get_type_of_plan(plan.is_public_service),
                         plan_creation_date=self.__format_date(plan.plan_creation_date),
-                        renewed=plan.renewed,
                         renew_plan_url=self.renew_plan_url_index.get_renew_plan_url(
                             plan.id
                         ),

--- a/migrations/versions/bc2747c3b268_delete_column_renewed_from_table_plan.py
+++ b/migrations/versions/bc2747c3b268_delete_column_renewed_from_table_plan.py
@@ -1,0 +1,29 @@
+"""delete column renewed from table Plan
+
+Revision ID: bc2747c3b268
+Revises: 5e541f042231
+Create Date: 2022-03-17 23:35:38.116844
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "bc2747c3b268"
+down_revision = "5e541f042231"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("plan") as batch_op:
+        batch_op.drop_column("renewed")
+
+
+def downgrade():
+    with op.batch_alter_table("plan") as batch_op:
+        batch_op.add_column(sa.Column("renewed", sa.Boolean(), nullable=True))
+    with op.batch_alter_table("plan") as batch_op:
+        batch_op.execute("UPDATE plan SET renewed = False")
+        batch_op.alter_column("renewed", nullable=False)

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -207,7 +207,7 @@ class PlanGenerator:
             is_public_service=is_public_service,
             plan_creation_date=plan_creation_date,
         )
-        response = self.seek_approval(draft.id, None)
+        response = self.seek_approval(draft.id)
         plan = self.plan_repository.get_plan_by_id(response.new_plan_id)
         assert plan
         assert plan.approved

--- a/tests/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/presenters/test_get_prefilled_draft_data_presenter.py
@@ -42,8 +42,7 @@ TEST_DRAFT_SUMMARY_SUCCESS = DraftSummarySuccess(
 
 def test_correct_refilled_data_is_returned_for_plan_summary():
     get_prefilled_data = GetPrefilledDraftDataPresenter()
-    result = get_prefilled_data.present(BUSINESS_PLAN_SUMMARY, True)
-    assert result.from_expired_plan == True
+    result = get_prefilled_data.present(BUSINESS_PLAN_SUMMARY)
     assert result.product_name == BUSINESS_PLAN_SUMMARY.product_name
     assert result.description == BUSINESS_PLAN_SUMMARY.description
     assert result.timeframe == str(BUSINESS_PLAN_SUMMARY.timeframe)
@@ -57,8 +56,7 @@ def test_correct_refilled_data_is_returned_for_plan_summary():
 
 def test_correct_refilled_data_is_returned_for_draft_summary():
     get_prefilled_data = GetPrefilledDraftDataPresenter()
-    result = get_prefilled_data.present(TEST_DRAFT_SUMMARY_SUCCESS, False)
-    assert result.from_expired_plan == False
+    result = get_prefilled_data.present(TEST_DRAFT_SUMMARY_SUCCESS)
     assert result.product_name == TEST_DRAFT_SUMMARY_SUCCESS.product_name
     assert result.description == TEST_DRAFT_SUMMARY_SUCCESS.description
     assert result.timeframe == str(TEST_DRAFT_SUMMARY_SUCCESS.timeframe)

--- a/tests/presenters/test_show_my_plans_presenter.py
+++ b/tests/presenters/test_show_my_plans_presenter.py
@@ -21,7 +21,6 @@ def _convert_into_plan_info(plan: Plan) -> PlanInfo:
         expiration_date=plan.expiration_date,
         expiration_relative=plan.expiration_relative,
         is_available=plan.is_available,
-        renewed=plan.renewed,
         is_cooperating=bool(plan.cooperation),
         cooperation=plan.cooperation,
     )
@@ -169,10 +168,6 @@ class ShowMyPlansPresenterTests(TestCase):
             expected_plan.prd_name,
         )
         self.assertEqual(row1.type_of_plan, "Produktiv")
-        self.assertEqual(
-            row1.renewed,
-            expected_plan.renewed,
-        )
         self.assertEqual(
             row1.renew_plan_url, self.renew_plan_url_index.get_renew_plan_url(plan.id)
         )

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -363,9 +363,6 @@ class PlanRepository(interfaces.PlanRepository):
         plan.expired = True
         plan.is_active = False
 
-    def set_plan_as_renewed(self, plan: Plan) -> None:
-        plan.renewed = True
-
     def set_expiration_date(self, plan: Plan, expiration_date: datetime) -> None:
         plan.expiration_date = expiration_date
 
@@ -506,7 +503,6 @@ class PlanRepository(interfaces.PlanRepository):
             approval_date=None,
             approval_reason=None,
             expired=False,
-            renewed=False,
             expiration_relative=None,
             expiration_date=None,
             active_days=None,


### PR DESCRIPTION
I think that the "create plan" procedure is unnecessarily complicated - especially the "plan renewal" part of it. "Plan renewal" should simply mean to take the plan info of an expired plan and copy it into a new plan draft. 

But right now the old plan is marked as "renewed" as well. This is unnecessarily complex: In my opinion, neither a future plan approval workflow nor accumulation control workflow will need the category of a "renewed plan". *) 

That's why I propose in this PR to delete the "Plan.renewed" attribute. "Renewing" a plan still is possible in the simpler meaning of copying the plan content to a new draft. Do you agree?

In an upcoming PR i would then refactor some of the parts of the "create plan" procedure. 

My Plan-ID: e8e5c56f-9e2d-497d-a896-a26bc41e1c16

------
*) The category of a "renewed plan" was originally implemented because a difference between renewing an expired plan (potentially without any changes to the plan attributes) and filing a completely new plan was desired. 
The idea was that renewing a plan without any changes would allow for automatic plan approval - but this is not true: criteria for plan approval should be, if plans have been met met, not if changes have been made to the plan.
Accumulation control originally was another argument in favor of having this category ("how much have increased the company's use of means of production?") - but accumulation control can also be done with completely new plans.  