### PR TITLE
Fix-pytest-warnings

### DIFF
--- a/arbeitszeit_web/get_member_profile_info.py
+++ b/arbeitszeit_web/get_member_profile_info.py
@@ -31,8 +31,8 @@ class GetMemberProfileInfoPresenter:
     ) -> GetMemberProfileInfoViewModel:
         return GetMemberProfileInfoViewModel(
             member_id=str(use_case_response.id),
-            account_balance=self.translator.ngettext(
-                "%(num).2f hour", "%(num).2f hours", use_case_response.account_balance
+            account_balance=self.translator.gettext(
+                "%(num).2f hours" % dict(num=use_case_response.account_balance)
             ),
             email=use_case_response.email,
             workplaces=[

--- a/arbeitszeit_web/get_statistics.py
+++ b/arbeitszeit_web/get_statistics.py
@@ -34,17 +34,17 @@ class GetStatisticsPresenter:
     url_index: PlotsUrlIndex
 
     def present(self, use_case_response: StatisticsResponse) -> GetStatisticsViewModel:
-        average_timeframe = self.translator.ngettext(
-            "%(num).2f day", "%(num).2f days", use_case_response.avg_timeframe
+        average_timeframe = self.translator.gettext(
+            "%(num).2f days" % dict(num=use_case_response.avg_timeframe)
         )
-        planned_work = self.translator.ngettext(
-            "%(num).2f hour", "%(num).2f hours", use_case_response.planned_work
+        planned_work = self.translator.gettext(
+            "%(num).2f hours" % dict(num=use_case_response.planned_work)
         )
-        planned_liquid_means = self.translator.ngettext(
-            "%(num).2f hour", "%(num).2f hours", use_case_response.planned_resources
+        planned_liquid_means = self.translator.gettext(
+            "%(num).2f hours" % dict(num=use_case_response.planned_resources)
         )
-        planned_fixed_means = self.translator.ngettext(
-            "%(num).2f hour", "%(num).2f hours", use_case_response.planned_means
+        planned_fixed_means = self.translator.gettext(
+            "%(num).2f hours" % dict(num=use_case_response.planned_means)
         )
         return GetStatisticsViewModel(
             planned_resources_hours=planned_liquid_means,

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -57,7 +57,7 @@ from tests.email import (
     RegistrationEmailTemplateImpl,
 )
 from tests.plotter import FakePlotter
-from tests.presenters.test_colors import TestColors
+from tests.presenters.test_colors import ColorsTestImpl
 from tests.request import FakeRequest
 from tests.session import FakeSession
 from tests.translator import FakeTranslator
@@ -231,7 +231,7 @@ class PresenterTestsInjector(Module):
         self,
         translator: FakeTranslator,
         plotter: FakePlotter,
-        colors: TestColors,
+        colors: ColorsTestImpl,
         url_index: PlotsUrlIndexImpl,
     ) -> GetStatisticsPresenter:
         return GetStatisticsPresenter(

--- a/tests/presenters/test_colors.py
+++ b/tests/presenters/test_colors.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 
-class TestColors:
+class ColorsTestImpl:
     def __init__(self) -> None:
         self.all_colors = {
             "primary": "primary_color",


### PR DESCRIPTION
fixes #309

This PR fixes two different pytest warnings: 

- warnings about the usage of ngettext in combination with Decimal
- a warning that was raised because of the naming of `TestColors`

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c