### PR TITLE
Include templates in package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include arbeitszeit_flask/templates *.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ classifiers =
 
 [options]
 packages = find:
+include_package_data = True
 
 [flake8]
 ignore = E501,W503,E712


### PR DESCRIPTION
This PR is about packaging. With the change proposed by this PR the templates used by `arbeitszeitapp` are also included in source and binary distributions of the app.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c