### PR TITLE
Implement (non-functional) /accountant/signup/<token> route

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -28,6 +28,7 @@ from arbeitszeit_flask.next_url import (
     save_next_url_in_session,
 )
 from arbeitszeit_flask.token import FlaskTokenService
+from arbeitszeit_flask.views.signup_accountant_view import SignupAccountantView
 from arbeitszeit_flask.views.signup_company_view import SignupCompanyView
 from arbeitszeit_flask.views.signup_member_view import SignupMemberView
 
@@ -231,6 +232,12 @@ def resend_confirmation_company(use_case: ResendConfirmationMail):
         flash("Eine neue Bestätigungsmail wurde gesendet.")
 
     return redirect(url_for("auth.unconfirmed_company"))
+
+
+@auth.route("/accountant/signup/<token>")
+@with_injection()
+def signup_accountant(token: str, view: SignupAccountantView):
+    return view.handle_request()
 
 
 # logout

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -6,7 +6,7 @@ from flask import url_for
 
 class GeneralUrlIndex:
     def get_accountant_invitation_url(self, token: str) -> str:
-        return "/not/implemented/yet"
+        return url_for("auth.signup_accountant", token=token)
 
 
 class MemberUrlIndex:

--- a/arbeitszeit_flask/views/signup_accountant_view.py
+++ b/arbeitszeit_flask/views/signup_accountant_view.py
@@ -1,0 +1,6 @@
+from flask import Response
+
+
+class SignupAccountantView:
+    def handle_request(self) -> Response:
+        return Response(status=200)

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -6,6 +6,10 @@ from arbeitszeit.repositories import (
     CompanyWorkerRepository,
     MemberRepository,
 )
+from arbeitszeit.use_cases.send_accountant_registration_token.accountant_invitation_presenter import (
+    AccountantInvitationPresenter,
+)
+from tests.accountant_invitation_presenter import AccountantInvitationPresenterTestImpl
 from tests.company import CompanyManager
 from tests.email import FakeEmailSender
 from tests.session import FakeSession
@@ -41,3 +45,16 @@ class TestingModule(Module):
         self, datetime_service: DatetimeService
     ) -> FakeTokenService:
         return FakeTokenService(datetime_service=datetime_service)
+
+    @provider
+    def provide_accountant_invitation_presenter(
+        self, presenter: AccountantInvitationPresenterTestImpl
+    ) -> AccountantInvitationPresenter:
+        return presenter
+
+    @singleton
+    @provider
+    def provide_accountant_invitation_presenter_test_impl(
+        self,
+    ) -> AccountantInvitationPresenterTestImpl:
+        return AccountantInvitationPresenterTestImpl()

--- a/tests/flask_integration/test_signup_accountant_view.py
+++ b/tests/flask_integration/test_signup_accountant_view.py
@@ -1,0 +1,30 @@
+from arbeitszeit.use_cases.send_accountant_registration_token import (
+    SendAccountantRegistrationTokenUseCase,
+)
+from tests.accountant_invitation_presenter import AccountantInvitationPresenterTestImpl
+
+from .flask import ViewTestCase
+
+
+class ViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.send_token_use_case = self.injector.get(
+            SendAccountantRegistrationTokenUseCase
+        )
+        self.accountant_invitation_presenter = self.injector.get(
+            AccountantInvitationPresenterTestImpl
+        )
+
+    def test_get_proper_200_response_with_valid_token(self) -> None:
+        token = self.invite_accountant("test@test.test")
+        response = self.client.get(f"/accountant/signup/{token}")
+        self.assertEqual(response.status_code, 200)
+
+    def invite_accountant(self, email: str) -> str:
+        self.send_token_use_case.send_accountant_registration_token(
+            request=SendAccountantRegistrationTokenUseCase.Request(
+                email=email,
+            )
+        )
+        return self.accountant_invitation_presenter.invitations[-1].token


### PR DESCRIPTION
This PR implements the basis of a web view for the register accountant view. It does not work currently since there is no proper controller and presenter in place to handle requests. This is planned for a future PR though. I tried to keep this PR really small to reduce the review burden.

I'd argue that it is safe to merge this PR since the view does currently not do anything. The next PR will implement the presenter and controller to handle proper registration requests.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c