### PR TITLE
Refactor /member/signup

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -131,6 +131,7 @@ from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresente
 from arbeitszeit_web.plan_summary_service import PlanSummaryServiceImpl
 from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.presenters.end_cooperation_presenter import EndCooperationPresenter
+from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
 from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
     RegistrationEmailTemplate,
@@ -447,6 +448,18 @@ class CompanyModule(Module):
 
 
 class FlaskModule(Module):
+    @provider
+    def provide_flask_session(
+        self, member_repository: MemberRepository
+    ) -> FlaskSession:
+        return FlaskSession(member_repository)
+
+    @provider
+    def provide_register_member_presenter(
+        self, session: Session, translator: Translator
+    ) -> RegisterMemberPresenter:
+        return RegisterMemberPresenter(session=session, translator=translator)
+
     @provider
     def provide_registration_email_presenter(
         self,

--- a/arbeitszeit_flask/dependency_injection/views.py
+++ b/arbeitszeit_flask/dependency_injection/views.py
@@ -7,7 +7,9 @@ from arbeitszeit.use_cases import (
     ShowCompanyWorkInviteDetailsUseCase,
 )
 from arbeitszeit.use_cases.list_workers import ListWorkers
+from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
 from arbeitszeit.use_cases.show_my_accounts import ShowMyAccounts
+from arbeitszeit_flask.database.repositories import MemberRepository
 from arbeitszeit_flask.template import TemplateIndex, TemplateRenderer
 from arbeitszeit_flask.views import (
     CompanyWorkInviteView,
@@ -20,6 +22,7 @@ from arbeitszeit_flask.views.invite_worker_to_company import (
     InviteWorkerPostRequestHandler,
 )
 from arbeitszeit_flask.views.show_my_accounts_view import ShowMyAccountsView
+from arbeitszeit_flask.views.signup_member_view import SignupMemberView
 from arbeitszeit_web.answer_company_work_invite import (
     AnswerCompanyWorkInviteController,
     AnswerCompanyWorkInvitePresenter,
@@ -36,6 +39,7 @@ from arbeitszeit_web.invite_worker_to_company import (
     InviteWorkerToCompanyPresenter,
 )
 from arbeitszeit_web.presenters.list_workers_presenter import ListWorkersPresenter
+from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
 from arbeitszeit_web.presenters.show_company_work_invite_details_presenter import (
     ShowCompanyWorkInviteDetailsPresenter,
 )
@@ -43,6 +47,7 @@ from arbeitszeit_web.presenters.show_my_accounts_presenter import (
     ShowMyAccountsPresenter,
 )
 from arbeitszeit_web.read_message import ReadMessageController, ReadMessagePresenter
+from arbeitszeit_web.register_member import RegisterMemberController
 
 
 class ViewsModule(Module):
@@ -152,3 +157,18 @@ class ViewsModule(Module):
         presenter: ShowMyAccountsPresenter,
     ) -> ShowMyAccountsView:
         return ShowMyAccountsView(template_renderer, controller, use_case, presenter)
+
+    @provider
+    def provide_signup_member_view(
+        self,
+        register_member: RegisterMemberUseCase,
+        member_repository: MemberRepository,
+        controller: RegisterMemberController,
+        register_member_presenter: RegisterMemberPresenter,
+    ) -> SignupMemberView:
+        return SignupMemberView(
+            register_member=register_member,
+            member_repository=member_repository,
+            controller=controller,
+            register_member_presenter=register_member_presenter,
+        )

--- a/arbeitszeit_flask/flask_session.py
+++ b/arbeitszeit_flask/flask_session.py
@@ -1,12 +1,24 @@
+from dataclasses import dataclass
 from typing import Optional
 from uuid import UUID
 
-from flask_login import current_user
+from flask import session
+from flask_login import current_user, login_user
+
+from arbeitszeit_flask.database.repositories import MemberRepository
 
 
+@dataclass
 class FlaskSession:
+    member_repository: MemberRepository
+
     def get_current_user(self) -> Optional[UUID]:
         try:
             return UUID(current_user.id)
         except AttributeError:
             return None
+
+    def login_member(self, email: str) -> None:
+        member = self.member_repository.get_member_orm_by_mail(email)
+        session["user_type"] = "member"
+        login_user(member)

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -85,6 +85,9 @@ class RegisterForm(Form):
     def get_password_string(self) -> str:
         return self.data["password"]
 
+    def add_email_error(self, error: str) -> None:
+        self.email.errors.append(error)
+
 
 class LoginForm(Form):
     email = StringField(

--- a/arbeitszeit_flask/views/signup_member_view.py
+++ b/arbeitszeit_flask/views/signup_member_view.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+from flask import redirect, render_template, request, session, url_for
+from flask_login import current_user, logout_user
+
+from arbeitszeit.use_cases import RegisterMemberUseCase
+from arbeitszeit_flask.database import MemberRepository
+from arbeitszeit_flask.forms import RegisterForm
+from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
+from arbeitszeit_web.register_member import RegisterMemberController
+
+
+@dataclass
+class SignupMemberView:
+    register_member: RegisterMemberUseCase
+    member_repository: MemberRepository
+    controller: RegisterMemberController
+    register_member_presenter: RegisterMemberPresenter
+
+    def handle_request(self):
+        register_form = RegisterForm(request.form)
+        if request.method == "POST" and register_form.validate():
+            self._handle_valid_post_request(register_form=register_form)
+        if current_user.is_authenticated:
+            if session.get("user_type") == "member":
+                return redirect(url_for("main_member.profile"))
+            else:
+                session["user_type"] = None
+                logout_user()
+
+        return render_template("auth/signup_member.html", form=register_form)
+
+    def _handle_valid_post_request(self, register_form: RegisterForm):
+        use_case_request = self.controller.create_request(register_form)
+        response = self.register_member(use_case_request)
+        view_model = self.register_member_presenter.present_member_registration(
+            response, register_form
+        )
+        if view_model.is_success_view:
+            return redirect(url_for("auth.unconfirmed_member"))
+        else:
+            return render_template("auth/signup_member.html", form=register_form)

--- a/arbeitszeit_web/presenters/register_member_presenter.py
+++ b/arbeitszeit_web/presenters/register_member_presenter.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
+from arbeitszeit_web.register_member import RegisterForm
+from arbeitszeit_web.session import Session
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class RegisterMemberViewModel:
+    is_success_view: bool
+
+
+@dataclass
+class RegisterMemberPresenter:
+    session: Session
+    translator: Translator
+
+    def present_member_registration(
+        self, response: RegisterMemberUseCase.Response, form: RegisterForm
+    ) -> RegisterMemberViewModel:
+        if response.is_rejected:
+            if (
+                response.rejection_reason
+                == RegisterMemberUseCase.Response.RejectionReason.member_already_exists
+            ):
+                form.add_email_error(
+                    self.translator.gettext("This email address is already registered.")
+                )
+            return RegisterMemberViewModel(is_success_view=False)
+        else:
+            email = form.get_email_string()
+            self.session.login_member(email)
+            return RegisterMemberViewModel(is_success_view=True)

--- a/arbeitszeit_web/register_member.py
+++ b/arbeitszeit_web/register_member.py
@@ -13,6 +13,9 @@ class RegisterForm(Protocol):
     def get_password_string(self) -> str:
         ...
 
+    def add_email_error(self, error: str) -> None:
+        ...
+
 
 class RegisterMemberController:
     def create_request(

--- a/arbeitszeit_web/session.py
+++ b/arbeitszeit_web/session.py
@@ -5,3 +5,6 @@ from uuid import UUID
 class Session(Protocol):
     def get_current_user(self) -> Optional[UUID]:
         ...
+
+    def login_member(self, email: str) -> None:
+        ...

--- a/tests/controllers/test_register_member_controller.py
+++ b/tests/controllers/test_register_member_controller.py
@@ -48,3 +48,6 @@ class FakeRegisterMemberForm:
 
     def get_password_string(self) -> str:
         return self.password
+
+    def add_email_error(self, error: str) -> None:
+        pass

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -20,6 +20,7 @@ from arbeitszeit_web.plan_summary_service import (
     PlanSummaryServiceImpl,
 )
 from arbeitszeit_web.presenters.end_cooperation_presenter import EndCooperationPresenter
+from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
 from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
@@ -49,6 +50,7 @@ from tests.email import (
 from tests.plotter import FakePlotter
 from tests.presenters.test_colors import TestColors
 from tests.request import FakeRequest
+from tests.session import FakeSession
 from tests.translator import FakeTranslator
 from tests.use_cases.dependency_injection import InMemoryModule
 
@@ -382,6 +384,12 @@ class PresenterTestsInjector(Module):
             email_configuration=email_configuration,
             translator=translator,
         )
+
+    @provider
+    def provide_register_member_presenter(
+        self, session: FakeSession, translator: FakeTranslator
+    ) -> RegisterMemberPresenter:
+        return RegisterMemberPresenter(session=session, translator=translator)
 
 
 def get_dependency_injector() -> Injector:

--- a/tests/presenters/test_register_member_presenter.py
+++ b/tests/presenters/test_register_member_presenter.py
@@ -1,0 +1,49 @@
+from typing import List
+from unittest import TestCase
+
+from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
+from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
+from tests.translator import FakeTranslator
+
+from .dependency_injection import get_dependency_injector
+
+
+class PresenterTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(RegisterMemberPresenter)
+        self.form = RegisterForm()
+        self.translator = self.injector.get(FakeTranslator)
+
+    def test_no_errors_are_rendered_when_registration_was_a_success(self) -> None:
+        response = RegisterMemberUseCase.Response(rejection_reason=None)
+        self.presenter.present_member_registration(response, self.form)
+        self.assertFalse(self.form.errors)
+
+    def test_that_error_message_is_rendered_correctly_when_email_already_exists(
+        self,
+    ) -> None:
+        reason = RegisterMemberUseCase.Response.RejectionReason.member_already_exists
+        response = RegisterMemberUseCase.Response(rejection_reason=reason)
+        self.presenter.present_member_registration(response, self.form)
+        error = self.form.errors[0]
+        self.assertEqual(
+            error, self.translator.gettext("This email address is already registered.")
+        )
+
+
+class RegisterForm:
+    def __init__(self) -> None:
+        self.errors: List[str] = []
+
+    def get_email_string(self) -> str:
+        return "test@test.test"
+
+    def get_name_string(self) -> str:
+        return "test user"
+
+    def get_password_string(self) -> str:
+        return "test password"
+
+    def add_email_error(self, error: str) -> None:
+        self.errors.append(error)

--- a/tests/session.py
+++ b/tests/session.py
@@ -11,3 +11,6 @@ class FakeSession:
 
     def get_current_user(self) -> Optional[UUID]:
         return self._current_user_id
+
+    def login_member(self, email: str) -> None:
+        pass


### PR DESCRIPTION
This PR refactors the route `/member/signup`.

# `RegisterMemberPresenter` was introduced

This presenter is a little different from other presenters that we already implement. Its responsibility is not only to render html to the user but also to sign the user in when the registration attempt was successful. I extended the concept of a `Session` to accommodate the change. Furthermore the error message that appears when an email is already registered is now translatable.

# `SignupMemberView` was implemented

This view is functionally identical to the code that was previously in the route. The newly implemented presenter replaced the code that handled successful form submissions.

I'm looking forward to feedback on this change since I would like to adopt this approach for the route `/company/register` and later `/accountant/register`.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c