### PR TITLE
Changes to cooperation creation and request

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -36,6 +36,7 @@ from arbeitszeit_flask.database import (
 )
 from arbeitszeit_flask.forms import (
     CompanySearchForm,
+    CreateCooperationForm,
     CreateDraftForm,
     InviteWorkerToCompanyForm,
     PayMeansOfProductionForm,
@@ -54,11 +55,11 @@ from arbeitszeit_flask.views import (
     ReadMessageView,
     RequestCooperationView,
 )
+from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.create_draft_view import CreateDraftView
 from arbeitszeit_flask.views.pay_means_of_production import PayMeansOfProductionView
 from arbeitszeit_flask.views.show_my_accounts_view import ShowMyAccountsView
 from arbeitszeit_flask.views.transfer_to_worker_view import TransferToWorkerView
-from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
 from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
 from arbeitszeit_web.get_coop_summary import GetCoopSummarySuccessPresenter
@@ -435,24 +436,12 @@ def coop_summary(
 
 @CompanyRoute("/company/create_cooperation", methods=["GET", "POST"])
 @commit_changes
-def create_cooperation(
-    create_cooperation: use_cases.CreateCooperation,
-    presenter: CreateCooperationPresenter,
-    template_renderer: UserTemplateRenderer,
-):
+def create_cooperation(view: CreateCooperationView):
+    form = CreateCooperationForm(request.form)
     if request.method == "POST":
-        name = request.form["name"]
-        definition = request.form["definition"]
-        use_case_request = use_cases.CreateCooperationRequest(
-            UUID(current_user.id), name, definition
-        )
-        use_case_response = create_cooperation(use_case_request)
-        presenter.present(use_case_response)
-        return template_renderer.render_template(
-            "company/create_cooperation.html", context=dict()
-        )
+        return view.respond_to_post(form)
     elif request.method == "GET":
-        return template_renderer.render_template("company/create_cooperation.html")
+        return view.respond_to_get(form)
 
 
 @CompanyRoute("/company/request_cooperation", methods=["GET", "POST"])

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -196,6 +196,7 @@ from arbeitszeit_web.url_index import (
     PlanSummaryUrlIndex,
     PlotsUrlIndex,
     RenewPlanUrlIndex,
+    RequestCoopUrlIndex,
     TogglePlanAvailabilityUrlIndex,
 )
 from arbeitszeit_web.user_action import UserActionResolver, UserActionResolverImpl
@@ -242,6 +243,12 @@ class MemberModule(Module):
     def provide_message_url_index(
         self, member_index: MemberUrlIndex
     ) -> MessageUrlIndex:
+        return member_index
+
+    @provider
+    def provide_request_coop_url_index(
+        self, member_index: MemberUrlIndex
+    ) -> RequestCoopUrlIndex:
         return member_index
 
     @provider
@@ -318,6 +325,12 @@ class CompanyModule(Module):
     def provide_hide_plan_url_index(
         self, company_index: CompanyUrlIndex
     ) -> HidePlanUrlIndex:
+        return company_index
+
+    @provider
+    def provide_request_coop_url_index(
+        self, company_index: CompanyUrlIndex
+    ) -> RequestCoopUrlIndex:
         return company_index
 
     @provider
@@ -790,11 +803,16 @@ class FlaskModule(Module):
         self,
         toggle_availability_index: TogglePlanAvailabilityUrlIndex,
         end_coop_url_index: EndCoopUrlIndex,
+        request_coop_url_index: RequestCoopUrlIndex,
         trans: Translator,
         plan_summary_service: PlanSummaryServiceImpl,
     ) -> GetPlanSummaryCompanySuccessPresenter:
         return GetPlanSummaryCompanySuccessPresenter(
-            toggle_availability_index, end_coop_url_index, trans, plan_summary_service
+            toggle_availability_index,
+            end_coop_url_index,
+            request_coop_url_index,
+            trans,
+            plan_summary_service,
         )
 
     @provider

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -24,6 +24,7 @@ from arbeitszeit.use_cases import (
     GetCompanySummary,
     ReadMessage,
 )
+from arbeitszeit.use_cases.create_cooperation import CreateCooperation
 from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraft
 from arbeitszeit.use_cases.get_draft_summary import GetDraftSummary
 from arbeitszeit.use_cases.get_plan_summary_company import GetPlanSummaryCompany
@@ -90,6 +91,7 @@ from arbeitszeit_flask.url_index import (
     MemberUrlIndex,
 )
 from arbeitszeit_flask.views import EndCooperationView, Http404View, ReadMessageView
+from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.create_draft_view import CreateDraftView
 from arbeitszeit_flask.views.pay_means_of_production import PayMeansOfProductionView
 from arbeitszeit_flask.views.transfer_to_worker_view import TransferToWorkerView
@@ -118,6 +120,7 @@ from arbeitszeit_web.controllers.show_company_work_invite_details_controller imp
 from arbeitszeit_web.controllers.show_my_accounts_controller import (
     ShowMyAccountsController,
 )
+from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
 from arbeitszeit_web.email import EmailConfiguration, UserAddressBook
 from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
@@ -348,6 +351,18 @@ class CompanyModule(Module):
     @provider
     def provide_template_index(self) -> TemplateIndex:
         return CompanyTemplateIndex()
+
+    @provider
+    def provide_create_cooperation_view(
+        self,
+        create_cooperation: CreateCooperation,
+        presenter: CreateCooperationPresenter,
+        template_renderer: UserTemplateRenderer,
+        session: FlaskSession,
+    ) -> CreateCooperationView:
+        return CreateCooperationView(
+            create_cooperation, presenter, template_renderer, session
+        )
 
     @provider
     def provide_end_cooperation_view(

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -24,7 +24,6 @@ from arbeitszeit.use_cases import (
     GetCompanySummary,
     ReadMessage,
 )
-from arbeitszeit.use_cases.create_cooperation import CreateCooperation
 from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraft
 from arbeitszeit.use_cases.get_draft_summary import GetDraftSummary
 from arbeitszeit.use_cases.get_plan_summary_company import GetPlanSummaryCompany
@@ -91,7 +90,6 @@ from arbeitszeit_flask.url_index import (
     MemberUrlIndex,
 )
 from arbeitszeit_flask.views import EndCooperationView, Http404View, ReadMessageView
-from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.create_draft_view import CreateDraftView
 from arbeitszeit_flask.views.pay_means_of_production import PayMeansOfProductionView
 from arbeitszeit_flask.views.transfer_to_worker_view import TransferToWorkerView
@@ -120,7 +118,6 @@ from arbeitszeit_web.controllers.show_company_work_invite_details_controller imp
 from arbeitszeit_web.controllers.show_my_accounts_controller import (
     ShowMyAccountsController,
 )
-from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
 from arbeitszeit_web.email import EmailConfiguration, UserAddressBook
 from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
@@ -351,18 +348,6 @@ class CompanyModule(Module):
     @provider
     def provide_template_index(self) -> TemplateIndex:
         return CompanyTemplateIndex()
-
-    @provider
-    def provide_create_cooperation_view(
-        self,
-        create_cooperation: CreateCooperation,
-        presenter: CreateCooperationPresenter,
-        template_renderer: UserTemplateRenderer,
-        session: FlaskSession,
-    ) -> CreateCooperationView:
-        return CreateCooperationView(
-            create_cooperation, presenter, template_renderer, session
-        )
 
     @provider
     def provide_end_cooperation_view(

--- a/arbeitszeit_flask/dependency_injection/views.py
+++ b/arbeitszeit_flask/dependency_injection/views.py
@@ -6,13 +6,18 @@ from arbeitszeit.use_cases import (
     ReadMessage,
     ShowCompanyWorkInviteDetailsUseCase,
 )
+from arbeitszeit.use_cases.create_cooperation import CreateCooperation
 from arbeitszeit.use_cases.list_workers import ListWorkers
 from arbeitszeit.use_cases.register_company import RegisterCompany
 from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
 from arbeitszeit.use_cases.show_my_accounts import ShowMyAccounts
 from arbeitszeit_flask.database.repositories import MemberRepository
 from arbeitszeit_flask.flask_session import FlaskSession
-from arbeitszeit_flask.template import TemplateIndex, TemplateRenderer
+from arbeitszeit_flask.template import (
+    TemplateIndex,
+    TemplateRenderer,
+    UserTemplateRenderer,
+)
 from arbeitszeit_flask.views import (
     CompanyWorkInviteView,
     Http404View,
@@ -22,6 +27,7 @@ from arbeitszeit_flask.views import (
 from arbeitszeit_flask.views.accountant_invitation_email_view import (
     AccountantInvitationEmailViewImpl,
 )
+from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.invite_worker_to_company import (
     InviteWorkerGetRequestHandler,
     InviteWorkerPostRequestHandler,
@@ -40,6 +46,7 @@ from arbeitszeit_web.controllers.show_company_work_invite_details_controller imp
 from arbeitszeit_web.controllers.show_my_accounts_controller import (
     ShowMyAccountsController,
 )
+from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
 from arbeitszeit_web.email import MailService
 from arbeitszeit_web.invite_worker_to_company import (
     InviteWorkerToCompanyController,
@@ -213,4 +220,16 @@ class ViewsModule(Module):
         return AccountantInvitationEmailViewImpl(
             mail_service=mail_service,
             template_renderer=template_renderer,
+        )
+
+    @provider
+    def provide_create_cooperation_view(
+        self,
+        create_cooperation: CreateCooperation,
+        presenter: CreateCooperationPresenter,
+        template_renderer: UserTemplateRenderer,
+        session: FlaskSession,
+    ) -> CreateCooperationView:
+        return CreateCooperationView(
+            create_cooperation, presenter, template_renderer, session
         )

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -5,6 +5,7 @@ from wtforms import (
     PasswordField,
     SelectField,
     StringField,
+    TextAreaField,
     validators,
 )
 
@@ -195,6 +196,23 @@ class InviteWorkerToCompanyForm(Form):
 
     def get_worker_id(self) -> str:
         return self.data["member_id"]
+
+
+class CreateCooperationForm(Form):
+    name = StringField(
+        render_kw={"placeholder": trans.lazy_gettext("Name")},
+        validators=[validators.InputRequired()],
+    )
+    definition = TextAreaField(
+        render_kw={"placeholder": trans.lazy_gettext("Definition")},
+        validators=[validators.InputRequired()],
+    )
+
+    def get_name_string(self) -> str:
+        return self.data["name"]
+
+    def get_definition_string(self) -> str:
+        return self.data["definition"]
 
 
 class RequestCooperationForm(Form):

--- a/arbeitszeit_flask/templates/company/create_cooperation.html
+++ b/arbeitszeit_flask/templates/company/create_cooperation.html
@@ -1,6 +1,7 @@
 {% extends "base_company.html" %}
 
 {% block navbar_start %}
+<a class="navbar-item" href="{{ url_for('main_company.my_cooperations') }}">{{ gettext("My cooperations") }}</a>
 <div class="navbar-item">{{ gettext("Create Cooperation") }}</div>
 {% endblock %}
 
@@ -16,7 +17,9 @@
                 <p>
                     {{ gettext("Here you can create a new cooperation.") }}
                     <br><br>
-                    {{ gettext("A cooperation contains similar products.  The prices for all products in a cooperation are averaged to reduce price competition.  All producers still receive the credits on sale corresponding to how they planned production. This means that producers receive the same amount of credit to their account whether they are part of a cooperation or not.") }}
+                    <!-- beautify ignore:start -->
+                    {{ gettext("A cooperation contains similar products.  The prices for all products in a cooperation are averaged to reduce price competition.  All producers still receive the credits on sale corresponding to how they planned production.") }}
+                    <!-- beautify ignore:end -->
                 </p>
             </div>
             <div class="content">
@@ -25,7 +28,7 @@
                     <div class="field">
                         <label class="label">{{ gettext("Cooperation name") }}</label>
                         <div class="control">
-                            <input class="input is-large" , type="text" , placeholder="Name" , name="name" required>
+                            {{ form.name(class_="input is-large") }}
                         </div>
                     </div>
                     <div class="block"></div>
@@ -33,7 +36,7 @@
                     <div class="field">
                         <label class="label">{{ gettext("Definition of the cooperation") }}</label>
                         <div class="control">
-                            <textarea class="textarea is-large" , name="definition" required></textarea>
+                            {{ form.definition(class_="textarea is-large") }}
                         </div>
                     </div>
                     <div class="block"></div>

--- a/arbeitszeit_flask/templates/company/dashboard.html
+++ b/arbeitszeit_flask/templates/company/dashboard.html
@@ -62,13 +62,6 @@
                     <div class="subtitle"></div>
                 </div>
             </a>
-            <a class="tile is-parent" href="{{ url_for('main_company.request_cooperation') }}">
-                <div class="tile is-child box has-background-danger-light">
-                    <h1 class="title is-5"><span class="icon"><i class="fas fa-hands-helping"></i></span> {{
-                        gettext("Join cooperation") }}</h1>
-                    <div class="subtitle"></div>
-                </div>
-            </a>
             <a class="tile is-parent" href="{{ url_for('main_company.invite_worker_to_company') }}">
                 <div class="tile is-child box has-background-danger-light">
                     <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-users"></i></span> {{
@@ -76,6 +69,7 @@
                     <div class="subtitle"></div>
                 </div>
             </a>
+            <div class="tile is-parent"></div>
         </div>
         <div class="has-text-centered py-5">
             <h1 class="title is-3">{{ gettext("Company accounting") }}</h1>

--- a/arbeitszeit_flask/templates/company/dashboard.html
+++ b/arbeitszeit_flask/templates/company/dashboard.html
@@ -29,7 +29,7 @@
             <div class="column"></div>
         </div>
         <div class="has-text-centered py-5">
-            <h1 class="title is-3">{{ gettext("Actions") }}</h1>
+            <h1 class="title is-3">{{ gettext("Frequent actions") }}</h1>
         </div>
         <div class="tile is-ancestor">
             <a class="tile is-parent" href="{{ url_for('main_company.create_draft') }}">
@@ -53,23 +53,6 @@
                     <div class="subtitle"></div>
                 </div>
             </a>
-        </div>
-        <div class="tile is-ancestor">
-            <a class="tile is-parent" href="{{ url_for('main_company.create_cooperation') }}">
-                <div class="tile is-child box has-background-danger-light">
-                    <h1 class="title is-5"><span class="icon"><i class="fas fa-hands-helping"></i></span> {{
-                        gettext("Create Cooperation") }}</h1>
-                    <div class="subtitle"></div>
-                </div>
-            </a>
-            <a class="tile is-parent" href="{{ url_for('main_company.invite_worker_to_company') }}">
-                <div class="tile is-child box has-background-danger-light">
-                    <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-users"></i></span> {{
-                        gettext("Invite workers") }}</h1>
-                    <div class="subtitle"></div>
-                </div>
-            </a>
-            <div class="tile is-parent"></div>
         </div>
         <div class="has-text-centered py-5">
             <h1 class="title is-3">{{ gettext("Company accounting") }}</h1>
@@ -110,7 +93,7 @@
                     <h1 class="title is-5"><span class="icon"><i class="fas fa-hands-helping"></i></span> {{
                         gettext("Cooperations") }}
                     </h1>
-                    <div class="subtitle is-6">{{("Cooperations you are coordinating")}}</div>
+                    <div class="subtitle is-6">{{("Your cooperations")}}</div>
                 </div>
             </a>
             <a class="tile is-parent" href="{{ url_for('main_company.my_purchases') }}">
@@ -123,6 +106,13 @@
             </a>
         </div>
         <div class="tile is-ancestor">
+            <a class="tile is-parent" href="{{ url_for('main_company.invite_worker_to_company') }}">
+                <div class="tile is-child box has-background-primary-light">
+                    <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-users"></i></span> {{
+                        gettext("Workers") }}</h1>
+                    <div class="subtitle is-6">{{ gettext("Members of your collective") }}</div>
+                </div>
+            </a>
             <a class="tile is-parent" href="{{ url_for('main_company.list_messages') }}">
                 <div class="tile is-child box has-background-primary-light">
                     <h1
@@ -131,23 +121,22 @@
                         {{ gettext("Messages") }}
                     </h1>
                     <div class="subtitle is-6">{% if message_indicator is defined %}{% if
-                        message_indicator.show_unread_messages_indicator %}{{ gettext("You received a new message") }}{%
+                        message_indicator.show_unread_messages_indicator %}{{ gettext("You have new messages") }}{%
                         else %}{{ gettext("No new messages") }}{% endif %}{%
                         endif %}
                     </div>
                 </div>
             </a>
             <div class="tile is-parent"></div>
-            <div class="tile is-parent"></div>
         </div>
         <div class="has-text-centered py-5">
-            <h1 class="title is-3">{{ gettext("Social accounting") }}</h1>
+            <h1 class="title is-3">{{ gettext("Public accounting") }}</h1>
         </div>
         <div class="tile is-ancestor">
             <a class="tile is-parent" href="{{ url_for('main_company.statistics') }}">
                 <div class="tile is-child box has-background-warning-light">
                     <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-chart-pie"></i></span> {{
-                        gettext("Statistics") }}
+                        gettext("Global statistics") }}
                     </h1>
                     <div class="subtitle"></div>
                 </div>

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -6,11 +6,25 @@
 
 {% block company %}
 <div class="section has-text-centered">
-    <div class="content">
-        <h1 class="title">
-            {{ gettext("Cooperations that I coordinate") }}
-        </h1>
+    <h1 class="title">
+        {{ gettext("My cooperations") }}
+    </h1>
+
+    <div class="tile is-ancestor">
+        <div class="tile is-parent"></div>
+        <a class="tile is-parent" href="{{ url_for('main_company.create_cooperation') }}">
+            <div class="tile is-child box has-background-primary-light">
+                <h1 class="title is-5"><span class="icon"><i class="fas fa-hands-helping"></i></span>
+                    {{ gettext("Create cooperation ") }}</h1>
+                <div class="subtitle"></div>
+            </div>
+        </a>
+        <div class="tile is-parent"></div>
     </div>
+
+    <h1 class="title is-4">
+        {{ gettext("Cooperations that I coordinate") }}
+    </h1>
     {% if accept_message or deny_message or cancel_message %}
     <div class="block"></div>
     {% for message in accept_message %}
@@ -55,7 +69,7 @@
         {% endif %}
     </div>
     <div class="content">
-        <h1 class="title">
+        <h1 class="title is-4">
             {{ gettext("Incoming cooperation request (by others)") }}
         </h1>
     </div>
@@ -112,7 +126,7 @@
     </div>
 
     <div class="content">
-        <h1 class="title">
+        <h1 class="title is-4">
             {{ gettext("Outgoing cooperation requests (own requests)") }}
         </h1>
     </div>

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -24,6 +24,11 @@
     <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
         <span>{{ gettext("End") }}</span>
     </a>
+    {% else %}
+    <div>{{ gettext("Join cooperation:") }}</div>
+    <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
+        <span>{{ gettext("Join") }}</span>
+    </a>
     {% endif %}
     {% endif %}
 </div>

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -11,25 +11,41 @@
 
 <div class="section has-text-centered pt-0">
     {% if view_model.show_action_section %}
-
-    <div>{{ gettext("Change availability:") }}</div>
-    <div>
-        <span class="{{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}"><a
-                style="text-decoration: none; color: inherit;" href="{{ view_model.action.toggle_availability_url }}"><i
-                    class="{{ 'fas fa-toggle-on' if view_model.action.is_available else 'fas fa-toggle-off' }}"></i></a></span>
+    <div class="content">
+        <h1 class="title">
+            {{ gettext("Actions") }}
+        </h1>
     </div>
 
-    {% if view_model.action.is_cooperating %}
-    <div>{{ gettext("End cooperation:") }}</div>
-    <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
-        <span>{{ gettext("End") }}</span>
-    </a>
-    {% else %}
-    <div>{{ gettext("Join cooperation:") }}</div>
-    <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
-        <span>{{ gettext("Join") }}</span>
-    </a>
-    {% endif %}
+    <div class="tile is-ancestor">
+        <div class="tile is-parent">
+            <div class="tile is-child box has-background-danger-light">
+                <h1 class="title is-5">{{ gettext("Change availability:") }}</h1>
+                <div
+                    class="icon is-large {{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}">
+                    <a style="text-decoration: none; color: inherit;"
+                        href="{{ view_model.action.toggle_availability_url }}"><i
+                            class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available else 'fas fa-lg fa-toggle-off' }}"></i></a>
+                </div>
+            </div>
+        </div>
+        <div class="tile is-parent" href="">
+            <div class="tile is-child box has-background-danger-light">
+                {% if view_model.action.is_cooperating %}
+                <h1 class="title is-5">{{ gettext("End cooperation:") }}</h1>
+                <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
+                    <span>{{ gettext("End") }}</span>
+                </a>
+                {% else %}
+                <h1 class="title is-5">{{ gettext("Join a cooperation") }} </h1>
+                <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
+                    <span>{{ gettext("Join") }}</span>
+                </a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
     {% endif %}
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
+++ b/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
@@ -484,7 +484,7 @@ msgstr "Keine Nachrichten erhalten."
 
 #: arbeitszeit_flask/templates/macros/plan_summary.html:7
 msgid "Plan information"
-msgstr "Planungsinformationen"
+msgstr "Planinformationen"
 
 #: arbeitszeit_flask/templates/macros/statistics.html:6
 msgid "Global statistics"

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -28,6 +28,9 @@ class MemberUrlIndex:
     def get_hide_plan_url(self, plan_id: UUID) -> str:
         ...
 
+    def get_request_coop_url(self) -> str:
+        ...
+
     def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         ...
 
@@ -67,6 +70,9 @@ class CompanyUrlIndex:
 
     def get_hide_plan_url(self, plan_id: UUID) -> str:
         return url_for("main_company.hide_plan", plan_id=plan_id)
+
+    def get_request_coop_url(self) -> str:
+        return url_for("main_company.request_cooperation")
 
     def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         return url_for(

--- a/arbeitszeit_flask/views/create_cooperation_view.py
+++ b/arbeitszeit_flask/views/create_cooperation_view.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+
+from flask import Response as FlaskResponse
+from flask import redirect, url_for
+
+from arbeitszeit.use_cases.create_cooperation import (
+    CreateCooperation,
+    CreateCooperationRequest,
+)
+from arbeitszeit_flask.flask_session import FlaskSession
+from arbeitszeit_flask.forms import CreateCooperationForm
+from arbeitszeit_flask.template import UserTemplateRenderer
+from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
+
+
+@dataclass
+class CreateCooperationView:
+    create_cooperation: CreateCooperation
+    presenter: CreateCooperationPresenter
+    template_renderer: UserTemplateRenderer
+    session: FlaskSession
+
+    def respond_to_get(self, form: CreateCooperationForm):
+        return FlaskResponse(self._render_template(form), status=200)
+
+    def respond_to_post(self, form: CreateCooperationForm):
+        name = form.get_name_string()
+        definition = form.get_definition_string()
+        user = self.session.get_current_user()
+        assert name
+        assert definition
+        assert user
+        use_case_request = CreateCooperationRequest(user, name, definition)
+        use_case_response = self.create_cooperation(use_case_request)
+        self.presenter.present(use_case_response)
+        if use_case_response.is_rejected:
+            return FlaskResponse(self._render_template(form), status=400)
+        return redirect(url_for("main_company.my_cooperations"))
+
+    def _render_template(self, form: CreateCooperationForm) -> str:
+        return self.template_renderer.render_template(
+            "company/create_cooperation.html", context=dict(form=form)
+        )

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -5,7 +5,11 @@ from arbeitszeit.use_cases.get_plan_summary_company import PlanSummaryCompanySuc
 
 from .plan_summary_service import PlanSummary, PlanSummaryService
 from .translator import Translator
-from .url_index import EndCoopUrlIndex, TogglePlanAvailabilityUrlIndex
+from .url_index import (
+    EndCoopUrlIndex,
+    RequestCoopUrlIndex,
+    TogglePlanAvailabilityUrlIndex,
+)
 
 
 @dataclass
@@ -14,6 +18,7 @@ class Action:
     toggle_availability_url: str
     is_cooperating: bool
     end_coop_url: Optional[str]
+    request_coop_url: Optional[str]
 
 
 @dataclass
@@ -30,25 +35,31 @@ class GetPlanSummaryCompanyViewModel:
 class GetPlanSummaryCompanySuccessPresenter:
     toggle_availability_url_index: TogglePlanAvailabilityUrlIndex
     end_coop_url_index: EndCoopUrlIndex
+    request_coop_url_index: RequestCoopUrlIndex
     trans: Translator
     plan_summary_service: PlanSummaryService
 
     def present(
         self, response: PlanSummaryCompanySuccess
     ) -> GetPlanSummaryCompanyViewModel:
+        plan_id = response.plan_summary.plan_id
+        coop_id = response.plan_summary.cooperation
+        is_available = response.plan_summary.is_available
+        is_cooperating = response.plan_summary.is_cooperating
         return GetPlanSummaryCompanyViewModel(
             summary=self.plan_summary_service.get_plan_summary(response.plan_summary),
             show_action_section=response.current_user_is_planner,
             action=Action(
-                is_available=response.plan_summary.is_available,
+                is_available=is_available,
                 toggle_availability_url=self.toggle_availability_url_index.get_toggle_availability_url(
-                    response.plan_summary.plan_id
+                    plan_id
                 ),
-                is_cooperating=response.plan_summary.is_cooperating,
-                end_coop_url=self.end_coop_url_index.get_end_coop_url(
-                    response.plan_summary.plan_id, response.plan_summary.cooperation
-                )
-                if response.plan_summary.cooperation
+                is_cooperating=is_cooperating,
+                end_coop_url=self.end_coop_url_index.get_end_coop_url(plan_id, coop_id)
+                if coop_id
+                else None,
+                request_coop_url=self.request_coop_url_index.get_request_coop_url()
+                if not is_cooperating
                 else None,
             ),
         )

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -37,9 +37,7 @@ class GetPlanSummaryCompanySuccessPresenter:
         self, response: PlanSummaryCompanySuccess
     ) -> GetPlanSummaryCompanyViewModel:
         return GetPlanSummaryCompanyViewModel(
-            summary=self.plan_summary_service.get_plan_summary_member(
-                response.plan_summary
-            ),
+            summary=self.plan_summary_service.get_plan_summary(response.plan_summary),
             show_action_section=response.current_user_is_planner,
             action=Action(
                 is_available=response.plan_summary.is_available,

--- a/arbeitszeit_web/get_plan_summary_member.py
+++ b/arbeitszeit_web/get_plan_summary_member.py
@@ -22,7 +22,5 @@ class GetPlanSummarySuccessPresenter:
 
     def present(self, response: PlanSummarySuccess) -> GetPlanSummaryViewModel:
         return GetPlanSummaryViewModel(
-            summary=self.plan_summary_service.get_plan_summary_member(
-                response.plan_summary
-            )
+            summary=self.plan_summary_service.get_plan_summary(response.plan_summary)
         )

--- a/arbeitszeit_web/plan_summary_service.py
+++ b/arbeitszeit_web/plan_summary_service.py
@@ -27,7 +27,7 @@ class PlanSummary:
 
 
 class PlanSummaryService(Protocol):
-    def get_plan_summary_member(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
+    def get_plan_summary(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
         ...
 
 
@@ -37,7 +37,7 @@ class PlanSummaryServiceImpl:
     company_url_index: CompanySummaryUrlIndex
     translator: Translator
 
-    def get_plan_summary_member(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
+    def get_plan_summary(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
         return PlanSummary(
             plan_id=(self.translator.gettext("Plan ID"), str(plan_summary.plan_id)),
             is_active=(

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -43,6 +43,11 @@ class HidePlanUrlIndex(Protocol):
         ...
 
 
+class RequestCoopUrlIndex(Protocol):
+    def get_request_coop_url(self) -> str:
+        ...
+
+
 class EndCoopUrlIndex(Protocol):
     def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         ...

--- a/tests/flask_integration/test_create_cooperation_view.py
+++ b/tests/flask_integration/test_create_cooperation_view.py
@@ -1,0 +1,34 @@
+from tests.data_generators import CooperationGenerator
+from tests.flask_integration.flask import ViewTestCase
+
+
+class AuthenticatedCompanyTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company, _, self.email = self.login_company()
+        self.company = self.confirm_company(company=self.company, email=self.email)
+        self.url = "/company/create_cooperation"
+        self.cooperation_generator = self.injector.get(CooperationGenerator)
+
+    def test_get_200(
+        self,
+    ) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_returns_302_when_posting_data(self) -> None:
+        response = self.client.post(
+            self.url, data={"name": "New Cooperation", "definition": "Coop definition"}
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_returns_400_when_posting_already_existing_coop_name(self) -> None:
+        exiting_coop = self.cooperation_generator.create_cooperation()
+        response = self.client.post(
+            self.url,
+            data={
+                "name": exiting_coop.name.title(),
+                "definition": "Coop definition",
+            },
+        )
+        self.assertEqual(response.status_code, 400)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -70,6 +70,13 @@ class CompanyUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
+    def test_request_coop_url_leads_to_functional_url(
+        self,
+    ) -> None:
+        url = self.url_index.get_request_coop_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_end_coop_url_for_existing_plan_and_cooperation_leads_to_functional_url(
         self,
     ) -> None:

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -83,6 +83,7 @@ from .url_index import (
     PlanSummaryUrlIndexTestImpl,
     PlotsUrlIndexImpl,
     RenewPlanUrlIndex,
+    RequestCoopUrlIndexTestImpl,
     TogglePlanAvailabilityUrlIndex,
 )
 from .user_action_resolver import UserActionResolver
@@ -222,12 +223,14 @@ class PresenterTestsInjector(Module):
         self,
         toggle_availability_url_index: TogglePlanAvailabilityUrlIndex,
         end_coop_url_index: EndCoopUrlIndexTestImpl,
+        request_coop_url_index: RequestCoopUrlIndexTestImpl,
         translator: FakeTranslator,
         plan_summary_service: PlanSummaryService,
     ) -> GetPlanSummaryCompanySuccessPresenter:
         return GetPlanSummaryCompanySuccessPresenter(
             toggle_availability_url_index=toggle_availability_url_index,
             end_coop_url_index=end_coop_url_index,
+            request_coop_url_index=request_coop_url_index,
             trans=translator,
             plan_summary_service=plan_summary_service,
         )

--- a/tests/presenters/test_plan_summary_service.py
+++ b/tests/presenters/test_plan_summary_service.py
@@ -40,14 +40,14 @@ class PlanSummaryServiceTests(TestCase):
         self.service = self.injector.get(PlanSummaryServiceImpl)
 
     def test_plan_id_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.plan_id,
             (self.translator.gettext("Plan ID"), str(BUSINESS_PLAN_SUMMARY.plan_id)),
         )
 
     def test_active_status_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.is_active,
             (self.translator.gettext("Status"), self.translator.gettext("Active")),
@@ -58,7 +58,7 @@ class PlanSummaryServiceTests(TestCase):
             BUSINESS_PLAN_SUMMARY,
             is_active=False,
         )
-        plan_summary = self.service.get_plan_summary_member(response)
+        plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
             plan_summary.is_active,
             (self.translator.gettext("Status"), self.translator.gettext("Inactive")),
@@ -70,7 +70,7 @@ class PlanSummaryServiceTests(TestCase):
             BUSINESS_PLAN_SUMMARY,
             planner_id=expected_planner_id,
         )
-        plan_summary = self.service.get_plan_summary_member(response)
+        plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
             plan_summary.planner,
             (
@@ -82,7 +82,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_product_name_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.product_name,
             (
@@ -94,7 +94,7 @@ class PlanSummaryServiceTests(TestCase):
     def test_description_is_displayed_correctly_as_tuple_of_string_and_list_of_string(
         self,
     ):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.description,
             (
@@ -110,7 +110,7 @@ class PlanSummaryServiceTests(TestCase):
             BUSINESS_PLAN_SUMMARY,
             description="first paragraph\rsecond paragraph",
         )
-        plan_summary = self.service.get_plan_summary_member(response)
+        plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
             plan_summary.description,
             (
@@ -120,7 +120,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_timeframe_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.timeframe,
             (
@@ -130,7 +130,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_production_unit_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.production_unit,
             (
@@ -140,14 +140,14 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_amount_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.amount,
             (self.translator.gettext("Amount"), str(BUSINESS_PLAN_SUMMARY.amount)),
         )
 
     def test_means_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.means_cost,
             (
@@ -157,7 +157,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_resources_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.resources_cost,
             (
@@ -167,7 +167,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_labour_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.labour_cost,
             (
@@ -183,7 +183,7 @@ class PlanSummaryServiceTests(TestCase):
             BUSINESS_PLAN_SUMMARY,
             is_public_service=False,
         )
-        plan_summary = self.service.get_plan_summary_member(response)
+        plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
             plan_summary.type_of_plan,
             (
@@ -199,7 +199,7 @@ class PlanSummaryServiceTests(TestCase):
             BUSINESS_PLAN_SUMMARY,
             is_public_service=True,
         )
-        plan_summary = self.service.get_plan_summary_member(response)
+        plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
             plan_summary.type_of_plan,
             (
@@ -209,7 +209,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_price_per_unit_is_displayed_correctly_as_tuple_of_strings_and_bool(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         coop_id = BUSINESS_PLAN_SUMMARY.cooperation
         assert coop_id
         self.assertTupleEqual(
@@ -223,7 +223,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_availability_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary_member(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.is_available,
             (

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -17,6 +17,11 @@ class CoopSummaryUrlIndexTestImpl:
         return f"fake_coop_url:{coop_id}"
 
 
+class RequestCoopUrlIndexTestImpl:
+    def get_request_coop_url(self) -> str:
+        return "fake_request_coop_url"
+
+
 class EndCoopUrlIndexTestImpl:
     def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         return f"fake_end_coop_url:{plan_id}, {cooperation_id}"


### PR DESCRIPTION
This PR aims for a (hopefully) more intuitive cooperation interface. 

- Requesting a cooperation is now found in "plan summary" page
- Creating a cooperation is now found in "my cooperations" 
- It introduces a tile layout for the plan summary action section

It also reduces items on the dashboard, making it less overwhelming and hiding away "advanced" functions.

- Delete request cooperation from dashboard
- Delete create cooperation from dashboard

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c

P.S.: I deleted a user facing sentence in create_cooperation.html, which seemed to me an unnecessary detail for the normal user. I can change it again.