### PR TITLE
Changes to translation procedure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,26 +114,46 @@ In development mode you can run it manually in the CLI.
 Translation
 ===========
 
-We use `Flask-Babel <https://flask-babel.tkte.ch/>` for translation. Available languages are set in ``arbeitszeit_flask/configuration_base.py``.
+We use `Flask-Babel <https://flask-babel.tkte.ch/>` for translation. 
+A possible procedure might be:
 
-You can mark translatable strings in python files with ``translator.gettext(message: str)`` and ``translator.pgettext(comment: str, message: str)``. 
-In jinja templates use ``gettext(message: str)`` and ``ngettext(singular: str, plural: str, n)``.
+1) 
+Add a new language:
 
-Parse the code and create a new ``.pot``-file::
+a. Execute::
 
-    $ pybabel extract -F babel.cfg -k lazy_gettext -o messages.pot .
+    $ pybabel init -i arbeitszeit_flask/translations/messages.pot -d arbeitszeit_flask/translations -l {LANGUAGE CODE e.g. en}
 
-Add a new language (create a ``.po``-file for that language from ``.pot``-file)::
+b. Add the new language to the LANGUAGES variable in ``arbeitszeit_flask/configuration_base.py``.
 
-    $ pybabel init -i messages.pot -d arbeitszeit_flask/translations -l LANGUAGE-CODE
+2)   
+Mark translatable, user-facing strings in the code. 
 
-Update all existing translation files (intelligent merge) from ``.pot``-file::
+In python files use: 
 
-    $ pybabel update -i messages.pot -d arbeitszeit_flask/translations
+- ``translator.gettext(message: str)`` 
+- ``translator.pgettext(comment: str, message: str)``
+- ``translator.ngettext(self, singular: str, plural: str, n: Number)``
 
-Compile (create ``.mo``-files from ``.po``-files)::
+In jinja templates use: 
+
+- ``gettext(message: str)``
+- ``ngettext(singular: str, plural: str, n)``
+
+
+3) 
+Parse the code and update language specific .po-files::
+
+		$ sh update-translations
+
+4) 
+Translate language specific .po-files.
+	
+5)
+Compile translation files::
 
     $ pybabel compile -d arbeitszeit_flask/translations
+		
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -115,14 +115,13 @@ Translation
 ===========
 
 We use `Flask-Babel <https://flask-babel.tkte.ch/>` for translation. 
-A possible procedure might be:
 
 1) 
 Add a new language:
 
 a. Execute::
 
-    $ pybabel init -i arbeitszeit_flask/translations/messages.pot -d arbeitszeit_flask/translations -l {LANGUAGE CODE e.g. en}
+    $ flask trans-new LANG_CODE
 
 b. Add the new language to the LANGUAGES variable in ``arbeitszeit_flask/configuration_base.py``.
 
@@ -142,9 +141,9 @@ In jinja templates use:
 
 
 3) 
-Parse the code and update language specific .po-files::
+Parse code and update language specific .po-files::
 
-		$ sh update-translations
+	$ flask trans-update
 
 4) 
 Translate language specific .po-files.
@@ -152,7 +151,7 @@ Translate language specific .po-files.
 5)
 Compile translation files::
 
-    $ pybabel compile -d arbeitszeit_flask/translations
+    $ flask trans-compile
 		
 
 License

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -1,3 +1,4 @@
+import click
 from flask import Flask, current_app, request, session
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
@@ -49,9 +50,17 @@ def create_app(config=None, db=None, migrate=None, template_folder=None):
 
     with app.app_context():
 
-        from arbeitszeit_flask.commands import update_and_payout
+        from arbeitszeit_flask.commands import (
+            trans_compile,
+            trans_new,
+            trans_update,
+            update_and_payout,
+        )
 
         app.cli.command("payout")(update_and_payout)
+        app.cli.command("trans-update")(trans_update)
+        app.cli.command("trans-compile")(trans_compile)
+        app.cli.command("trans-new")(click.argument("lang_code")(trans_new))
 
         from .models import Company, Member
 

--- a/arbeitszeit_flask/commands.py
+++ b/arbeitszeit_flask/commands.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from arbeitszeit.use_cases import UpdatePlansAndPayout
 from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.dependency_injection import with_injection
@@ -9,6 +11,65 @@ def update_and_payout(
     payout: UpdatePlansAndPayout,
 ):
     """
-    run every hour on production server or call manually from CLI `flask payout`.
+    Run every hour on production server or call manually from CLI `flask payout`.
     """
     payout()
+
+
+def trans_update():
+    """
+    Parse code and update language specific .po-files.
+    """
+    subprocess.run(
+        [
+            "pybabel",
+            "extract",
+            "-F",
+            "babel.cfg",
+            "-k",
+            "lazy_gettext",
+            "-o",
+            "arbeitszeit_flask/translations/messages.pot",
+            ".",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "pybabel",
+            "update",
+            "-i",
+            "arbeitszeit_flask/translations/messages.pot",
+            "-d",
+            "arbeitszeit_flask/translations",
+            "--no-fuzzy-matching",
+        ],
+        check=True,
+    )
+
+
+def trans_compile():
+    """Compile translation files."""
+    subprocess.run(
+        ["pybabel", "compile", "-d", "arbeitszeit_flask/translations"], check=True
+    )
+
+
+def trans_new(lang_code: str):
+    """
+    Add a new language.
+    Examples for argument lang_code are en, de, fr, etc.
+    """
+    subprocess.run(
+        [
+            "pybabel",
+            "init",
+            "-i",
+            "arbeitszeit_flask/translations/messages.pot",
+            "-d",
+            "arbeitszeit_flask/translations",
+            "-l",
+            lang_code,
+        ],
+        check=True,
+    )

--- a/startapp_heroku.sh
+++ b/startapp_heroku.sh
@@ -2,6 +2,6 @@ export FLASK_APP=arbeitszeit_flask
 export ARBEITSZEIT_APP_CONFIGURATION="$PWD/arbeitszeit_flask/production_settings.py"
 
 echo "Compiling translation files..."
-pybabel compile -d arbeitszeit_flask/translations
+flask trans-compile
 
 gunicorn arbeitszeit_flask.wsgi:app

--- a/update-translations
+++ b/update-translations
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-pybabel extract -F babel.cfg -k lazy_gettext -o messages.pot .
-pybabel update -i messages.pot -d arbeitszeit_flask/translations --no-fuzzy-matching
+pybabel extract -F babel.cfg -k lazy_gettext -o arbeitszeit_flask/translations/messages.pot .
+pybabel update -i arbeitszeit_flask/translations/messages.pot -d arbeitszeit_flask/translations --no-fuzzy-matching

--- a/update-translations
+++ b/update-translations
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-pybabel extract -F babel.cfg -k lazy_gettext -o arbeitszeit_flask/translations/messages.pot .
-pybabel update -i arbeitszeit_flask/translations/messages.pot -d arbeitszeit_flask/translations --no-fuzzy-matching

--- a/update-translations
+++ b/update-translations
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 pybabel extract -F babel.cfg -k lazy_gettext -o messages.pot .
-pybabel update -i messages.pot -d arbeitszeit_flask/translations
+pybabel update -i messages.pot -d arbeitszeit_flask/translations --no-fuzzy-matching


### PR DESCRIPTION
This PR proposes some changes to the translation procedure:

- It deactivates babel's fuzzy matching (babel was trying to find translations of similar strings in our catalog). That was not working well.
- All flask-related translation files are now in the `arbeitszeit_flask` module, not on top level of the application
- There are now simple flask custom commands to execute the rather lenghty babel commands
- README has been adapted

Plan: e8e5c56f-9e2d-497d-a896-a26bc41e1c16