### PR TITLE
Let FlaskSession handle login and logout

### DIFF
--- a/arbeitszeit_flask/company/blueprint.py
+++ b/arbeitszeit_flask/company/blueprint.py
@@ -36,7 +36,7 @@ class CompanyRoute:
 
 
 def user_is_company():
-    return session["user_type"] == "company"
+    return session.get("user_type") == "company"
 
 
 def check_confirmed(func):

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -450,9 +450,9 @@ class CompanyModule(Module):
 class FlaskModule(Module):
     @provider
     def provide_flask_session(
-        self, member_repository: MemberRepository
+        self, member_repository: MemberRepository, company_repository: CompanyRepository
     ) -> FlaskSession:
-        return FlaskSession(member_repository)
+        return FlaskSession(member_repository, company_repository)
 
     @provider
     def provide_register_member_presenter(

--- a/arbeitszeit_flask/dependency_injection/views.py
+++ b/arbeitszeit_flask/dependency_injection/views.py
@@ -10,6 +10,7 @@ from arbeitszeit.use_cases.list_workers import ListWorkers
 from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
 from arbeitszeit.use_cases.show_my_accounts import ShowMyAccounts
 from arbeitszeit_flask.database.repositories import MemberRepository
+from arbeitszeit_flask.flask_session import FlaskSession
 from arbeitszeit_flask.template import TemplateIndex, TemplateRenderer
 from arbeitszeit_flask.views import (
     CompanyWorkInviteView,
@@ -165,10 +166,12 @@ class ViewsModule(Module):
         member_repository: MemberRepository,
         controller: RegisterMemberController,
         register_member_presenter: RegisterMemberPresenter,
+        flask_session: FlaskSession,
     ) -> SignupMemberView:
         return SignupMemberView(
             register_member=register_member,
             member_repository=member_repository,
             controller=controller,
             register_member_presenter=register_member_presenter,
+            flask_session=flask_session,
         )

--- a/arbeitszeit_flask/views/signup_member_view.py
+++ b/arbeitszeit_flask/views/signup_member_view.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 
-from flask import redirect, render_template, request, session, url_for
-from flask_login import current_user, logout_user
+from flask import redirect, render_template, request, url_for
+from flask_login import current_user
 
 from arbeitszeit.use_cases import RegisterMemberUseCase
 from arbeitszeit_flask.database import MemberRepository
+from arbeitszeit_flask.flask_session import FlaskSession
 from arbeitszeit_flask.forms import RegisterForm
 from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberPresenter
 from arbeitszeit_web.register_member import RegisterMemberController
@@ -16,17 +17,17 @@ class SignupMemberView:
     member_repository: MemberRepository
     controller: RegisterMemberController
     register_member_presenter: RegisterMemberPresenter
+    flask_session: FlaskSession
 
     def handle_request(self):
         register_form = RegisterForm(request.form)
         if request.method == "POST" and register_form.validate():
             self._handle_valid_post_request(register_form=register_form)
         if current_user.is_authenticated:
-            if session.get("user_type") == "member":
+            if self.flask_session.is_logged_in_as_member():
                 return redirect(url_for("main_member.profile"))
             else:
-                session["user_type"] = None
-                logout_user()
+                self.flask_session.logout()
 
         return render_template("auth/signup_member.html", form=register_form)
 

--- a/arbeitszeit_web/session.py
+++ b/arbeitszeit_web/session.py
@@ -6,5 +6,5 @@ class Session(Protocol):
     def get_current_user(self) -> Optional[UUID]:
         ...
 
-    def login_member(self, email: str) -> None:
+    def login_member(self, email: str, remember: bool = ...) -> None:
         ...

--- a/tests/session.py
+++ b/tests/session.py
@@ -12,5 +12,5 @@ class FakeSession:
     def get_current_user(self) -> Optional[UUID]:
         return self._current_user_id
 
-    def login_member(self, email: str) -> None:
+    def login_member(self, email: str, remember: bool = False) -> None:
         pass


### PR DESCRIPTION
This PR refactors the auth routes with respect to logging in and logging out.  All login related functions are now handled by `FlaskSession`. Unfortunately I was not able to remove some references to `session["user_type"]` from the rest of the code (which would be desirable IMO).

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c