### PR TITLE
Refactor presenter tests to utilize dependency injection

### DIFF
--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -11,12 +11,18 @@ from arbeitszeit_web.get_plan_summary_company import (
 from arbeitszeit_web.get_statistics import GetStatisticsPresenter
 from arbeitszeit_web.hide_plan import HidePlanPresenter
 from arbeitszeit_web.list_all_cooperations import ListAllCooperationsPresenter
+from arbeitszeit_web.list_messages import ListMessagesPresenter
 from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.pay_consumer_product import PayConsumerProductPresenter
+from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresenter
 from arbeitszeit_web.plan_summary_service import (
     PlanSummaryService,
     PlanSummaryServiceImpl,
 )
 from arbeitszeit_web.presenters.end_cooperation_presenter import EndCooperationPresenter
+from arbeitszeit_web.query_companies import QueryCompaniesPresenter
+from arbeitszeit_web.query_plans import QueryPlansPresenter
+from arbeitszeit_web.read_message import ReadMessagePresenter
 from arbeitszeit_web.url_index import ListMessagesUrlIndex
 from tests.request import FakeRequest
 from tests.translator import FakeTranslator
@@ -27,9 +33,11 @@ from .url_index import (
     CoopSummaryUrlIndexTestImpl,
     EndCoopUrlIndexTestImpl,
     ListMessageUrlIndexTestImpl,
+    MessageUrlIndex,
     PlanSummaryUrlIndexTestImpl,
     TogglePlanAvailabilityUrlIndex,
 )
+from .user_action_resolver import UserActionResolver
 
 
 class PresenterTestsInjector(Module):
@@ -187,6 +195,77 @@ class PresenterTestsInjector(Module):
         return HidePlanPresenter(
             notifier=notifier,
             trans=translator,
+        )
+
+    @provider
+    def provide_list_messages_presenter(
+        self, messages_url_index: MessageUrlIndex
+    ) -> ListMessagesPresenter:
+        return ListMessagesPresenter(url_index=messages_url_index)
+
+    @provider
+    def provide_pay_consumer_product_presenter(
+        self, notifier: Notifier, translator: FakeTranslator
+    ) -> PayConsumerProductPresenter:
+        return PayConsumerProductPresenter(
+            user_notifier=notifier,
+            translator=translator,
+        )
+
+    @provider
+    def provide_pay_means_of_production_presenter(
+        self, notifier: Notifier, translator: FakeTranslator
+    ) -> PayMeansOfProductionPresenter:
+        return PayMeansOfProductionPresenter(
+            user_notifier=notifier,
+            trans=translator,
+        )
+
+    @provider
+    def provide_plan_summary_service_impl(
+        self,
+        coop_url_index: CoopSummaryUrlIndexTestImpl,
+        company_url_index: CompanySummaryUrlIndex,
+        translator: FakeTranslator,
+    ) -> PlanSummaryServiceImpl:
+        return PlanSummaryServiceImpl(
+            coop_url_index=coop_url_index,
+            company_url_index=company_url_index,
+            trans=translator,
+        )
+
+    @provider
+    def provide_query_companies_presenter(
+        self, notifier: Notifier, company_url_index: CompanySummaryUrlIndex
+    ) -> QueryCompaniesPresenter:
+        return QueryCompaniesPresenter(
+            user_notifier=notifier,
+            company_url_index=company_url_index,
+        )
+
+    @provider
+    def provide_query_plans_presenter(
+        self,
+        notifier: Notifier,
+        coop_url_index: CoopSummaryUrlIndexTestImpl,
+        plan_url_index: PlanSummaryUrlIndexTestImpl,
+        company_url_index: CompanySummaryUrlIndex,
+        translator: FakeTranslator,
+    ) -> QueryPlansPresenter:
+        return QueryPlansPresenter(
+            plan_url_index=plan_url_index,
+            company_url_index=company_url_index,
+            coop_url_index=coop_url_index,
+            user_notifier=notifier,
+            trans=translator,
+        )
+
+    @provider
+    def provide_read_message_presenter(
+        self, user_action_resolver: UserActionResolver
+    ) -> ReadMessagePresenter:
+        return ReadMessagePresenter(
+            action_link_resolver=user_action_resolver,
         )
 
 

--- a/tests/presenters/test_list_messages_presenter.py
+++ b/tests/presenters/test_list_messages_presenter.py
@@ -7,11 +7,15 @@ from hypothesis import given, strategies
 from arbeitszeit.use_cases import ListedMessage, ListMessagesResponse
 from arbeitszeit_web.list_messages import ListMessagesPresenter
 
+from .dependency_injection import get_dependency_injector
+from .url_index import MessageUrlIndex
+
 
 class ListMessagesPresenterTests(TestCase):
     def setUp(self) -> None:
-        self.url_index = FakeUrlIndex()
-        self.presenter = ListMessagesPresenter(self.url_index)
+        self.injector = get_dependency_injector()
+        self.url_index = self.injector.get(MessageUrlIndex)
+        self.presenter = self.injector.get(ListMessagesPresenter)
 
     def test_view_model_contains_no_messages_when_non_were_provided(self) -> None:
         response = ListMessagesResponse(messages=[])
@@ -76,8 +80,3 @@ class ListMessagesPresenterTests(TestCase):
                 )
             ]
         )
-
-
-class FakeUrlIndex:
-    def get_message_url(self, message_id: UUID) -> str:
-        return f"url:{message_id}"

--- a/tests/presenters/test_list_plans_presenter.py
+++ b/tests/presenters/test_list_plans_presenter.py
@@ -1,34 +1,37 @@
+from unittest import TestCase
 from uuid import uuid4
 
 from arbeitszeit.use_cases import ListedPlan
 from arbeitszeit_web.list_plans import ListPlansPresenter, ListPlansResponse
+
+from .dependency_injection import get_dependency_injector
 
 fake_response_with_one_plan = ListPlansResponse(
     plans=[ListedPlan(id=uuid4(), prd_name="fake prd name")]
 )
 
 
-def test_presenter_does_not_show_empty_list_of_plans():
-    presenter = ListPlansPresenter()
-    presentation = presenter.present(ListPlansResponse(plans=[]))
-    assert not presentation.plans
-    assert not presentation.show_plan_listing
+class PresenterTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(ListPlansPresenter)
 
+    def test_presenter_does_not_show_empty_list_of_plans(self) -> None:
+        presentation = self.presenter.present(ListPlansResponse(plans=[]))
+        assert not presentation.plans
+        assert not presentation.show_plan_listing
 
-def test_presenter_shows_one_plan():
-    presenter = ListPlansPresenter()
-    presentation = presenter.present(fake_response_with_one_plan)
-    assert presentation.plans
-    assert presentation.show_plan_listing
+    def test_presenter_shows_one_plan(self) -> None:
+        presentation = self.presenter.present(fake_response_with_one_plan)
+        assert presentation.plans
+        assert presentation.show_plan_listing
 
-
-def test_presenter_shows_correct_info_of_one_plan():
-    presenter = ListPlansPresenter()
-    presentation = presenter.present(fake_response_with_one_plan)
-    assert len(presentation.plans) == 1
-    assert presentation.plans[0].id == str(fake_response_with_one_plan.plans[0].id)
-    assert (
-        presentation.plans[0].id_truncated
-        == str(fake_response_with_one_plan.plans[0].id)[:6]
-    )
-    assert presentation.plans[0].prd_name_truncated == "fake prd name"[:10]
+    def test_presenter_shows_correct_info_of_one_plan(self) -> None:
+        presentation = self.presenter.present(fake_response_with_one_plan)
+        assert len(presentation.plans) == 1
+        assert presentation.plans[0].id == str(fake_response_with_one_plan.plans[0].id)
+        assert (
+            presentation.plans[0].id_truncated
+            == str(fake_response_with_one_plan.plans[0].id)[:6]
+        )
+        assert presentation.plans[0].prd_name_truncated == "fake prd name"[:10]

--- a/tests/presenters/test_list_workers_presenter.py
+++ b/tests/presenters/test_list_workers_presenter.py
@@ -5,10 +5,13 @@ from uuid import UUID, uuid4
 from arbeitszeit.use_cases.list_workers import ListedWorker, ListWorkersResponse
 from arbeitszeit_web.presenters.list_workers_presenter import ListWorkersPresenter
 
+from .dependency_injection import get_dependency_injector
+
 
 class PresenterTests(TestCase):
     def setUp(self) -> None:
-        self.presenter = ListWorkersPresenter()
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(ListWorkersPresenter)
 
     def test_that_view_model_does_not_contains_workers_if_response_didnt_either(
         self,

--- a/tests/presenters/test_pay_consumer_product_presenter.py
+++ b/tests/presenters/test_pay_consumer_product_presenter.py
@@ -7,16 +7,16 @@ from arbeitszeit.use_cases.pay_consumer_product import (
 from arbeitszeit_web.pay_consumer_product import PayConsumerProductPresenter
 from tests.translator import FakeTranslator
 
+from .dependency_injection import get_dependency_injector
 from .notifier import NotifierTestImpl
 
 
 class PayConsumerProductPresenterTests(TestCase):
     def setUp(self) -> None:
-        self.notifier = NotifierTestImpl()
-        self.translator = FakeTranslator()
-        self.presenter = PayConsumerProductPresenter(
-            user_notifier=self.notifier, translator=self.translator
-        )
+        self.injector = get_dependency_injector()
+        self.notifier = self.injector.get(NotifierTestImpl)
+        self.translator = self.injector.get(FakeTranslator)
+        self.presenter = self.injector.get(PayConsumerProductPresenter)
 
     def test_presenter_shows_correct_notification_when_payment_was_a_success(
         self,

--- a/tests/presenters/test_pay_means_of_production_presenter.py
+++ b/tests/presenters/test_pay_means_of_production_presenter.py
@@ -7,6 +7,7 @@ from arbeitszeit_web.pay_means_of_production import (
 )
 from tests.translator import FakeTranslator
 
+from .dependency_injection import get_dependency_injector
 from .notifier import NotifierTestImpl
 
 reasons = PayMeansOfProductionResponse.RejectionReason
@@ -14,11 +15,10 @@ reasons = PayMeansOfProductionResponse.RejectionReason
 
 class PayMeansOfProductionTests(TestCase):
     def setUp(self) -> None:
-        self.notifier = NotifierTestImpl()
-        self.trans = FakeTranslator()
-        self.presenter = PayMeansOfProductionPresenter(
-            user_notifier=self.notifier, trans=self.trans
-        )
+        self.injector = get_dependency_injector()
+        self.notifier = self.injector.get(NotifierTestImpl)
+        self.trans = self.injector.get(FakeTranslator)
+        self.presenter = self.injector.get(PayMeansOfProductionPresenter)
 
     def test_show_confirmation_when_payment_was_successful(self) -> None:
         self.presenter.present(

--- a/tests/presenters/test_plan_summary_service.py
+++ b/tests/presenters/test_plan_summary_service.py
@@ -1,11 +1,14 @@
 from dataclasses import replace
 from decimal import Decimal
 from unittest import TestCase
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from arbeitszeit.plan_summary import BusinessPlanSummary
 from arbeitszeit_web.plan_summary_service import PlanSummaryServiceImpl
 from tests.translator import FakeTranslator
+
+from .dependency_injection import get_dependency_injector
+from .url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndexTestImpl
 
 BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
     plan_id=uuid4(),
@@ -30,12 +33,11 @@ BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
 
 class PlanSummaryServiceTests(TestCase):
     def setUp(self) -> None:
-        self.coop_url_index = CoopSummaryUrlIndex()
-        self.company_url_index = CompanySummaryUrlIndex()
-        self.translator = FakeTranslator()
-        self.service = PlanSummaryServiceImpl(
-            self.coop_url_index, self.company_url_index, self.translator
-        )
+        self.injector = get_dependency_injector()
+        self.coop_url_index = self.injector.get(CoopSummaryUrlIndexTestImpl)
+        self.company_url_index = self.injector.get(CompanySummaryUrlIndex)
+        self.translator = self.injector.get(FakeTranslator)
+        self.service = self.injector.get(PlanSummaryServiceImpl)
 
     def test_plan_id_is_displayed_correctly_as_tuple_of_strings(self):
         plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
@@ -213,13 +215,3 @@ class PlanSummaryServiceTests(TestCase):
                 "Ja",
             ),
         )
-
-
-class CoopSummaryUrlIndex:
-    def get_coop_summary_url(self, coop_id: UUID) -> str:
-        return f"fake_coop_url:{coop_id}"
-
-
-class CompanySummaryUrlIndex:
-    def get_company_summary_url(self, company_id: UUID) -> str:
-        return f"fake_company_url:{company_id}"

--- a/tests/presenters/test_query_companies_presenter.py
+++ b/tests/presenters/test_query_companies_presenter.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from arbeitszeit.use_cases.query_companies import CompanyQueryResponse, QueriedCompany
 from arbeitszeit_web.query_companies import QueryCompaniesPresenter
 
+from .dependency_injection import get_dependency_injector
 from .notifier import NotifierTestImpl
 
 RESPONSE_WITHOUT_RESULTS = CompanyQueryResponse(results=[])
@@ -20,11 +21,9 @@ RESPONSE_WITH_ONE_RESULT = CompanyQueryResponse(
 
 class QueryCompaniesPresenterTests(TestCase):
     def setUp(self):
-        self.notifier = NotifierTestImpl()
-        self.url_index = CompanySummaryUrlIndex()
-        self.presenter = QueryCompaniesPresenter(
-            user_notifier=self.notifier, company_url_index=self.url_index
-        )
+        self.injector = get_dependency_injector()
+        self.notifier = self.injector.get(NotifierTestImpl)
+        self.presenter = self.injector.get(QueryCompaniesPresenter)
 
     def test_empty_view_model_does_not_show_results(self):
         presentation = self.presenter.get_empty_view_model()
@@ -41,8 +40,3 @@ class QueryCompaniesPresenterTests(TestCase):
     def test_dont_show_notifications_when_results_are_found(self):
         self.presenter.present(RESPONSE_WITH_ONE_RESULT)
         self.assertFalse(self.notifier.warnings)
-
-
-class CompanySummaryUrlIndex:
-    def get_company_summary_url(self, company_id: UUID) -> str:
-        return f"fake_company_url:{company_id}"

--- a/tests/presenters/test_read_message_presenter.py
+++ b/tests/presenters/test_read_message_presenter.py
@@ -8,11 +8,15 @@ from arbeitszeit.user_action import UserAction, UserActionType
 from arbeitszeit_web.read_message import ReadMessagePresenter
 from tests.strategies import user_actions
 
+from .dependency_injection import get_dependency_injector
+from .user_action_resolver import UserActionResolver
+
 
 class ReadMessagePresenterTests(TestCase):
     def setUp(self) -> None:
-        self.action_link_resolver = UserActionResolver()
-        self.presenter = ReadMessagePresenter(self.action_link_resolver)
+        self.injector = get_dependency_injector()
+        self.action_link_resolver = self.injector.get(UserActionResolver)
+        self.presenter = self.injector.get(ReadMessagePresenter)
         self.use_case_response = ReadMessageSuccess(
             message_title="test title",
             message_content="message content",
@@ -99,24 +103,4 @@ class ReadMessagePresenterTests(TestCase):
         self.assertEqual(
             view_model.action_link_label,
             self.action_link_resolver.resolve_user_action_name(action),
-        )
-
-
-class UserActionResolver:
-    def resolve_user_action_reference(self, action: UserAction) -> str:
-        return " ".join(
-            [
-                str(action.type),
-                str(action.reference),
-                "reference",
-            ]
-        )
-
-    def resolve_user_action_name(self, action: UserAction) -> str:
-        return " ".join(
-            [
-                str(action.type),
-                str(action.reference),
-                "name",
-            ]
         )

--- a/tests/presenters/test_request_cooperation_presenter.py
+++ b/tests/presenters/test_request_cooperation_presenter.py
@@ -3,14 +3,17 @@ from unittest import TestCase
 from arbeitszeit.use_cases import RequestCooperationResponse
 from arbeitszeit_web.request_cooperation import RequestCooperationPresenter
 
-rr = RequestCooperationResponse.RejectionReason
+from .dependency_injection import get_dependency_injector
+
+RejectionReason = RequestCooperationResponse.RejectionReason
 
 SUCCESSFUL_COOPERATION_REQUEST = RequestCooperationResponse(rejection_reason=None)
 
 
 class RequestCooperationPresenterTests(TestCase):
     def setUp(self) -> None:
-        self.presenter = RequestCooperationPresenter()
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(RequestCooperationPresenter)
 
     def test_do_not_show_as_error_if_request_was_successful(self):
         presentation = self.presenter.present(SUCCESSFUL_COOPERATION_REQUEST)
@@ -18,25 +21,27 @@ class RequestCooperationPresenterTests(TestCase):
 
     def test_show_as_error_if_request_was_rejected(self):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.plan_not_found)
+            RequestCooperationResponse(rejection_reason=RejectionReason.plan_not_found)
         )
         self.assertTrue(presentation.is_error)
 
     def test_correct_notification_when_rejected_because_plan_not_found(self):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.plan_not_found)
+            RequestCooperationResponse(rejection_reason=RejectionReason.plan_not_found)
         )
         self.assertEqual(presentation.notifications[0], "Plan nicht gefunden.")
 
     def test_correct_notification_when_rejected_because_coop_not_found(self):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.cooperation_not_found)
+            RequestCooperationResponse(
+                rejection_reason=RejectionReason.cooperation_not_found
+            )
         )
         self.assertEqual(presentation.notifications[0], "Kooperation nicht gefunden.")
 
     def test_correct_notification_when_rejected_because_plan_inactive(self):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.plan_inactive)
+            RequestCooperationResponse(rejection_reason=RejectionReason.plan_inactive)
         )
         self.assertEqual(presentation.notifications[0], "Plan nicht aktiv.")
 
@@ -44,7 +49,9 @@ class RequestCooperationPresenterTests(TestCase):
         self,
     ):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.plan_has_cooperation)
+            RequestCooperationResponse(
+                rejection_reason=RejectionReason.plan_has_cooperation
+            )
         )
         self.assertEqual(
             presentation.notifications[0],
@@ -56,7 +63,7 @@ class RequestCooperationPresenterTests(TestCase):
     ):
         presentation = self.presenter.present(
             RequestCooperationResponse(
-                rejection_reason=rr.plan_is_already_requesting_cooperation
+                rejection_reason=RejectionReason.plan_is_already_requesting_cooperation
             )
         )
         self.assertEqual(
@@ -68,7 +75,9 @@ class RequestCooperationPresenterTests(TestCase):
         self,
     ):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.plan_is_public_service)
+            RequestCooperationResponse(
+                rejection_reason=RejectionReason.plan_is_public_service
+            )
         )
         self.assertEqual(
             presentation.notifications[0],
@@ -79,7 +88,9 @@ class RequestCooperationPresenterTests(TestCase):
         self,
     ):
         presentation = self.presenter.present(
-            RequestCooperationResponse(rejection_reason=rr.requester_is_not_planner)
+            RequestCooperationResponse(
+                rejection_reason=RejectionReason.requester_is_not_planner
+            )
         )
         self.assertEqual(
             presentation.notifications[0],

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -29,3 +29,8 @@ class TogglePlanAvailabilityUrlIndex:
 class CompanySummaryUrlIndex:
     def get_company_summary_url(self, company_id: UUID) -> str:
         return f"fake_company_url:{company_id}"
+
+
+class MessageUrlIndex:
+    def get_message_url(self, message_id: UUID) -> str:
+        return f"url:{message_id}"

--- a/tests/presenters/user_action_resolver.py
+++ b/tests/presenters/user_action_resolver.py
@@ -1,0 +1,21 @@
+from arbeitszeit_web.user_action import UserAction
+
+
+class UserActionResolver:
+    def resolve_user_action_reference(self, action: UserAction) -> str:
+        return " ".join(
+            [
+                str(action.type),
+                str(action.reference),
+                "reference",
+            ]
+        )
+
+    def resolve_user_action_name(self, action: UserAction) -> str:
+        return " ".join(
+            [
+                str(action.type),
+                str(action.reference),
+                "name",
+            ]
+        )


### PR DESCRIPTION
This is a continuation of the ongoing refactoring effort. Mainly some more presenter tests were refactored to use dependency injection in their object construction. The long term goal here is to reduce coupling between the test cases and the object construction for classes that are not under test.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c