### PR TITLE
adding FLASK_APP envvar to cron job script

### DIFF
--- a/cron_job_heroku.sh
+++ b/cron_job_heroku.sh
@@ -1,2 +1,3 @@
+export FLASK_APP=arbeitszeit_flask
 export ARBEITSZEIT_APP_CONFIGURATION="$PWD/arbeitszeit_flask/production_settings.py"
 flask payout


### PR DESCRIPTION
Since around two weeks the hourly cron job on prod server did not run.
Heroku logs did show:

```
2022-03-28T19:01:02.730212+00:00 heroku[scheduler.4154]: State changed from starting to up
2022-03-28T19:01:04.420068+00:00 app[scheduler.4154]: Error: Could not locate a Flask application. You did not provide the "FLASK_APP" environment variable, and a "wsgi.py" or "app.py" module was not found in the current directory.
``` 

It has been fixed in this PR (and already pushed to heroku) by defining the FLASK_APP environment variable in the cron job script.  

Luckily the `flask payout` command is intelligent enough to pay out missed payouts from the past as soon as it runs again.

Plan-ID: e8e5c56f-9e2d-497d-a896-a26bc41e1c16
