### PR TITLE
Adding more internal links

### DIFF
--- a/arbeitszeit/use_cases/query_plans.py
+++ b/arbeitszeit/use_cases/query_plans.py
@@ -28,6 +28,7 @@ class PlanQueryResponse:
 class QueriedPlan:
     plan_id: UUID
     company_name: str
+    company_id: UUID
     product_name: str
     description: str
     price_per_unit: Decimal
@@ -75,6 +76,7 @@ class QueryPlans:
         return QueriedPlan(
             plan_id=plan.id,
             company_name=plan.planner.name,
+            company_id=plan.planner.id,
             product_name=plan.prd_name,
             description=plan.description,
             price_per_unit=price_per_unit,

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -488,9 +488,11 @@ class FlaskModule(Module):
 
     @provider
     def provide_query_companies_presenter(
-        self, notifier: Notifier
+        self, notifier: Notifier, company_url_index: CompanySummaryUrlIndex
     ) -> QueryCompaniesPresenter:
-        return QueryCompaniesPresenter(user_notifier=notifier)
+        return QueryCompaniesPresenter(
+            user_notifier=notifier, company_url_index=company_url_index
+        )
 
     @provider
     def provide_pay_means_of_production_presenter(

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -538,10 +538,13 @@ class FlaskModule(Module):
     def provide_query_plans_presenter(
         self,
         plan_index: PlanSummaryUrlIndex,
+        company_index: CompanySummaryUrlIndex,
         coop_index: CoopSummaryUrlIndex,
         notifier: Notifier,
     ) -> QueryPlansPresenter:
-        return QueryPlansPresenter(plan_index, coop_index, user_notifier=notifier)
+        return QueryPlansPresenter(
+            plan_index, company_index, coop_index, user_notifier=notifier
+        )
 
     @provider
     def provide_user_action_resolver(

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -96,6 +96,7 @@ from arbeitszeit_web.controllers.show_my_accounts_controller import (
     ShowMyAccountsController,
 )
 from arbeitszeit_web.email import EmailConfiguration
+from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_coop_summary import GetCoopSummarySuccessPresenter
 from arbeitszeit_web.get_member_profile_info import GetMemberProfileInfoPresenter
 from arbeitszeit_web.get_plan_summary_company import (
@@ -575,6 +576,12 @@ class FlaskModule(Module):
         self, plan_index: PlanSummaryUrlIndex, end_coop_index: EndCoopUrlIndex
     ) -> GetCoopSummarySuccessPresenter:
         return GetCoopSummarySuccessPresenter(plan_index, end_coop_index)
+
+    @provider
+    def provide_get_company_summary_success_presenter(
+        self, plan_index: PlanSummaryUrlIndex
+    ) -> GetCompanySummarySuccessPresenter:
+        return GetCompanySummarySuccessPresenter(plan_index)
 
     @provider
     def provide_transaction_repository(

--- a/arbeitszeit_flask/templates/macros.html
+++ b/arbeitszeit_flask/templates/macros.html
@@ -360,7 +360,7 @@
     <tbody>
       {% for column in view_model.results.rows %}
       <tr>
-        <td>{{ column.company_name }}</td>
+        <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
         <td>{{ column.company_email }}</td>
       </tr>
       {% endfor %}

--- a/arbeitszeit_flask/templates/macros.html
+++ b/arbeitszeit_flask/templates/macros.html
@@ -277,8 +277,8 @@
     <thead>
       <tr>
         <th>Plan-ID</th>
-        <th>Betrieb</th>
         <th>Produktname</th>
+        <th>Betrieb</th>
         <th>Beschreibung</th>
         <th>Stückpr.</th>
         <th>Art</th>
@@ -291,8 +291,8 @@
       <tr>
         <td><a href="{{ column.plan_summary_url }}">{{ column.plan_id }}</a>
         </td>
-        <td>{{ column.company_name }}</td>
         <td>{{ column.product_name }}</td>
+        <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
         <td>{% for paragraph in column.description %}{{ paragraph }}<br>{% endfor %}</td>
         <td>{{ column.price_per_unit }} {% if column.is_cooperating %} <span>
             <a href="{{ column.coop_summary_url }}"><i class="fas fa-hands-helping"></i></a></span>{% endif %}

--- a/arbeitszeit_flask/templates/macros/company_summary.html
+++ b/arbeitszeit_flask/templates/macros/company_summary.html
@@ -4,7 +4,7 @@
     <div class="column is-two-thirds">
         <div class="content">
             <h1 class="title">
-              {{ gettext("Company") }}
+                {{ gettext("Company") }}
             </h1>
         </div>
         <br>
@@ -33,20 +33,18 @@
         </div>
         <div class="table-container">
             <h1 class="title is-4">
-              {{ gettext("Active plans") }}
+                {{ gettext("Active plans") }}
             </h1>
             <table class="table is-fullwidth has-text-left">
                 <thead>
                     <tr>
-                        <th>{{ gettext("Plan-ID") }}</th>
                         <th>{{ gettext("Product name") }}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for plan in view_model.active_plans %}
                     <tr>
-                        <td>{{ plan.id }}</td>
-                        <td>{{ plan.name }}</td>
+                        <td><a href="{{ plan.url }}">{{ plan.name }}</a></td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/arbeitszeit_web/get_company_summary.py
+++ b/arbeitszeit_web/get_company_summary.py
@@ -6,12 +6,14 @@ from arbeitszeit.use_cases.get_company_summary import (
     GetCompanySummarySuccess,
     PlanDetails,
 )
+from arbeitszeit_web.url_index import PlanSummaryUrlIndex
 
 
 @dataclass
 class PlanDetailsWeb:
     id: str
     name: str
+    url: str
 
 
 @dataclass
@@ -28,6 +30,8 @@ class GetCompanySummaryViewModel:
 
 @dataclass
 class GetCompanySummarySuccessPresenter:
+    plan_index: PlanSummaryUrlIndex
+
     def present(
         self, use_case_response: GetCompanySummarySuccess
     ) -> GetCompanySummaryViewModel:
@@ -40,4 +44,8 @@ class GetCompanySummarySuccessPresenter:
         )
 
     def _get_plan_details(self, plan_details: PlanDetails) -> PlanDetailsWeb:
-        return PlanDetailsWeb(str(plan_details.id), plan_details.name)
+        return PlanDetailsWeb(
+            str(plan_details.id),
+            plan_details.name,
+            self.plan_index.get_plan_summary_url(plan_details.id),
+        )

--- a/arbeitszeit_web/query_companies.py
+++ b/arbeitszeit_web/query_companies.py
@@ -6,6 +6,7 @@ from arbeitszeit.use_cases.query_companies import (
     CompanyQueryResponse,
     QueryCompaniesRequest,
 )
+from arbeitszeit_web.url_index import CompanySummaryUrlIndex
 
 from .notification import Notifier
 
@@ -51,6 +52,7 @@ class ResultTableRow:
     company_id: str
     company_name: str
     company_email: str
+    company_summary_url: str
 
 
 @dataclass
@@ -70,6 +72,7 @@ class QueryCompaniesViewModel:
 @dataclass
 class QueryCompaniesPresenter:
     user_notifier: Notifier
+    company_url_index: CompanySummaryUrlIndex
 
     def present(self, response: CompanyQueryResponse) -> QueryCompaniesViewModel:
         if not response.results:
@@ -82,6 +85,9 @@ class QueryCompaniesPresenter:
                         company_id=str(result.company_id),
                         company_name=result.company_name,
                         company_email=result.company_email,
+                        company_summary_url=self.company_url_index.get_company_summary_url(
+                            result.company_id
+                        ),
                     )
                     for result in response.results
                 ],

--- a/arbeitszeit_web/query_plans.py
+++ b/arbeitszeit_web/query_plans.py
@@ -8,7 +8,7 @@ from arbeitszeit.use_cases.query_plans import (
 )
 
 from .notification import Notifier
-from .url_index import CoopSummaryUrlIndex, PlanSummaryUrlIndex
+from .url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndex, PlanSummaryUrlIndex
 
 
 class QueryPlansFormData(Protocol):
@@ -49,6 +49,7 @@ class QueryPlansController:
 class ResultTableRow:
     plan_id: str
     plan_summary_url: str
+    company_summary_url: str
     coop_summary_url: Optional[str]
     company_name: str
     product_name: str
@@ -77,6 +78,7 @@ class QueryPlansViewModel:
 @dataclass
 class QueryPlansPresenter:
     plan_url_index: PlanSummaryUrlIndex
+    company_url_index: CompanySummaryUrlIndex
     coop_url_index: CoopSummaryUrlIndex
     user_notifier: Notifier
 
@@ -91,6 +93,9 @@ class QueryPlansPresenter:
                         plan_id=str(result.plan_id),
                         plan_summary_url=self.plan_url_index.get_plan_summary_url(
                             result.plan_id
+                        ),
+                        company_summary_url=self.company_url_index.get_company_summary_url(
+                            result.company_id
                         ),
                         coop_summary_url=self.coop_url_index.get_coop_summary_url(
                             result.cooperation

--- a/tests/presenters/test_get_company_summary_presenter.py
+++ b/tests/presenters/test_get_company_summary_presenter.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from unittest import TestCase
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.get_company_summary import (
     GetCompanySummarySuccess,
@@ -19,7 +19,8 @@ RESPONSE_WITH_2_PLANS = GetCompanySummarySuccess(
 
 class GetGetCompanySummaryPresenterTests(TestCase):
     def setUp(self) -> None:
-        self.presenter = GetCompanySummarySuccessPresenter()
+        self.plan_index = PlanSummaryUrlIndex()
+        self.presenter = GetCompanySummarySuccessPresenter(plan_index=self.plan_index)
 
     def test_company_id_is_shown(self):
         view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
@@ -58,3 +59,23 @@ class GetGetCompanySummaryPresenterTests(TestCase):
             view_model.active_plans[1].name,
             str(RESPONSE_WITH_2_PLANS.active_plans[1].name),
         )
+
+    def test_urls_of_plans_are_shown(self):
+        view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
+        self.assertEqual(
+            view_model.active_plans[0].url,
+            self.plan_index.get_plan_summary_url(
+                RESPONSE_WITH_2_PLANS.active_plans[0].id
+            ),
+        )
+        self.assertEqual(
+            view_model.active_plans[1].url,
+            self.plan_index.get_plan_summary_url(
+                RESPONSE_WITH_2_PLANS.active_plans[1].id
+            ),
+        )
+
+
+class PlanSummaryUrlIndex:
+    def get_plan_summary_url(self, plan_id: UUID) -> str:
+        return f"fake_plan_url:{plan_id}"

--- a/tests/presenters/test_query_companies_presenter.py
+++ b/tests/presenters/test_query_companies_presenter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.query_companies import CompanyQueryResponse, QueriedCompany
 from arbeitszeit_web.query_companies import QueryCompaniesPresenter
@@ -21,7 +21,10 @@ RESPONSE_WITH_ONE_RESULT = CompanyQueryResponse(
 class QueryCompaniesPresenterTests(TestCase):
     def setUp(self):
         self.notifier = NotifierTestImpl()
-        self.presenter = QueryCompaniesPresenter(user_notifier=self.notifier)
+        self.url_index = CompanySummaryUrlIndex()
+        self.presenter = QueryCompaniesPresenter(
+            user_notifier=self.notifier, company_url_index=self.url_index
+        )
 
     def test_empty_view_model_does_not_show_results(self):
         presentation = self.presenter.get_empty_view_model()
@@ -38,3 +41,8 @@ class QueryCompaniesPresenterTests(TestCase):
     def test_dont_show_notifications_when_results_are_found(self):
         self.presenter.present(RESPONSE_WITH_ONE_RESULT)
         self.assertFalse(self.notifier.warnings)
+
+
+class CompanySummaryUrlIndex:
+    def get_company_summary_url(self, company_id: UUID) -> str:
+        return f"fake_company_url:{company_id}"

--- a/tests/presenters/test_query_plans_presenter.py
+++ b/tests/presenters/test_query_plans_presenter.py
@@ -13,6 +13,7 @@ RESPONSE_WITH_ONE_RESULT = PlanQueryResponse(
         QueriedPlan(
             plan_id=uuid4(),
             company_name="Planner name",
+            company_id=uuid4(),
             product_name="Bread",
             description="For eating",
             price_per_unit=Decimal(5),
@@ -30,6 +31,7 @@ RESPONSE_WITH_ONE_COOPERATING_RESULT = PlanQueryResponse(
         QueriedPlan(
             plan_id=uuid4(),
             company_name="Planner name",
+            company_id=uuid4(),
             product_name="Bread",
             description="For eating",
             price_per_unit=Decimal(5),
@@ -46,10 +48,14 @@ RESPONSE_WITH_ONE_COOPERATING_RESULT = PlanQueryResponse(
 class QueryPlansPresenterTests(TestCase):
     def setUp(self):
         self.plan_url_index = PlanSummaryUrlIndex()
+        self.company_url_index = CompanySummaryUrlIndex()
         self.coop_url_index = CoopSummaryUrlIndex()
         self.notifier = NotifierTestImpl()
         self.presenter = QueryPlansPresenter(
-            self.plan_url_index, self.coop_url_index, user_notifier=self.notifier
+            self.plan_url_index,
+            self.company_url_index,
+            self.coop_url_index,
+            user_notifier=self.notifier,
         )
 
     def test_presenting_empty_response_leads_to_not_showing_results(self):
@@ -81,6 +87,15 @@ class QueryPlansPresenterTests(TestCase):
             self.plan_url_index.get_plan_summary_url(plan_id),
         )
 
+    def test_company_url(self) -> None:
+        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
+        company_id = RESPONSE_WITH_ONE_RESULT.results[0].company_id
+        table_row = presentation.results.rows[0]
+        self.assertEqual(
+            table_row.company_summary_url,
+            self.company_url_index.get_company_summary_url(company_id),
+        )
+
     def test_no_coop_url_is_shown_with_one_non_cooperating_plan(self) -> None:
         presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
         table_row = presentation.results.rows[0]
@@ -108,3 +123,8 @@ class PlanSummaryUrlIndex:
 class CoopSummaryUrlIndex:
     def get_coop_summary_url(self, coop_id: UUID) -> str:
         return f"fake_coop_url:{coop_id}"
+
+
+class CompanySummaryUrlIndex:
+    def get_company_summary_url(self, company_id: UUID) -> str:
+        return f"fake_company_url:{company_id}"

--- a/tests/use_cases/test_query_plans.py
+++ b/tests/use_cases/test_query_plans.py
@@ -17,7 +17,9 @@ from .dependency_injection import injection_test
 def plan_in_results(plan: Plan, response: PlanQueryResponse) -> bool:
     return any(
         (
-            plan.id == result.plan_id and plan.prd_name == result.product_name
+            plan.id == result.plan_id
+            and plan.prd_name == result.product_name
+            and plan.planner.id == result.company_id
             for result in response.results
         )
     )


### PR DESCRIPTION
fixes #281 

As described in issue #281, I added internal links to three views, using the UrlIndex system:
- company_summary
- query_companies
- query_plans

EDIT: In my opinion this should fix issue 281. I would like to have some internal links in the account views, but that is a more complicated thing to do and should be a different issue/PR.