### PR TITLE
Use flask endpoints for plot creation

### DIFF
--- a/arbeitszeit/use_cases/show_prd_account_details.py
+++ b/arbeitszeit/use_cases/show_prd_account_details.py
@@ -27,6 +27,7 @@ class PlotDetails:
 
 @dataclass
 class ShowPRDAccountDetailsResponse:
+    company_id: UUID
     transactions: List[TransactionInfo]
     account_balance: Decimal
     plot: PlotDetails
@@ -56,7 +57,10 @@ class ShowPRDAccountDetails:
             accumulated_volumes=self._get_plot_volumes(transactions),
         )
         return ShowPRDAccountDetailsResponse(
-            transactions=transactions, account_balance=account_balance, plot=plot
+            company_id=company_id,
+            transactions=transactions,
+            account_balance=account_balance,
+            plot=plot,
         )
 
     def _create_info(

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -80,8 +80,10 @@ def create_app(config=None, db=None, migrate=None, template_folder=None):
         # register blueprints
         from . import company, member
         from .auth import routes as auth_routes
+        from .plots import routes as plots_routes
 
         app.register_blueprint(auth_routes.auth)
+        app.register_blueprint(plots_routes.plots)
         app.register_blueprint(company.blueprint.main_company)
         app.register_blueprint(member.blueprint.main_member)
 

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -168,6 +168,7 @@ from arbeitszeit_web.url_index import (
     ListMessagesUrlIndex,
     MessageUrlIndex,
     PlanSummaryUrlIndex,
+    PlotsUrlIndex,
     RenewPlanUrlIndex,
     TogglePlanAvailabilityUrlIndex,
 )
@@ -227,6 +228,10 @@ class MemberModule(Module):
     def provide_company_url_index(
         self, member_index: MemberUrlIndex
     ) -> CompanySummaryUrlIndex:
+        return member_index
+
+    @provider
+    def provide_plots_url_index(self, member_index: MemberUrlIndex) -> PlotsUrlIndex:
         return member_index
 
     @provider
@@ -303,6 +308,10 @@ class CompanyModule(Module):
     def provide_company_url_index(
         self, company_index: CompanyUrlIndex
     ) -> CompanySummaryUrlIndex:
+        return company_index
+
+    @provider
+    def provide_plots_url_index(self, company_index: CompanyUrlIndex) -> PlotsUrlIndex:
         return company_index
 
     @provider
@@ -500,10 +509,14 @@ class FlaskModule(Module):
 
     @provider
     def provide_get_statistics_presenter(
-        self, translator: Translator, plotter: Plotter, colors: Colors
+        self,
+        translator: Translator,
+        plotter: Plotter,
+        colors: Colors,
+        url_index: PlotsUrlIndex,
     ) -> GetStatisticsPresenter:
         return GetStatisticsPresenter(
-            translator=translator, plotter=plotter, colors=colors
+            translator=translator, plotter=plotter, colors=colors, url_index=url_index
         )
 
     @provider

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -410,9 +410,11 @@ class CompanyModule(Module):
 
     @provider
     def provide_show_prd_account_details_presenter(
-        self, translator: Translator, plotter: Plotter
+        self, translator: Translator, url_index: PlotsUrlIndex
     ) -> ShowPRDAccountDetailsPresenter:
-        return ShowPRDAccountDetailsPresenter(translator=translator, plotter=plotter)
+        return ShowPRDAccountDetailsPresenter(
+            translator=translator, url_index=url_index
+        )
 
     @provider
     def provide_show_r_account_details_presenter(

--- a/arbeitszeit_flask/flask_plotter.py
+++ b/arbeitszeit_flask/flask_plotter.py
@@ -1,22 +1,22 @@
-import base64
 import io
 from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional, Tuple, Union
 
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 
 class FlaskPlotter:
     def create_line_plot(
         self, x: List[datetime], y: List[Decimal], fig_size: Tuple[int, int] = (10, 5)
-    ) -> str:
+    ) -> bytes:
         fig = Figure()
         ax = fig.subplots()
         ax.axhline(linestyle="--", color="black")
         ax.plot(x, y)
         fig.set_size_inches(fig_size[0], fig_size[1])
-        return self._fig_to_string(fig)
+        return self._figure_to_bytes(fig)
 
     def create_bar_plot(
         self,
@@ -25,7 +25,7 @@ class FlaskPlotter:
         colors_of_bars: List[str],
         fig_size: Tuple[int, int],
         y_label: Optional[str],
-    ) -> str:
+    ) -> bytes:
         fig = Figure()
         ax = fig.subplots()
         ax.bar(x_coordinates, height_of_bars, color=colors_of_bars)
@@ -34,10 +34,9 @@ class FlaskPlotter:
         if y_label:
             ax.set_ylabel(y_label)
         fig.set_size_inches(fig_size[0], fig_size[1])
-        return self._fig_to_string(fig)
+        return self._figure_to_bytes(fig)
 
-    def _fig_to_string(self, fig: Figure) -> str:
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", bbox_inches="tight")
-        string = base64.b64encode(buf.getbuffer()).decode("utf-8")
-        return string
+    def _figure_to_bytes(self, fig: Figure) -> bytes:
+        output = io.BytesIO()
+        FigureCanvas(fig).print_png(output)
+        return output.getvalue()

--- a/arbeitszeit_flask/plots/routes.py
+++ b/arbeitszeit_flask/plots/routes.py
@@ -1,8 +1,10 @@
 from decimal import Decimal
+from uuid import UUID
 
 from flask import Blueprint, Response, request
 from flask_login import login_required
 
+from arbeitszeit.use_cases.show_prd_account_details import ShowPRDAccountDetails
 from arbeitszeit_flask.dependency_injection import with_injection
 from arbeitszeit_web.colors import Colors
 from arbeitszeit_web.plotter import Plotter
@@ -83,5 +85,21 @@ def global_barplot_for_plans(plotter: Plotter, translator: Translator, colors: C
         colors_of_bars=list(colors.get_all_defined_colors().values()),
         fig_size=(5, 4),
         y_label=translator.gettext("Amount"),
+    )
+    return Response(png, mimetype="image/png", direct_passthrough=True)
+
+
+@plots.route("/plots/line_plot_of_company_prd_account")
+@with_injection()
+@login_required
+def line_plot_of_company_prd_account(
+    plotter: Plotter,
+    use_case: ShowPRDAccountDetails,
+):
+    company_id = UUID(request.args["company_id"])
+    use_case_response = use_case(company_id)
+    png = plotter.create_line_plot(
+        x=use_case_response.plot.timestamps,
+        y=use_case_response.plot.accumulated_volumes,
     )
     return Response(png, mimetype="image/png", direct_passthrough=True)

--- a/arbeitszeit_flask/plots/routes.py
+++ b/arbeitszeit_flask/plots/routes.py
@@ -1,0 +1,87 @@
+from decimal import Decimal
+
+from flask import Blueprint, Response, request
+from flask_login import login_required
+
+from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_web.colors import Colors
+from arbeitszeit_web.plotter import Plotter
+from arbeitszeit_web.translator import Translator
+
+plots = Blueprint(
+    "plots", __name__, template_folder="templates", static_folder="static"
+)
+
+
+@plots.route("/plots/global_barplot_for_certificates")
+@with_injection()
+@login_required
+def global_barplot_for_certificates(
+    plotter: Plotter, translator: Translator, colors: Colors
+):
+    certificates_count = Decimal(request.args["certificates_count"])
+    available_product = Decimal(request.args["available_product"])
+    png = plotter.create_bar_plot(
+        x_coordinates=[
+            translator.gettext("Work certificates"),
+            translator.gettext("Available product"),
+        ],
+        height_of_bars=[
+            certificates_count,
+            available_product,
+        ],
+        colors_of_bars=[colors.primary, colors.info],
+        fig_size=(5, 4),
+        y_label=translator.gettext("Hours"),
+    )
+    return Response(png, mimetype="image/png", direct_passthrough=True)
+
+
+@plots.route("/plots/global_barplot_for_means_of_production")
+@with_injection()
+@login_required
+def global_barplot_for_means_of_production(
+    plotter: Plotter, translator: Translator, colors: Colors
+):
+    planned_means = Decimal(request.args["planned_means"])
+    planned_resources = Decimal(request.args["planned_resources"])
+    planned_work = Decimal(request.args["planned_work"])
+    png = plotter.create_bar_plot(
+        x_coordinates=[
+            translator.pgettext("Text should be short", "Fixed means"),
+            translator.pgettext("Text should be short", "Liquid means"),
+            translator.gettext("Work"),
+        ],
+        height_of_bars=[
+            planned_means,
+            planned_resources,
+            planned_work,
+        ],
+        colors_of_bars=[
+            colors.primary,
+            colors.info,
+            colors.danger,
+        ],
+        fig_size=(5, 4),
+        y_label=translator.gettext("Hours"),
+    )
+    return Response(png, mimetype="image/png", direct_passthrough=True)
+
+
+@plots.route("/plots/global_barplot_for_plans")
+@with_injection()
+@login_required
+def global_barplot_for_plans(plotter: Plotter, translator: Translator, colors: Colors):
+    productive_plans = Decimal(request.args["productive_plans"])
+    public_plans = Decimal(request.args["public_plans"])
+    png = plotter.create_bar_plot(
+        x_coordinates=[
+            translator.gettext("Productive plans"),
+            translator.gettext("Public plans"),
+        ],
+        height_of_bars=[productive_plans, public_plans],
+        colors_of_bars=list(colors.get_all_defined_colors().values()),
+        fig_size=(5, 4),
+        y_label=translator.gettext("Amount"),
+    )
+    return Response(png, mimetype="image/png", direct_passthrough=True)

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -14,7 +14,7 @@
         {{ view_model.account_balance }}</p>
 
     <div>
-        <img src="data:image/png;base64, {{ view_model.plot }}" alt="plot of prd account">
+        <img src="{{ view_model.plot_url }}" alt="plot of prd account">
     </div>
 
     <div class="table-container">

--- a/arbeitszeit_flask/templates/macros/statistics.html
+++ b/arbeitszeit_flask/templates/macros/statistics.html
@@ -36,8 +36,7 @@
             <div class="tile is-child box">
                 <h1 class="title is-4 has-text-centered">{{ gettext("Plans") }}</h1>
                 <div>
-                    <img src="data:image/png;base64, {{ view_model.barplot_plans }}"
-                        alt="bar plot of public and productive plans">
+                    <img src="{{ view_model.barplot_plans_url }}" alt="bar plot of public and productive plans">
                 </div>
             </div>
         </div>
@@ -45,8 +44,7 @@
             <div class="tile is-child box">
                 <h1 class="title is-4 has-text-centered">{{ gettext("Planned ressources") }}</h1>
                 <div>
-                    <img src="data:image/png;base64, {{ view_model.barplot_means_of_production }}"
-                        alt="bar plot of means of production">
+                    <img src="{{ view_model.barplot_means_of_production_url }}" alt="bar plot of means of production">
                 </div>
             </div>
         </div>
@@ -54,8 +52,7 @@
             <div class="tile is-child box">
                 <h1 class="title is-4 has-text-centered">{{ gettext("Certificates and products") }}</h1>
                 <div>
-                    <img src="data:image/png;base64, {{ view_model.barplot_certificates }}"
-                        alt="bar plot of certificates vs product">
+                    <img src="{{ view_model.barplot_for_certificates_url }}" alt="bar plot of certificates vs product">
                 </div>
             </div>
         </div>

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from uuid import UUID
 
 from flask import url_for
@@ -40,6 +41,34 @@ class MemberUrlIndex:
     def get_confirmation_url(self, token: str) -> str:
         return url_for(
             endpoint="auth.confirm_email_member", token=token, _external=True
+        )
+
+    def get_global_barplot_for_certificates_url(
+        self, certificates_count: Decimal, available_product: Decimal
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_certificates",
+            certificates_count=str(certificates_count),
+            available_product=str(available_product),
+        )
+
+    def get_global_barplot_for_means_of_production_url(
+        self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_means_of_production",
+            planned_means=planned_means,
+            planned_resources=planned_resources,
+            planned_work=planned_work,
+        )
+
+    def get_global_barplot_for_plans_url(
+        self, productive_plans: int, public_plans: int
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_plans",
+            productive_plans=productive_plans,
+            public_plans=public_plans,
         )
 
 
@@ -88,4 +117,32 @@ class CompanyUrlIndex:
     def get_confirmation_url(self, token: str) -> str:
         return url_for(
             endpoint="auth.confirm_email_company", token=token, _external=True
+        )
+
+    def get_global_barplot_for_certificates_url(
+        self, certificates_count: Decimal, available_product: Decimal
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_certificates",
+            certificates_count=str(certificates_count),
+            available_product=str(available_product),
+        )
+
+    def get_global_barplot_for_means_of_production_url(
+        self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_means_of_production",
+            planned_means=planned_means,
+            planned_resources=planned_resources,
+            planned_work=planned_work,
+        )
+
+    def get_global_barplot_for_plans_url(
+        self, productive_plans: int, public_plans: int
+    ) -> str:
+        return url_for(
+            endpoint="plots.global_barplot_for_plans",
+            productive_plans=productive_plans,
+            public_plans=public_plans,
         )

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -71,6 +71,12 @@ class MemberUrlIndex:
             public_plans=public_plans,
         )
 
+    def get_line_plot_of_company_prd_account(self, company_id: UUID) -> str:
+        return url_for(
+            endpoint="plots.line_plot_of_company_prd_account",
+            company_id=str(company_id),
+        )
+
 
 class CompanyUrlIndex:
     def get_plan_summary_url(self, plan_id: UUID) -> str:
@@ -145,4 +151,10 @@ class CompanyUrlIndex:
             endpoint="plots.global_barplot_for_plans",
             productive_plans=productive_plans,
             public_plans=public_plans,
+        )
+
+    def get_line_plot_of_company_prd_account(self, company_id: UUID) -> str:
+        return url_for(
+            endpoint="plots.line_plot_of_company_prd_account",
+            company_id=str(company_id),
         )

--- a/arbeitszeit_web/get_statistics.py
+++ b/arbeitszeit_web/get_statistics.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from decimal import Decimal
 
 from arbeitszeit.use_cases import StatisticsResponse
 from arbeitszeit_web.colors import Colors
 from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import PlotsUrlIndex
 
 
 @dataclass
@@ -21,9 +21,9 @@ class GetStatisticsViewModel:
     planned_resources_hours: str
     planned_means_hours: str
 
-    barplot_certificates: str
-    barplot_means_of_production: str
-    barplot_plans: str
+    barplot_for_certificates_url: str
+    barplot_means_of_production_url: str
+    barplot_plans_url: str
 
 
 @dataclass
@@ -31,6 +31,7 @@ class GetStatisticsPresenter:
     translator: Translator
     plotter: Plotter
     colors: Colors
+    url_index: PlotsUrlIndex
 
     def present(self, use_case_response: StatisticsResponse) -> GetStatisticsViewModel:
         average_timeframe = self.translator.ngettext(
@@ -61,52 +62,20 @@ class GetStatisticsPresenter:
             active_plans_count=str(use_case_response.active_plans_count),
             active_plans_public_count=str(use_case_response.active_plans_public_count),
             average_timeframe_days=average_timeframe,
-            barplot_certificates=self.plotter.create_bar_plot(
-                x_coordinates=[
-                    self.translator.gettext("Work certificates"),
-                    self.translator.gettext("Available product"),
-                ],
-                height_of_bars=[
-                    use_case_response.certificates_count,
-                    use_case_response.available_product,
-                ],
-                colors_of_bars=[self.colors.primary, self.colors.info],
-                fig_size=(5, 4),
-                y_label=self.translator.gettext("Hours"),
+            barplot_for_certificates_url=self.url_index.get_global_barplot_for_certificates_url(
+                use_case_response.certificates_count,
+                use_case_response.available_product,
             ),
-            barplot_means_of_production=self.plotter.create_bar_plot(
-                x_coordinates=[
-                    self.translator.pgettext("Text should be short", "Fixed means"),
-                    self.translator.pgettext("Text should be short", "Liquid means"),
-                    self.translator.gettext("Work"),
-                ],
-                height_of_bars=[
-                    use_case_response.planned_means,
-                    use_case_response.planned_resources,
-                    use_case_response.planned_work,
-                ],
-                colors_of_bars=[
-                    self.colors.primary,
-                    self.colors.info,
-                    self.colors.danger,
-                ],
-                fig_size=(5, 4),
-                y_label=self.translator.gettext("Hours"),
+            barplot_means_of_production_url=self.url_index.get_global_barplot_for_means_of_production_url(
+                use_case_response.planned_means,
+                use_case_response.planned_resources,
+                use_case_response.planned_work,
             ),
-            barplot_plans=self.plotter.create_bar_plot(
-                x_coordinates=[
-                    self.translator.gettext("Productive plans"),
-                    self.translator.gettext("Public plans"),
-                ],
-                height_of_bars=[
-                    Decimal(
-                        use_case_response.active_plans_count
-                        - use_case_response.active_plans_public_count
-                    ),
-                    Decimal(use_case_response.active_plans_public_count),
-                ],
-                colors_of_bars=list(self.colors.get_all_defined_colors().values()),
-                fig_size=(5, 4),
-                y_label=self.translator.gettext("Amount"),
+            barplot_plans_url=self.url_index.get_global_barplot_for_plans_url(
+                (
+                    use_case_response.active_plans_count
+                    - use_case_response.active_plans_public_count
+                ),
+                use_case_response.active_plans_public_count,
             ),
         )

--- a/arbeitszeit_web/plotter.py
+++ b/arbeitszeit_web/plotter.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Protocol, Tuple, Union
 class Plotter(Protocol):
     def create_line_plot(
         self, x: List[datetime], y: List[Decimal], fig_size: Tuple[int, int] = (10, 5)
-    ) -> str:
+    ) -> bytes:
         ...
 
     def create_bar_plot(
@@ -16,5 +16,5 @@ class Plotter(Protocol):
         colors_of_bars: List[str],
         fig_size: Tuple[int, int],
         y_label: Optional[str],
-    ) -> str:
+    ) -> bytes:
         ...

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -4,12 +4,11 @@ from typing import List
 
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.show_prd_account_details import (
-    PlotDetails,
     ShowPRDAccountDetailsResponse,
     TransactionInfo,
 )
-from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import PlotsUrlIndex
 
 
 @dataclass
@@ -25,13 +24,13 @@ class ShowPRDAccountDetailsResponseViewModel:
     transactions: List[ViewModelTransactionInfo]
     show_transactions: bool
     account_balance: str
-    plot: str
+    plot_url: str
 
 
 @dataclass
 class ShowPRDAccountDetailsPresenter:
     translator: Translator
-    plotter: Plotter
+    url_index: PlotsUrlIndex
 
     def present(
         self, use_case_response: ShowPRDAccountDetailsResponse
@@ -44,7 +43,9 @@ class ShowPRDAccountDetailsPresenter:
             transactions=transactions,
             show_transactions=bool(transactions),
             account_balance=str(round(use_case_response.account_balance, 2)),
-            plot=self._create_graph(use_case_response.plot),
+            plot_url=self.url_index.get_line_plot_of_company_prd_account(
+                use_case_response.company_id
+            ),
         )
 
     def _create_info(self, transaction: TransactionInfo) -> ViewModelTransactionInfo:
@@ -65,9 +66,3 @@ class ShowPRDAccountDetailsPresenter:
             str(round(transaction.transaction_volume, 2)),
             transaction.purpose,
         )
-
-    def _create_graph(self, plot: PlotDetails) -> str:
-        graph = self.plotter.create_line_plot(
-            x=plot.timestamps, y=plot.accumulated_volumes
-        )
-        return graph

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -78,3 +78,6 @@ class PlotsUrlIndex(Protocol):
         self, productive_plans: int, public_plans: int
     ) -> str:
         ...
+
+    def get_line_plot_of_company_prd_account(self, company_id: UUID) -> str:
+        ...

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Protocol
 from uuid import UUID
 
@@ -59,4 +60,21 @@ class ListMessagesUrlIndex(Protocol):
 
 class ConfirmationUrlIndex(Protocol):
     def get_confirmation_url(self, token: str) -> str:
+        ...
+
+
+class PlotsUrlIndex(Protocol):
+    def get_global_barplot_for_certificates_url(
+        self, certificates_count: Decimal, available_product: Decimal
+    ) -> str:
+        ...
+
+    def get_global_barplot_for_means_of_production_url(
+        self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
+    ) -> str:
+        ...
+
+    def get_global_barplot_for_plans_url(
+        self, productive_plans: int, public_plans: int
+    ) -> str:
         ...

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from uuid import UUID
 
 from arbeitszeit.use_cases import InviteWorkerToCompany, InviteWorkerToCompanyRequest
@@ -88,6 +89,32 @@ class CompanyUrlIndexTests(ViewTestCase):
         url = self.url_index.get_list_messages_url()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_url_for_barplot_for_certificates_returns_png(self) -> None:
+        url = self.url_index.get_global_barplot_for_certificates_url(
+            certificates_count=Decimal("10"), available_product=Decimal("5")
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "image/png")
+
+    def test_url_for_barplot_for_means_of_productions_returns_png(self) -> None:
+        url = self.url_index.get_global_barplot_for_means_of_production_url(
+            planned_means=Decimal("10"),
+            planned_resources=Decimal("5"),
+            planned_work=Decimal("20"),
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "image/png")
+
+    def test_url_for_barplot_for_plans_returns_png(self) -> None:
+        url = self.url_index.get_global_barplot_for_plans_url(
+            productive_plans=10, public_plans=5
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "image/png")
 
 
 class MemberUrlIndexTests(ViewTestCase):

--- a/tests/plotter.py
+++ b/tests/plotter.py
@@ -6,8 +6,8 @@ from typing import List, Optional, Tuple, Union
 class FakePlotter:
     def create_line_plot(
         self, x: List[datetime], y: List[Decimal], fig_size: Tuple[int, int] = (10, 5)
-    ) -> str:
-        return "fake line plot"
+    ) -> bytes:
+        return b"fake line plot"
 
     def create_bar_plot(
         self,
@@ -16,5 +16,5 @@ class FakePlotter:
         colors_of_bars: List[str],
         fig_size: Tuple[int, int],
         y_label: Optional[str] = None,
-    ) -> str:
-        return "fake bar plot"
+    ) -> bytes:
+        return b"fake bar plot"

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -344,11 +344,12 @@ class PresenterTestsInjector(Module):
 
     @provider
     def provide_show_prd_account_details_presenter(
-        self, translator: FakeTranslator, plotter: FakePlotter
+        self,
+        translator: FakeTranslator,
+        url_index: PlotsUrlIndexImpl,
     ) -> ShowPRDAccountDetailsPresenter:
         return ShowPRDAccountDetailsPresenter(
-            translator=translator,
-            plotter=plotter,
+            translator=translator, url_index=url_index
         )
 
     @provider

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -66,6 +66,7 @@ from .url_index import (
     ListMessageUrlIndexTestImpl,
     MessageUrlIndex,
     PlanSummaryUrlIndexTestImpl,
+    PlotsUrlIndexImpl,
     RenewPlanUrlIndex,
     TogglePlanAvailabilityUrlIndex,
 )
@@ -208,10 +209,14 @@ class PresenterTestsInjector(Module):
 
     @provider
     def provide_get_statistics_presenter(
-        self, translator: FakeTranslator, plotter: FakePlotter, colors: TestColors
+        self,
+        translator: FakeTranslator,
+        plotter: FakePlotter,
+        colors: TestColors,
+        url_index: PlotsUrlIndexImpl,
     ) -> GetStatisticsPresenter:
         return GetStatisticsPresenter(
-            translator=translator, plotter=plotter, colors=colors
+            translator=translator, plotter=plotter, colors=colors, url_index=url_index
         )
 
     @provider

--- a/tests/presenters/test_get_statistics_presenter.py
+++ b/tests/presenters/test_get_statistics_presenter.py
@@ -12,14 +12,14 @@ TESTING_RESPONSE_MODEL = StatisticsResponse(
     registered_companies_count=5,
     registered_members_count=30,
     cooperations_count=10,
-    certificates_count=Decimal(50),
-    available_product=Decimal(20.5),
+    certificates_count=Decimal("50"),
+    available_product=Decimal("20.5"),
     active_plans_count=6,
     active_plans_public_count=2,
-    avg_timeframe=Decimal(30.5),
-    planned_work=Decimal(500.23),
-    planned_resources=Decimal(400.1),
-    planned_means=Decimal(215.23),
+    avg_timeframe=Decimal("30.5"),
+    planned_work=Decimal("500.23"),
+    planned_resources=Decimal("400.1"),
+    planned_means=Decimal("215.23"),
 )
 
 
@@ -148,4 +148,44 @@ class GetStatisticsPresenterTests(TestCase):
         self.assertEqual(
             view_model.average_timeframe_days,
             self.translator.gettext("%.2f days") % 31.21,
+        )
+
+    def test_that_plot_url_for_certificates_with_correct_args_is_returned(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.certificates_count),
+            view_model.barplot_for_certificates_url,
+        )
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.available_product),
+            view_model.barplot_for_certificates_url,
+        )
+
+    def test_that_plot_url_for_means_of_productions_with_correct_args_is_returned(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.planned_means),
+            view_model.barplot_means_of_production_url,
+        )
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.planned_resources),
+            view_model.barplot_means_of_production_url,
+        )
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.planned_work),
+            view_model.barplot_means_of_production_url,
+        )
+
+    def test_that_plot_url_for_plans_with_correct_args_is_returned(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertIn(
+            str(
+                TESTING_RESPONSE_MODEL.active_plans_count
+                - TESTING_RESPONSE_MODEL.active_plans_public_count
+            ),
+            view_model.barplot_plans_url,
+        )
+        self.assertIn(
+            str(TESTING_RESPONSE_MODEL.active_plans_public_count),
+            view_model.barplot_plans_url,
         )

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from uuid import UUID
 
 
@@ -59,3 +60,22 @@ class InviteUrlIndexImpl:
 class ConfirmationUrlIndexImpl:
     def get_confirmation_url(self, token: str) -> str:
         return f"{token} url"
+
+
+class PlotsUrlIndexImpl:
+    def get_global_barplot_for_certificates_url(
+        self, certificates_count: Decimal, available_product: Decimal
+    ) -> str:
+        return f"barplot url with {certificates_count} and {available_product}"
+
+    def get_global_barplot_for_means_of_production_url(
+        self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
+    ) -> str:
+        return (
+            f"barplot url with {planned_means}, {planned_resources} and {planned_work}"
+        )
+
+    def get_global_barplot_for_plans_url(
+        self, productive_plans: int, public_plans: int
+    ) -> str:
+        return f"barplot url with {productive_plans} and {public_plans}"

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -79,3 +79,6 @@ class PlotsUrlIndexImpl:
         self, productive_plans: int, public_plans: int
     ) -> str:
         return f"barplot url with {productive_plans} and {public_plans}"
+
+    def get_line_plot_of_company_prd_account(self, company_id: UUID) -> str:
+        return f"line plot for {company_id}"

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -40,6 +40,19 @@ def test_balance_is_zero_when_no_transactions_took_place(
 
 
 @injection_test
+def test_company_id_is_returned(
+    show_prd_account_details: ShowPRDAccountDetails,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+):
+    member_generator.create_member()
+    company = company_generator.create_company()
+
+    response = show_prd_account_details(company.id)
+    assert response.company_id == company.id
+
+
+@injection_test
 def test_that_no_info_is_generated_after_company_buying_p(
     show_prd_account_details: ShowPRDAccountDetails,
     company_generator: CompanyGenerator,


### PR DESCRIPTION
fixes #359 

This PR proposes a solution to the security issue described in #359. Presenters do not insert a base64 string into the templates anymore but return an url to an endpoint where plots are created. This makes the plot rendering more complicated. 

I'm interested in your opinion if there is something I could improve. But from what I read and from what we discussed so far this seems to be more or less the way to go. 

Some remarks:

- There is a new flask blueprint called "plots".
- For test performance reasons I wrote integration tests of url indexes only for companies, not for members (in `tests/flask_integration/test_url_index.py`).
- In the current setting it is possible for members as well as for other companies to access a company's PRD account plot (by manually typing the url). The only access restriction is that users must be logged in. I think that is fine, as this should be probably public information.
- In route "line_plot_of_company_prd_account" there is a second call to Use Case `ShowPRDAccountDetails` (a first call takes place in the presenter). If we want to prevent this we could split the Use Case in two parts: One for showing the transactions plus the current balance, and a second one for just showing the prd account plot. 