### PR TITLE
Reworking plan summary page

### DIFF
--- a/arbeitszeit/plan_summary.py
+++ b/arbeitszeit/plan_summary.py
@@ -3,9 +3,15 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
+from injector import inject
+
+from arbeitszeit.entities import Plan
+from arbeitszeit.price_calculator import calculate_price
+from arbeitszeit.repositories import PlanCooperationRepository
+
 
 @dataclass
-class BusinessPlanSummary:
+class PlanSummary:
     plan_id: UUID
     is_active: bool
     planner_id: UUID
@@ -24,3 +30,34 @@ class BusinessPlanSummary:
     is_available: bool
     is_cooperating: bool
     cooperation: Optional[UUID]
+
+
+@inject
+@dataclass
+class PlanSummaryService:
+    plan_cooperation_repository: PlanCooperationRepository
+
+    def get_summary_from_plan(self, plan: Plan) -> PlanSummary:
+        price_per_unit = calculate_price(
+            self.plan_cooperation_repository.get_cooperating_plans(plan.id)
+        )
+        return PlanSummary(
+            plan_id=plan.id,
+            is_active=plan.is_active,
+            planner_id=plan.planner.id,
+            planner_name=plan.planner.name,
+            product_name=plan.prd_name,
+            description=plan.description,
+            timeframe=plan.timeframe,
+            active_days=plan.active_days or 0,
+            production_unit=plan.prd_unit,
+            amount=plan.prd_amount,
+            means_cost=plan.production_costs.means_cost,
+            resources_cost=plan.production_costs.resource_cost,
+            labour_cost=plan.production_costs.labour_cost,
+            is_public_service=plan.is_public_service,
+            price_per_unit=price_per_unit,
+            is_available=plan.is_available,
+            is_cooperating=bool(plan.cooperation),
+            cooperation=plan.cooperation or None,
+        )

--- a/arbeitszeit/plan_summary.py
+++ b/arbeitszeit/plan_summary.py
@@ -13,6 +13,7 @@ class BusinessPlanSummary:
     product_name: str
     description: str
     timeframe: int
+    active_days: int
     production_unit: str
     amount: int
     means_cost: Decimal

--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -61,16 +61,8 @@ from .get_member_profile_info import (
     GetMemberProfileInfoResponse,
     Workplace,
 )
-from .get_plan_summary_company import (
-    GetPlanSummaryCompany,
-    PlanSummaryCompanyResponse,
-    PlanSummaryCompanySuccess,
-)
-from .get_plan_summary_member import (
-    GetPlanSummaryMember,
-    PlanSummaryResponse,
-    PlanSummarySuccess,
-)
+from .get_plan_summary_company import GetPlanSummaryCompany
+from .get_plan_summary_member import GetPlanSummaryMember
 from .get_statistics import GetStatistics, StatisticsResponse
 from .hide_plan import HidePlan, HidePlanResponse
 from .invite_worker_to_company import (
@@ -258,10 +250,6 @@ __all__ = [
     "PayMeansOfProductionRequest",
     "PlanFilter",
     "PlanQueryResponse",
-    "PlanSummaryCompanyResponse",
-    "PlanSummaryCompanySuccess",
-    "PlanSummaryResponse",
-    "PlanSummarySuccess",
     "PurchaseQueryResponse",
     "QueryCompanies",
     "QueryCompaniesRequest",

--- a/arbeitszeit/use_cases/get_plan_summary_company.py
+++ b/arbeitszeit/use_cases/get_plan_summary_company.py
@@ -1,68 +1,38 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import Union
 from uuid import UUID
 
 from injector import inject
 
-from arbeitszeit.entities import Company, Plan
-from arbeitszeit.plan_summary import BusinessPlanSummary
-from arbeitszeit.price_calculator import calculate_price
-from arbeitszeit.repositories import (
-    CompanyRepository,
-    PlanCooperationRepository,
-    PlanRepository,
-)
-
-
-@dataclass
-class PlanSummaryCompanySuccess:
-    plan_summary: BusinessPlanSummary
-    current_user_is_planner: bool
-
-
-PlanSummaryCompanyResponse = Optional[PlanSummaryCompanySuccess]
+from arbeitszeit.plan_summary import PlanSummary, PlanSummaryService
+from arbeitszeit.repositories import CompanyRepository, PlanRepository
 
 
 @inject
 @dataclass
 class GetPlanSummaryCompany:
+    @dataclass
+    class Success:
+        plan_summary: PlanSummary
+        current_user_is_planner: bool
+
+    @dataclass
+    class Failure:
+        pass
+
     plan_repository: PlanRepository
     company_repository: CompanyRepository
-    plan_cooperation_repository: PlanCooperationRepository
+    plan_summary_service: PlanSummaryService
 
-    def __call__(self, plan_id: UUID, company_id: UUID) -> PlanSummaryCompanyResponse:
+    def __call__(self, plan_id: UUID, company_id: UUID) -> Union[Success, Failure]:
         plan = self.plan_repository.get_plan_by_id(plan_id)
         company = self.company_repository.get_by_id(company_id)
         if plan is None:
-            return None
+            return self.Failure()
         assert company
-        current_user_is_planner = self.check_if_current_user_is_planner(plan, company)
-        price_per_unit = calculate_price(
-            self.plan_cooperation_repository.get_cooperating_plans(plan.id)
+        return self.Success(
+            plan_summary=self.plan_summary_service.get_summary_from_plan(plan),
+            current_user_is_planner=(plan.planner == company),
         )
-        return PlanSummaryCompanySuccess(
-            plan_summary=BusinessPlanSummary(
-                plan_id=plan.id,
-                is_active=plan.is_active,
-                planner_id=plan.planner.id,
-                planner_name=plan.planner.name,
-                product_name=plan.prd_name,
-                description=plan.description,
-                timeframe=plan.timeframe,
-                active_days=plan.active_days or 0,
-                production_unit=plan.prd_unit,
-                amount=plan.prd_amount,
-                means_cost=plan.production_costs.means_cost,
-                resources_cost=plan.production_costs.resource_cost,
-                labour_cost=plan.production_costs.labour_cost,
-                is_public_service=plan.is_public_service,
-                price_per_unit=price_per_unit,
-                is_available=plan.is_available,
-                is_cooperating=bool(plan.cooperation),
-                cooperation=plan.cooperation or None,
-            ),
-            current_user_is_planner=current_user_is_planner,
-        )
-
-    def check_if_current_user_is_planner(self, plan: Plan, company: Company) -> bool:
-        return plan.planner == company

--- a/arbeitszeit/use_cases/get_plan_summary_company.py
+++ b/arbeitszeit/use_cases/get_plan_summary_company.py
@@ -49,6 +49,7 @@ class GetPlanSummaryCompany:
                 product_name=plan.prd_name,
                 description=plan.description,
                 timeframe=plan.timeframe,
+                active_days=plan.active_days or 0,
                 production_unit=plan.prd_unit,
                 amount=plan.prd_amount,
                 means_cost=plan.production_costs.means_cost,

--- a/arbeitszeit/use_cases/get_plan_summary_member.py
+++ b/arbeitszeit/use_cases/get_plan_summary_member.py
@@ -1,54 +1,33 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import Union
 from uuid import UUID
 
 from injector import inject
 
-from arbeitszeit.plan_summary import BusinessPlanSummary
-from arbeitszeit.price_calculator import calculate_price
-from arbeitszeit.repositories import PlanCooperationRepository, PlanRepository
-
-
-@dataclass
-class PlanSummarySuccess:
-    plan_summary: BusinessPlanSummary
-
-
-PlanSummaryResponse = Optional[PlanSummarySuccess]
+from arbeitszeit.plan_summary import PlanSummary, PlanSummaryService
+from arbeitszeit.repositories import PlanRepository
 
 
 @inject
 @dataclass
 class GetPlanSummaryMember:
-    plan_repository: PlanRepository
-    plan_cooperation_repository: PlanCooperationRepository
+    @dataclass
+    class Success:
+        plan_summary: PlanSummary
 
-    def __call__(self, plan_id: UUID) -> PlanSummaryResponse:
+    @dataclass
+    class Failure:
+        pass
+
+    plan_repository: PlanRepository
+    plan_summary_service: PlanSummaryService
+
+    def __call__(self, plan_id: UUID) -> Union[Success, Failure]:
         plan = self.plan_repository.get_plan_by_id(plan_id)
         if plan is None:
-            return None
-        price_per_unit = calculate_price(
-            self.plan_cooperation_repository.get_cooperating_plans(plan.id)
-        )
-        return PlanSummarySuccess(
-            plan_summary=BusinessPlanSummary(
-                plan_id=plan.id,
-                is_active=plan.is_active,
-                planner_id=plan.planner.id,
-                planner_name=plan.planner.name,
-                product_name=plan.prd_name,
-                description=plan.description,
-                timeframe=plan.timeframe,
-                active_days=plan.active_days or 0,
-                production_unit=plan.prd_unit,
-                amount=plan.prd_amount,
-                means_cost=plan.production_costs.means_cost,
-                resources_cost=plan.production_costs.resource_cost,
-                labour_cost=plan.production_costs.labour_cost,
-                is_public_service=plan.is_public_service,
-                price_per_unit=price_per_unit,
-                is_available=plan.is_available,
-                is_cooperating=bool(plan.cooperation),
-                cooperation=plan.cooperation or None,
-            )
+            return self.Failure()
+        return self.Success(
+            plan_summary=self.plan_summary_service.get_summary_from_plan(plan)
         )

--- a/arbeitszeit/use_cases/get_plan_summary_member.py
+++ b/arbeitszeit/use_cases/get_plan_summary_member.py
@@ -39,6 +39,7 @@ class GetPlanSummaryMember:
                 product_name=plan.prd_name,
                 description=plan.description,
                 timeframe=plan.timeframe,
+                active_days=plan.active_days or 0,
                 production_unit=plan.prd_unit,
                 amount=plan.prd_amount,
                 means_cost=plan.production_costs.means_cost,

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -365,7 +365,7 @@ def plan_summary(
     http_404_view: Http404View,
 ):
     use_case_response = get_plan_summary_company(plan_id, UUID(current_user.id))
-    if isinstance(use_case_response, use_cases.PlanSummaryCompanySuccess):
+    if isinstance(use_case_response, use_cases.GetPlanSummaryCompany.Success):
         view_model = presenter.present(use_case_response)
         return template_renderer.render_template(
             "company/plan_summary.html", context=dict(view_model=view_model.to_dict())

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -183,7 +183,7 @@ def plan_summary(
     http_404_view: Http404View,
 ) -> Response:
     use_case_response = get_plan_summary_member(plan_id)
-    if isinstance(use_case_response, use_cases.PlanSummarySuccess):
+    if isinstance(use_case_response, use_cases.GetPlanSummaryMember.Success):
         view_model = presenter.present(use_case_response)
         return Response(
             template_renderer.render_template(

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -9,43 +9,47 @@
 {% from 'macros/plan_summary.html' import plan_summary %}
 {{ plan_summary(view_model) }}
 
-<div class="section has-text-centered pt-0">
+<div class="section has-text-centered">
     {% if view_model.show_action_section %}
     <div class="content">
         <h1 class="title">
             {{ gettext("Actions") }}
         </h1>
     </div>
-
-    <div class="tile is-ancestor">
-        <div class="tile is-parent">
-            <div class="tile is-child box has-background-danger-light">
-                <h1 class="title is-5">{{ gettext("Change availability:") }}</h1>
-                <div
-                    class="icon is-large {{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}">
-                    <a style="text-decoration: none; color: inherit;"
-                        href="{{ view_model.action.toggle_availability_url }}"><i
-                            class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available else 'fas fa-lg fa-toggle-off' }}"></i></a>
+    <div class="column is-offset-2 is-8">
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-vertical">
+                    <div class="tile is-parent">
+                        <div class="tile is-child box has-background-danger-light">
+                            <h1 class="title is-4">{{ gettext("Change availability:") }}</h1>
+                            <div
+                                class="icon is-large {{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}">
+                                <a style="text-decoration: none; color: inherit;"
+                                    href="{{ view_model.action.toggle_availability_url }}"><i
+                                        class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available else 'fas fa-lg fa-toggle-off' }}"></i></a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tile is-parent" href="">
+                        <div class="tile is-child box has-background-danger-light">
+                            {% if view_model.action.is_cooperating %}
+                            <h1 class="title is-4">{{ gettext("End cooperation:") }}</h1>
+                            <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
+                                <span>{{ gettext("End") }}</span>
+                            </a>
+                            {% else %}
+                            <h1 class="title is-4">{{ gettext("Join a cooperation") }} </h1>
+                            <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
+                                <span>{{ gettext("Join") }}</span>
+                            </a>
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="tile is-parent" href="">
-            <div class="tile is-child box has-background-danger-light">
-                {% if view_model.action.is_cooperating %}
-                <h1 class="title is-5">{{ gettext("End cooperation:") }}</h1>
-                <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
-                    <span>{{ gettext("End") }}</span>
-                </a>
-                {% else %}
-                <h1 class="title is-5">{{ gettext("Join a cooperation") }} </h1>
-                <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
-                    <span>{{ gettext("Join") }}</span>
-                </a>
-                {% endif %}
-            </div>
-        </div>
     </div>
-
     {% endif %}
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -24,10 +24,10 @@
                         <div class="tile is-child box has-background-danger-light">
                             <h1 class="title is-4">{{ gettext("Change availability:") }}</h1>
                             <div
-                                class="icon is-large {{ 'has-text-success' if view_model.action.is_available else 'has-text-danger' }}">
+                                class="icon is-large {{ 'has-text-success' if view_model.action.is_available_bool else 'has-text-danger' }}">
                                 <a style="text-decoration: none; color: inherit;"
                                     href="{{ view_model.action.toggle_availability_url }}"><i
-                                        class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available else 'fas fa-lg fa-toggle-off' }}"></i></a>
+                                        class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available_bool else 'fas fa-lg fa-toggle-off' }}"></i></a>
                             </div>
                         </div>
                     </div>

--- a/arbeitszeit_flask/templates/macros/plan_summary.html
+++ b/arbeitszeit_flask/templates/macros/plan_summary.html
@@ -13,18 +13,18 @@
                         <div class="tile is-parent is-vertical">
                             <article class="tile is-child notification">
                                 <p class="title is-4">{{ view_model.summary.plan_id[0] }}</p>
-                                <p class="">{{ view_model.summary.plan_id[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.plan_id[1] }}</p>
                             </article>
                             <article class="tile is-child notification">
                                 <p class="title is-4">{{ view_model.summary.planner[0] }}</p>
-                                <p class=""><a href="{{ view_model.summary.planner[2] }}">{{
+                                <p class="subtitle"><a href="{{ view_model.summary.planner[2] }}">{{
                                         view_model.summary.planner[3] }}</a></p>
                             </article>
                         </div>
                         <div class="tile is-parent is-vertical">
                             <article class="tile is-child notification">
                                 <p class="title is-4">{{ view_model.summary.product_name[0] }}</p>
-                                <p class="">{{ view_model.summary.product_name[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.product_name[1] }}</p>
                             </article>
                             <article class="tile is-child notification"></article>
                         </div>
@@ -49,16 +49,18 @@
                 <div class="tile is-4">
                     <div class="tile is-parent">
                         <article class="tile is-child notification has-background-warning-light">
-                            <p class="title is-4">{{ view_model.summary.is_active[0] }}</p>
-                            <p class="">{{ view_model.summary.is_active[1] }}</p>
+                            <p class="title is-4">{{ view_model.summary.activity_string[0] }}</p>
+                            <p class="subtitle">{{ view_model.summary.activity_string[1] }}</p>
                         </article>
                     </div>
                 </div>
                 <div class="tile is-parent">
                     <div class="tile is-child notification">
                         <p class="title is-4">{{ view_model.summary.timeframe[0] }}</p>
-                        <p class="subtitle">(x von {{ view_model.summary.timeframe[1] }})</p>
-                        <progress class="progress" value="2" max="{{ view_model.summary.timeframe[1] }}">15%</progress>
+                        <p class="subtitle">({{ view_model.summary.active_days}} / {{ view_model.summary.timeframe[1]
+                            }})</p>
+                        <progress class="progress" value="{{ view_model.summary.active_days}}"
+                            max="{{ view_model.summary.timeframe[1] }}"></progress>
                     </div>
                 </div>
             </div>
@@ -72,11 +74,11 @@
                         <div class="tile is-parent is-vertical">
                             <article class="tile is-child notification">
                                 <p class="title is-4">{{ view_model.summary.amount[0] }}</p>
-                                <p class="">{{ view_model.summary.amount[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.amount[1] }}</p>
                             </article>
                             <article class="tile is-child notification">
                                 <p class="title is-4">{{ view_model.summary.production_unit[0] }}</p>
-                                <p class="">{{ view_model.summary.production_unit[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.production_unit[1] }}</p>
                             </article>
                         </div>
                     </div>
@@ -86,15 +88,15 @@
                         <div class="tile is-parent is-vertical">
                             <article class="tile is-child notification has-background-danger-light">
                                 <p class="title is-4">{{ view_model.summary.means_cost[0] }}</p>
-                                <p class="">{{ view_model.summary.means_cost[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.means_cost[1] }}</p>
                             </article>
                             <article class="tile is-child notification has-background-danger-light">
                                 <p class="title is-4">{{ view_model.summary.resources_cost[0] }}</p>
-                                <p class="">{{ view_model.summary.resources_cost[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.resources_cost[1] }}</p>
                             </article>
                             <article class="tile is-child notification has-background-danger-light">
                                 <p class="title is-4">{{ view_model.summary.labour_cost[0] }}</p>
-                                <p class="">{{ view_model.summary.labour_cost[1] }}</p>
+                                <p class="subtitle">{{ view_model.summary.labour_cost[1] }}</p>
                             </article>
                         </div>
                     </div>
@@ -107,13 +109,13 @@
                 <div class="tile is-parent">
                     <article class="tile is-child notification">
                         <p class="title is-4">{{ view_model.summary.type_of_plan[0] }}</p>
-                        <p>{{ view_model.summary.type_of_plan[1] }}</p>
+                        <p class="subtitle">{{ view_model.summary.type_of_plan[1] }}</p>
                     </article>
                 </div>
                 <div class="tile is-parent">
-                    <div class="tile is-child notification">
+                    <div class="tile is-child notification has-background-warning-light">
                         <p class="title is-4">{{ view_model.summary.price_per_unit[0] }}</p>
-                        <p>{{ view_model.summary.price_per_unit[1] }}
+                        <p class="subtitle">{{ view_model.summary.price_per_unit[1] }}
                             {% if view_model.summary.price_per_unit[2] %} <span>
                                 <a href="{{ view_model.summary.price_per_unit[3] }}">
                                     <i class="fas fa-hands-helping"></i></a>
@@ -124,8 +126,8 @@
                 </div>
                 <div class="tile is-parent">
                     <article class="tile is-child notification">
-                        <p class="title is-4">{{ view_model.summary.is_available[0] }}</p>
-                        <p>{{ view_model.summary.is_available[1] }}</p>
+                        <p class="title is-4">{{ view_model.summary.availability_string[0] }}</p>
+                        <p class="subtitle">{{ view_model.summary.availability_string[1] }}</p>
                     </article>
                 </div>
             </div>

--- a/arbeitszeit_flask/templates/macros/plan_summary.html
+++ b/arbeitszeit_flask/templates/macros/plan_summary.html
@@ -1,43 +1,135 @@
 {% macro plan_summary(view_model) %}
 <div class="section has-text-centered">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
-            <div class="content">
-                <h1 class="title">
-                    {{ gettext("Plan information") }}
-                </h1>
+    <div class="section">
+        <div class="content">
+            <h1 class="title">
+                {{ gettext("Plan information") }}
+            </h1>
+        </div>
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-vertical is-8">
+                    <div class="tile">
+                        <div class="tile is-parent is-vertical">
+                            <article class="tile is-child notification">
+                                <p class="title is-4">{{ view_model.summary.plan_id[0] }}</p>
+                                <p class="">{{ view_model.summary.plan_id[1] }}</p>
+                            </article>
+                            <article class="tile is-child notification">
+                                <p class="title is-4">{{ view_model.summary.planner[0] }}</p>
+                                <p class=""><a href="{{ view_model.summary.planner[2] }}">{{
+                                        view_model.summary.planner[3] }}</a></p>
+                            </article>
+                        </div>
+                        <div class="tile is-parent is-vertical">
+                            <article class="tile is-child notification">
+                                <p class="title is-4">{{ view_model.summary.product_name[0] }}</p>
+                                <p class="">{{ view_model.summary.product_name[1] }}</p>
+                            </article>
+                            <article class="tile is-child notification"></article>
+                        </div>
+                    </div>
+                </div>
+                <div class="tile is-parent">
+                    <article class="tile is-child notification has-background-primary-light">
+                        <div class="content">
+                            <p class="title is-4">{{ view_model.summary.description[0] }}</p>
+                            <div class="content">
+                                <p>{% for paragraph in view_model.summary.description[1] %}{{ paragraph
+                                    }}<br>{% endfor %}</p>
+                            </div>
+                        </div>
+                    </article>
+                </div>
             </div>
-            <br>
-            <div class="table-container">
-                <table class="table is-fullwidth">
-                    <tbody>
-                        {% for key in view_model.summary %}
-                        <tr>
-                            <td class="has-text-left has-text-weight-semibold">{{ view_model.summary[key][0] }}</td>
-                            {% if key == "description" %}
-                            <td class="has-text-left">{% for paragraph in view_model.summary[key][1] %}{{ paragraph
-                                }}<br>{% endfor %}
-                            </td>
-                            {% elif key == "price_per_unit" %}
-                            <td class="has-text-left">{{ view_model.summary[key][1] }}{% if view_model.summary[key][2]
-                                %} <span>
-                                    <a href="{{ view_model.summary[key][3] }}"><i
-                                            class="fas fa-hands-helping"></i></a></span>{% endif %}
-                            </td>
-                            {% elif key == "planner" %}
-                            <td class="has-text-left"><a href="{{ view_model.summary[key][2] }}">{{
-                                    view_model.summary[key][3] }}</a>
-                            </td>
-                            {% else %}
-                            <td class="has-text-left">{{ view_model.summary[key][1] }}
-                            </td>
+        </div>
+
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-4">
+                    <div class="tile is-parent">
+                        <article class="tile is-child notification has-background-warning-light">
+                            <p class="title is-4">{{ view_model.summary.is_active[0] }}</p>
+                            <p class="">{{ view_model.summary.is_active[1] }}</p>
+                        </article>
+                    </div>
+                </div>
+                <div class="tile is-parent">
+                    <div class="tile is-child notification">
+                        <p class="title is-4">{{ view_model.summary.timeframe[0] }}</p>
+                        <p class="subtitle">(x von {{ view_model.summary.timeframe[1] }})</p>
+                        <progress class="progress" value="2" max="{{ view_model.summary.timeframe[1] }}">15%</progress>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-vertical">
+                    <div class="tile">
+                        <div class="tile is-parent is-vertical">
+                            <article class="tile is-child notification">
+                                <p class="title is-4">{{ view_model.summary.amount[0] }}</p>
+                                <p class="">{{ view_model.summary.amount[1] }}</p>
+                            </article>
+                            <article class="tile is-child notification">
+                                <p class="title is-4">{{ view_model.summary.production_unit[0] }}</p>
+                                <p class="">{{ view_model.summary.production_unit[1] }}</p>
+                            </article>
+                        </div>
+                    </div>
+                </div>
+                <div class="tile is-vertical is-8">
+                    <div class="tile">
+                        <div class="tile is-parent is-vertical">
+                            <article class="tile is-child notification has-background-danger-light">
+                                <p class="title is-4">{{ view_model.summary.means_cost[0] }}</p>
+                                <p class="">{{ view_model.summary.means_cost[1] }}</p>
+                            </article>
+                            <article class="tile is-child notification has-background-danger-light">
+                                <p class="title is-4">{{ view_model.summary.resources_cost[0] }}</p>
+                                <p class="">{{ view_model.summary.resources_cost[1] }}</p>
+                            </article>
+                            <article class="tile is-child notification has-background-danger-light">
+                                <p class="title is-4">{{ view_model.summary.labour_cost[0] }}</p>
+                                <p class="">{{ view_model.summary.labour_cost[1] }}</p>
+                            </article>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-parent">
+                    <article class="tile is-child notification">
+                        <p class="title is-4">{{ view_model.summary.type_of_plan[0] }}</p>
+                        <p>{{ view_model.summary.type_of_plan[1] }}</p>
+                    </article>
+                </div>
+                <div class="tile is-parent">
+                    <div class="tile is-child notification">
+                        <p class="title is-4">{{ view_model.summary.price_per_unit[0] }}</p>
+                        <p>{{ view_model.summary.price_per_unit[1] }}
+                            {% if view_model.summary.price_per_unit[2] %} <span>
+                                <a href="{{ view_model.summary.price_per_unit[3] }}">
+                                    <i class="fas fa-hands-helping"></i></a>
+                            </span>
                             {% endif %}
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                        </p>
+                    </div>
+                </div>
+                <div class="tile is-parent">
+                    <article class="tile is-child notification">
+                        <p class="title is-4">{{ view_model.summary.is_available[0] }}</p>
+                        <p>{{ view_model.summary.is_available[1] }}</p>
+                    </article>
+                </div>
             </div>
         </div>
     </div>
-</div>
-{% endmacro %}
+
+    {% endmacro %}

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -7,10 +7,7 @@ from flask import redirect, url_for
 
 from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraft
 from arbeitszeit.use_cases.get_draft_summary import DraftSummarySuccess, GetDraftSummary
-from arbeitszeit.use_cases.get_plan_summary_company import (
-    GetPlanSummaryCompany,
-    PlanSummaryCompanySuccess,
-)
+from arbeitszeit.use_cases.get_plan_summary_company import GetPlanSummaryCompany
 from arbeitszeit_flask.forms import CreateDraftForm
 from arbeitszeit_flask.template import UserTemplateRenderer
 from arbeitszeit_flask.types import Response
@@ -82,13 +79,11 @@ class CreateDraftView:
             planner = self.session.get_current_user()
             assert expired_plan_id is not None
             assert planner is not None
-            plan_summary_success = self.get_plan_summary_company(
-                UUID(expired_plan_id), planner
-            )
-            if isinstance(plan_summary_success, PlanSummaryCompanySuccess):
+            response = self.get_plan_summary_company(UUID(expired_plan_id), planner)
+            if isinstance(response, GetPlanSummaryCompany.Success):
                 view_model = (
                     self.get_prefilled_draft_data_presenter.show_prefilled_draft_data(
-                        plan_summary_success.plan_summary
+                        response.plan_summary
                     )
                 )
                 form = CreateDraftForm(data=asdict(view_model.prefilled_draft_data))

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -14,7 +14,7 @@ from .url_index import (
 
 @dataclass
 class Action:
-    is_available: bool
+    is_available_bool: bool
     toggle_availability_url: str
     is_cooperating: bool
     end_coop_url: Optional[str]
@@ -44,13 +44,12 @@ class GetPlanSummaryCompanySuccessPresenter:
     ) -> GetPlanSummaryCompanyViewModel:
         plan_id = response.plan_summary.plan_id
         coop_id = response.plan_summary.cooperation
-        is_available = response.plan_summary.is_available
         is_cooperating = response.plan_summary.is_cooperating
         return GetPlanSummaryCompanyViewModel(
             summary=self.plan_summary_service.get_plan_summary(response.plan_summary),
             show_action_section=response.current_user_is_planner,
             action=Action(
-                is_available=is_available,
+                is_available_bool=response.plan_summary.is_available,
                 toggle_availability_url=self.toggle_availability_url_index.get_toggle_availability_url(
                     plan_id
                 ),

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -1,9 +1,9 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 
-from arbeitszeit.use_cases.get_plan_summary_company import PlanSummaryCompanySuccess
+from arbeitszeit.use_cases.get_plan_summary_company import GetPlanSummaryCompany
 
-from .plan_summary_service import PlanSummary, PlanSummaryService
+from .plan_summary_service import PlanSummaryService, PlanSummaryWeb
 from .translator import Translator
 from .url_index import (
     EndCoopUrlIndex,
@@ -23,7 +23,7 @@ class Action:
 
 @dataclass
 class GetPlanSummaryCompanyViewModel:
-    summary: PlanSummary
+    summary: PlanSummaryWeb
     show_action_section: bool
     action: Action
 
@@ -40,7 +40,7 @@ class GetPlanSummaryCompanySuccessPresenter:
     plan_summary_service: PlanSummaryService
 
     def present(
-        self, response: PlanSummaryCompanySuccess
+        self, response: GetPlanSummaryCompany.Success
     ) -> GetPlanSummaryCompanyViewModel:
         plan_id = response.plan_summary.plan_id
         coop_id = response.plan_summary.cooperation

--- a/arbeitszeit_web/get_plan_summary_member.py
+++ b/arbeitszeit_web/get_plan_summary_member.py
@@ -1,15 +1,15 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Dict
 
-from arbeitszeit.use_cases.get_plan_summary_member import PlanSummarySuccess
-from arbeitszeit_web.plan_summary_service import PlanSummary, PlanSummaryService
+from arbeitszeit.use_cases.get_plan_summary_member import GetPlanSummaryMember
+from arbeitszeit_web.plan_summary_service import PlanSummaryService, PlanSummaryWeb
 
 from .translator import Translator
 
 
 @dataclass
 class GetPlanSummaryViewModel:
-    summary: PlanSummary
+    summary: PlanSummaryWeb
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -20,7 +20,9 @@ class GetPlanSummarySuccessPresenter:
     trans: Translator
     plan_summary_service: PlanSummaryService
 
-    def present(self, response: PlanSummarySuccess) -> GetPlanSummaryViewModel:
+    def present(
+        self, response: GetPlanSummaryMember.Success
+    ) -> GetPlanSummaryViewModel:
         return GetPlanSummaryViewModel(
             summary=self.plan_summary_service.get_plan_summary(response.plan_summary)
         )

--- a/arbeitszeit_web/get_prefilled_draft_data.py
+++ b/arbeitszeit_web/get_prefilled_draft_data.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Protocol, Union
 
 from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.plan_summary import BusinessPlanSummary
+from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit.use_cases import CreatePlanDraftRequest, DraftSummarySuccess
 from arbeitszeit_web.session import Session
 
@@ -88,7 +88,7 @@ class GetPrefilledDraftDataPresenter:
 
     def show_prefilled_draft_data(
         self,
-        summary_data: Union[BusinessPlanSummary, DraftSummarySuccess],
+        summary_data: Union[PlanSummary, DraftSummarySuccess],
     ) -> ViewModel:
         prefilled_data = self.PrefilledDraftData(
             prd_name=summary_data.product_name,

--- a/arbeitszeit_web/plan_summary_service.py
+++ b/arbeitszeit_web/plan_summary_service.py
@@ -11,11 +11,12 @@ from .translator import Translator
 @dataclass
 class PlanSummary:
     plan_id: Tuple[str, str]
-    is_active: Tuple[str, str]
+    activity_string: Tuple[str, str]
     planner: Tuple[str, str, str, str]
     product_name: Tuple[str, str]
     description: Tuple[str, List[str]]
     timeframe: Tuple[str, str]
+    active_days: str
     production_unit: Tuple[str, str]
     amount: Tuple[str, str]
     means_cost: Tuple[str, str]
@@ -23,7 +24,7 @@ class PlanSummary:
     labour_cost: Tuple[str, str]
     type_of_plan: Tuple[str, str]
     price_per_unit: Tuple[str, str, bool, Optional[str]]
-    is_available: Tuple[str, str]
+    availability_string: Tuple[str, str]
 
 
 class PlanSummaryService(Protocol):
@@ -40,7 +41,7 @@ class PlanSummaryServiceImpl:
     def get_plan_summary(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
         return PlanSummary(
             plan_id=(self.translator.gettext("Plan ID"), str(plan_summary.plan_id)),
-            is_active=(
+            activity_string=(
                 self.translator.gettext("Status"),
                 self.translator.gettext("Active")
                 if plan_summary.is_active
@@ -64,6 +65,7 @@ class PlanSummaryServiceImpl:
                 self.translator.gettext("Planning timeframe (days)"),
                 str(plan_summary.timeframe),
             ),
+            active_days=str(plan_summary.active_days),
             production_unit=(
                 self.translator.gettext("Smallest delivery unit"),
                 plan_summary.production_unit,
@@ -95,7 +97,7 @@ class PlanSummaryServiceImpl:
                 if plan_summary.cooperation
                 else None,
             ),
-            is_available=(
+            availability_string=(
                 self.translator.gettext("Product currently available"),
                 self.translator.gettext("Yes")
                 if plan_summary.is_available

--- a/arbeitszeit_web/plan_summary_service.py
+++ b/arbeitszeit_web/plan_summary_service.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Optional, Protocol, Tuple
 
-from arbeitszeit.plan_summary import BusinessPlanSummary
+from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit_web.url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndex
 
 from .translator import Translator
 
 
 @dataclass
-class PlanSummary:
+class PlanSummaryWeb:
     plan_id: Tuple[str, str]
     activity_string: Tuple[str, str]
     planner: Tuple[str, str, str, str]
@@ -28,7 +28,7 @@ class PlanSummary:
 
 
 class PlanSummaryService(Protocol):
-    def get_plan_summary(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
+    def get_plan_summary(self, plan_summary: PlanSummary) -> PlanSummaryWeb:
         ...
 
 
@@ -38,8 +38,8 @@ class PlanSummaryServiceImpl:
     company_url_index: CompanySummaryUrlIndex
     translator: Translator
 
-    def get_plan_summary(self, plan_summary: BusinessPlanSummary) -> PlanSummary:
-        return PlanSummary(
+    def get_plan_summary(self, plan_summary: PlanSummary) -> PlanSummaryWeb:
+        return PlanSummaryWeb(
             plan_id=(self.translator.gettext("Plan ID"), str(plan_summary.plan_id)),
             activity_string=(
                 self.translator.gettext("Status"),

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -24,6 +24,7 @@ TESTING_RESPONSE_MODEL = PlanSummaryCompanySuccess(
         planner_name="planner name",
         product_name="test product name",
         description="test description",
+        active_days=5,
         timeframe=7,
         production_unit="Piece",
         amount=100,
@@ -41,6 +42,10 @@ TESTING_RESPONSE_MODEL = PlanSummaryCompanySuccess(
 
 
 class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
+    """
+    some functionality are tested in tests/presenters/test_plan_summary_service.py
+    """
+
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
         self.toggle_availability_url_index = self.injector.get(
@@ -59,17 +64,31 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertFalse(view_model.show_action_section)
 
-    def test_url_for_changing_availability_is_displayed_correctly(self):
+    def test_view_model_sows_availability_when_plan_is_available(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
-            view_model.action.is_available,
+            view_model.action.is_available_bool,
             TESTING_RESPONSE_MODEL.plan_summary.is_available,
         )
+
+    def test_url_for_changing_availability_is_displayed_correctly(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
             view_model.action.toggle_availability_url,
             self.toggle_availability_url_index.get_toggle_availability_url(
                 TESTING_RESPONSE_MODEL.plan_summary.plan_id
             ),
+        )
+
+    def test_view_model_shows_plan_as_cooperating_when_plan_is_cooperating(
+        self,
+    ):
+        assert TESTING_RESPONSE_MODEL.plan_summary.cooperation
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertTrue(view_model.action.is_cooperating)
+        self.assertEqual(
+            view_model.action.is_cooperating,
+            TESTING_RESPONSE_MODEL.plan_summary.is_cooperating,
         )
 
     def test_url_for_ending_cooperation_is_displayed_correctly_when_plan_is_cooperating(

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 from unittest import TestCase
 from uuid import uuid4
 
-from arbeitszeit.plan_summary import BusinessPlanSummary
-from arbeitszeit.use_cases.get_plan_summary_company import PlanSummaryCompanySuccess
+from arbeitszeit.plan_summary import PlanSummary
+from arbeitszeit.use_cases.get_plan_summary_company import GetPlanSummaryCompany
 from arbeitszeit_web.get_plan_summary_company import (
     GetPlanSummaryCompanySuccessPresenter,
 )
@@ -16,8 +16,8 @@ from .url_index import (
     TogglePlanAvailabilityUrlIndex,
 )
 
-TESTING_RESPONSE_MODEL = PlanSummaryCompanySuccess(
-    plan_summary=BusinessPlanSummary(
+TESTING_RESPONSE_MODEL = GetPlanSummaryCompany.Success(
+    plan_summary=PlanSummary(
         plan_id=uuid4(),
         is_active=True,
         planner_id=uuid4(),
@@ -119,7 +119,7 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         plan_summary = replace(
             TESTING_RESPONSE_MODEL.plan_summary, is_cooperating=False, cooperation=None
         )
-        response = PlanSummaryCompanySuccess(
+        response = GetPlanSummaryCompany.Success(
             plan_summary=plan_summary, current_user_is_planner=True
         )
         view_model = self.presenter.present(response)
@@ -132,7 +132,7 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         plan_summary = replace(
             TESTING_RESPONSE_MODEL.plan_summary, is_cooperating=False, cooperation=None
         )
-        response = PlanSummaryCompanySuccess(
+        response = GetPlanSummaryCompany.Success(
             plan_summary=plan_summary, current_user_is_planner=True
         )
         view_model = self.presenter.present(response)

--- a/tests/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/presenters/test_get_prefilled_draft_data_presenter.py
@@ -1,13 +1,13 @@
 from decimal import Decimal
 from uuid import uuid4
 
-from arbeitszeit.plan_summary import BusinessPlanSummary
+from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit.use_cases import DraftSummarySuccess
 from arbeitszeit_web.get_prefilled_draft_data import GetPrefilledDraftDataPresenter
 
 from .dependency_injection import get_dependency_injector
 
-BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
+PLAN_SUMMARY = PlanSummary(
     plan_id=uuid4(),
     is_active=True,
     planner_id=uuid4(),
@@ -46,27 +46,18 @@ TEST_DRAFT_SUMMARY_SUCCESS = DraftSummarySuccess(
 def test_correct_prefilled_data_is_returned_for_plan_summary():
     injector = get_dependency_injector()
     get_prefilled_data = injector.get(GetPrefilledDraftDataPresenter)
-    view_model = get_prefilled_data.show_prefilled_draft_data(BUSINESS_PLAN_SUMMARY)
-    assert (
-        view_model.prefilled_draft_data.prd_name == BUSINESS_PLAN_SUMMARY.product_name
-    )
-    assert (
-        view_model.prefilled_draft_data.description == BUSINESS_PLAN_SUMMARY.description
-    )
-    assert view_model.prefilled_draft_data.timeframe == BUSINESS_PLAN_SUMMARY.timeframe
-    assert (
-        view_model.prefilled_draft_data.prd_unit
-        == BUSINESS_PLAN_SUMMARY.production_unit
-    )
-    assert view_model.prefilled_draft_data.prd_amount == BUSINESS_PLAN_SUMMARY.amount
-    assert view_model.prefilled_draft_data.costs_p == BUSINESS_PLAN_SUMMARY.means_cost
-    assert (
-        view_model.prefilled_draft_data.costs_r == BUSINESS_PLAN_SUMMARY.resources_cost
-    )
-    assert view_model.prefilled_draft_data.costs_a == BUSINESS_PLAN_SUMMARY.labour_cost
+    view_model = get_prefilled_data.show_prefilled_draft_data(PLAN_SUMMARY)
+    assert view_model.prefilled_draft_data.prd_name == PLAN_SUMMARY.product_name
+    assert view_model.prefilled_draft_data.description == PLAN_SUMMARY.description
+    assert view_model.prefilled_draft_data.timeframe == PLAN_SUMMARY.timeframe
+    assert view_model.prefilled_draft_data.prd_unit == PLAN_SUMMARY.production_unit
+    assert view_model.prefilled_draft_data.prd_amount == PLAN_SUMMARY.amount
+    assert view_model.prefilled_draft_data.costs_p == PLAN_SUMMARY.means_cost
+    assert view_model.prefilled_draft_data.costs_r == PLAN_SUMMARY.resources_cost
+    assert view_model.prefilled_draft_data.costs_a == PLAN_SUMMARY.labour_cost
     assert (
         view_model.prefilled_draft_data.productive_or_public == "public"
-        if BUSINESS_PLAN_SUMMARY.is_public_service
+        if PLAN_SUMMARY.is_public_service
         else "productive"
     )
     assert view_model.prefilled_draft_data.action == ""

--- a/tests/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/presenters/test_get_prefilled_draft_data_presenter.py
@@ -15,6 +15,7 @@ BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
     product_name="test",
     description="beschreibung",
     timeframe=10,
+    active_days=5,
     production_unit="1 kilo",
     amount=2,
     means_cost=Decimal(5),

--- a/tests/presenters/test_plan_summary_service.py
+++ b/tests/presenters/test_plan_summary_service.py
@@ -3,14 +3,14 @@ from decimal import Decimal
 from unittest import TestCase
 from uuid import uuid4
 
-from arbeitszeit.plan_summary import BusinessPlanSummary
+from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit_web.plan_summary_service import PlanSummaryServiceImpl
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
 from .url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndexTestImpl
 
-BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
+PLAN_SUMMARY = PlanSummary(
     plan_id=uuid4(),
     is_active=True,
     planner_id=uuid4(),
@@ -41,14 +41,14 @@ class PlanSummaryServiceTests(TestCase):
         self.service = self.injector.get(PlanSummaryServiceImpl)
 
     def test_plan_id_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.plan_id,
-            (self.translator.gettext("Plan ID"), str(BUSINESS_PLAN_SUMMARY.plan_id)),
+            (self.translator.gettext("Plan ID"), str(PLAN_SUMMARY.plan_id)),
         )
 
     def test_active_status_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.activity_string,
             (self.translator.gettext("Status"), self.translator.gettext("Active")),
@@ -56,7 +56,7 @@ class PlanSummaryServiceTests(TestCase):
 
     def test_inactive_status_is_displayed_correctly_as_tuple_of_strings(self):
         response = replace(
-            BUSINESS_PLAN_SUMMARY,
+            PLAN_SUMMARY,
             is_active=False,
         )
         plan_summary = self.service.get_plan_summary(response)
@@ -68,7 +68,7 @@ class PlanSummaryServiceTests(TestCase):
     def test_planner_is_displayed_correctly_as_tuple_of_strings(self):
         expected_planner_id = uuid4()
         response = replace(
-            BUSINESS_PLAN_SUMMARY,
+            PLAN_SUMMARY,
             planner_id=expected_planner_id,
         )
         plan_summary = self.service.get_plan_summary(response)
@@ -78,29 +78,29 @@ class PlanSummaryServiceTests(TestCase):
                 self.translator.gettext("Planning company"),
                 str(expected_planner_id),
                 self.company_url_index.get_company_summary_url(expected_planner_id),
-                BUSINESS_PLAN_SUMMARY.planner_name,
+                PLAN_SUMMARY.planner_name,
             ),
         )
 
     def test_product_name_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.product_name,
             (
                 self.translator.gettext("Name of product"),
-                BUSINESS_PLAN_SUMMARY.product_name,
+                PLAN_SUMMARY.product_name,
             ),
         )
 
     def test_description_is_displayed_correctly_as_tuple_of_string_and_list_of_string(
         self,
     ):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.description,
             (
                 self.translator.gettext("Description of product"),
-                [BUSINESS_PLAN_SUMMARY.description],
+                [PLAN_SUMMARY.description],
             ),
         )
 
@@ -108,7 +108,7 @@ class PlanSummaryServiceTests(TestCase):
         self,
     ):
         response = replace(
-            BUSINESS_PLAN_SUMMARY,
+            PLAN_SUMMARY,
             description="first paragraph\rsecond paragraph",
         )
         plan_summary = self.service.get_plan_summary(response)
@@ -121,59 +121,59 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_timeframe_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.timeframe,
             (
                 self.translator.gettext("Planning timeframe (days)"),
-                str(BUSINESS_PLAN_SUMMARY.timeframe),
+                str(PLAN_SUMMARY.timeframe),
             ),
         )
 
     def test_production_unit_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.production_unit,
             (
                 self.translator.gettext("Smallest delivery unit"),
-                BUSINESS_PLAN_SUMMARY.production_unit,
+                PLAN_SUMMARY.production_unit,
             ),
         )
 
     def test_amount_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.amount,
-            (self.translator.gettext("Amount"), str(BUSINESS_PLAN_SUMMARY.amount)),
+            (self.translator.gettext("Amount"), str(PLAN_SUMMARY.amount)),
         )
 
     def test_means_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.means_cost,
             (
                 self.translator.gettext("Costs for fixed means of production"),
-                str(BUSINESS_PLAN_SUMMARY.means_cost),
+                str(PLAN_SUMMARY.means_cost),
             ),
         )
 
     def test_resources_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.resources_cost,
             (
                 self.translator.gettext("Costs for liquid means of production"),
-                str(BUSINESS_PLAN_SUMMARY.resources_cost),
+                str(PLAN_SUMMARY.resources_cost),
             ),
         )
 
     def test_labour_cost_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.labour_cost,
             (
                 self.translator.gettext("Costs for work"),
-                str(BUSINESS_PLAN_SUMMARY.labour_cost),
+                str(PLAN_SUMMARY.labour_cost),
             ),
         )
 
@@ -181,7 +181,7 @@ class PlanSummaryServiceTests(TestCase):
         self,
     ):
         response = replace(
-            BUSINESS_PLAN_SUMMARY,
+            PLAN_SUMMARY,
             is_public_service=False,
         )
         plan_summary = self.service.get_plan_summary(response)
@@ -197,7 +197,7 @@ class PlanSummaryServiceTests(TestCase):
         self,
     ):
         response = replace(
-            BUSINESS_PLAN_SUMMARY,
+            PLAN_SUMMARY,
             is_public_service=True,
         )
         plan_summary = self.service.get_plan_summary(response)
@@ -210,8 +210,8 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_price_per_unit_is_displayed_correctly_as_tuple_of_strings_and_bool(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
-        coop_id = BUSINESS_PLAN_SUMMARY.cooperation
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
+        coop_id = PLAN_SUMMARY.cooperation
         assert coop_id
         self.assertTupleEqual(
             plan_summary.price_per_unit,
@@ -224,7 +224,7 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_availability_is_displayed_correctly_as_tuple_of_strings(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertTupleEqual(
             plan_summary.availability_string,
             (
@@ -234,8 +234,8 @@ class PlanSummaryServiceTests(TestCase):
         )
 
     def test_active_days_is_displayed_correctly_as_string(self):
-        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        plan_summary = self.service.get_plan_summary(PLAN_SUMMARY)
         self.assertEqual(
             plan_summary.active_days,
-            str(BUSINESS_PLAN_SUMMARY.active_days),
+            str(PLAN_SUMMARY.active_days),
         )

--- a/tests/presenters/test_plan_summary_service.py
+++ b/tests/presenters/test_plan_summary_service.py
@@ -18,6 +18,7 @@ BUSINESS_PLAN_SUMMARY = BusinessPlanSummary(
     product_name="test product name",
     description="test description",
     timeframe=7,
+    active_days=5,
     production_unit="Piece",
     amount=100,
     means_cost=Decimal(1),
@@ -49,7 +50,7 @@ class PlanSummaryServiceTests(TestCase):
     def test_active_status_is_displayed_correctly_as_tuple_of_strings(self):
         plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
-            plan_summary.is_active,
+            plan_summary.activity_string,
             (self.translator.gettext("Status"), self.translator.gettext("Active")),
         )
 
@@ -60,7 +61,7 @@ class PlanSummaryServiceTests(TestCase):
         )
         plan_summary = self.service.get_plan_summary(response)
         self.assertTupleEqual(
-            plan_summary.is_active,
+            plan_summary.activity_string,
             (self.translator.gettext("Status"), self.translator.gettext("Inactive")),
         )
 
@@ -225,9 +226,16 @@ class PlanSummaryServiceTests(TestCase):
     def test_availability_is_displayed_correctly_as_tuple_of_strings(self):
         plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
         self.assertTupleEqual(
-            plan_summary.is_available,
+            plan_summary.availability_string,
             (
                 self.translator.gettext("Product currently available"),
                 self.translator.gettext("Yes"),
             ),
+        )
+
+    def test_active_days_is_displayed_correctly_as_string(self):
+        plan_summary = self.service.get_plan_summary(BUSINESS_PLAN_SUMMARY)
+        self.assertEqual(
+            plan_summary.active_days,
+            str(BUSINESS_PLAN_SUMMARY.active_days),
         )

--- a/tests/use_cases/test_get_plan_summary_company.py
+++ b/tests/use_cases/test_get_plan_summary_company.py
@@ -11,7 +11,9 @@ from arbeitszeit.use_cases import (
     PlanSummaryCompanyResponse,
     PlanSummaryCompanySuccess,
 )
+from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.datetime_service import FakeDatetimeService
 
 from .dependency_injection import get_dependency_injector
 
@@ -22,6 +24,8 @@ class Tests(TestCase):
         self.plan_generator = self.injector.get(PlanGenerator)
         self.get_plan_summary_company = self.injector.get(GetPlanSummaryCompany)
         self.company_generator = self.injector.get(CompanyGenerator)
+        self.payout_use_case = self.injector.get(UpdatePlansAndPayout)
+        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_current_user_is_correctly_shown_as_planner(self):
         planner_and_current_user = self.company_generator.create_company()
@@ -163,6 +167,48 @@ class Tests(TestCase):
         response = self.get_plan_summary_company(plan.id, current_user.id)
         assert_success(response, lambda s: s.is_cooperating == True)
         assert_success(response, lambda s: s.cooperation == coop.id)
+
+    def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(activation_date=None)
+        self.payout_use_case()
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.active_days == 0)
+
+    def test_that_zero_active_days_is_shown_if_plan_is_active_since_less_than_one_day(
+        self,
+    ):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now()
+        )
+        self.payout_use_case()
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.active_days == 0)
+
+    def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
+        self,
+    ):
+        current_user = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_25_hours()
+        )
+        self.payout_use_case()
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.active_days == 1)
+
+    def test_that_a_plans_timeframe_is_shown_as_active_days_if_plan_is_expired(
+        self,
+    ):
+        current_user = self.company_generator.create_company()
+        timeframe = 7
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_ten_days(),
+            timeframe=timeframe,
+        )
+        self.payout_use_case()
+        response = self.get_plan_summary_company(plan.id, current_user.id)
+        assert_success(response, lambda s: s.active_days == timeframe)
 
 
 def assert_success(

--- a/tests/use_cases/test_get_plan_summary_company.py
+++ b/tests/use_cases/test_get_plan_summary_company.py
@@ -1,16 +1,12 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import Callable
+from typing import Callable, Union
 from unittest import TestCase
 from uuid import uuid4
 
 from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.plan_summary import BusinessPlanSummary
-from arbeitszeit.use_cases import (
-    GetPlanSummaryCompany,
-    PlanSummaryCompanyResponse,
-    PlanSummaryCompanySuccess,
-)
+from arbeitszeit.plan_summary import PlanSummary
+from arbeitszeit.use_cases import GetPlanSummaryCompany
 from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
 from tests.datetime_service import FakeDatetimeService
@@ -31,14 +27,14 @@ class Tests(TestCase):
         planner_and_current_user = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=planner_and_current_user)
         response = self.get_plan_summary_company(plan.id, planner_and_current_user.id)
-        assert isinstance(response, PlanSummaryCompanySuccess)
+        assert isinstance(response, GetPlanSummaryCompany.Success)
         assert response.current_user_is_planner
 
     def test_that_current_user_is_correctly_shown_as_non_planner(self):
         current_user = self.company_generator.create_company()
         plan = self.plan_generator.create_plan()
         response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert isinstance(response, PlanSummaryCompanySuccess)
+        assert isinstance(response, GetPlanSummaryCompany.Success)
         assert not response.current_user_is_planner
 
     def test_that_correct_planner_id_is_shown(self):
@@ -137,9 +133,12 @@ class Tests(TestCase):
         response = self.get_plan_summary_company(plan.id, current_user.id)
         assert_success(response, lambda s: s.is_public_service == True)
 
-    def test_that_none_is_returned_when_plan_does_not_exist(self) -> None:
+    def test_that_failure_is_returned_when_plan_does_not_exist(self):
         current_user = self.company_generator.create_company()
-        assert self.get_plan_summary_company(uuid4(), current_user.id) is None
+        self.assertIsInstance(
+            self.get_plan_summary_company(uuid4(), current_user.id),
+            GetPlanSummaryCompany.Failure,
+        )
 
     def test_that_correct_availability_is_shown(self):
         current_user = self.company_generator.create_company()
@@ -212,9 +211,9 @@ class Tests(TestCase):
 
 
 def assert_success(
-    response: PlanSummaryCompanyResponse,
-    assertion: Callable[[BusinessPlanSummary], bool],
+    response: Union[GetPlanSummaryCompany.Success, GetPlanSummaryCompany.Failure],
+    assertion: Callable[[PlanSummary], bool],
 ) -> None:
-    assert isinstance(response, PlanSummaryCompanySuccess)
-    assert isinstance(response.plan_summary, BusinessPlanSummary)
+    assert isinstance(response, GetPlanSummaryCompany.Success)
+    assert isinstance(response.plan_summary, PlanSummary)
     assert assertion(response.plan_summary)

--- a/tests/use_cases/test_get_plan_summary_member.py
+++ b/tests/use_cases/test_get_plan_summary_member.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 from typing import Callable
+from unittest import TestCase
 from uuid import uuid4
 
 from arbeitszeit.entities import ProductionCosts
@@ -10,210 +11,183 @@ from arbeitszeit.use_cases import (
     PlanSummaryResponse,
     PlanSummarySuccess,
 )
+from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.datetime_service import FakeDatetimeService
 
-from .dependency_injection import injection_test
-
-
-@injection_test
-def test_that_correct_planner_name_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary: GetPlanSummaryMember,
-    company_generator: CompanyGenerator,
-):
-    planner = company_generator.create_company()
-    plan = plan_generator.create_plan(planner=planner)
-    summary = get_plan_summary(plan.id)
-    assert_success(summary, lambda s: s.planner_name == plan.planner.name)
+from .dependency_injection import get_dependency_injector
 
 
-@injection_test
-def test_that_correct_planner_id_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-    company_generator: CompanyGenerator,
-):
-    planner = company_generator.create_company()
-    plan = plan_generator.create_plan(planner=planner)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.planner_id == plan.planner.id)
+class UseCaseTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.datetime_service = self.injector.get(FakeDatetimeService)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.use_case = self.injector.get(GetPlanSummaryMember)
+        self.payout_use_case = self.injector.get(UpdatePlansAndPayout)
+        self.company = self.company_generator.create_company()
 
+    def test_that_correct_planner_name_is_shown(self):
+        plan = self.plan_generator.create_plan(planner=self.company)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.planner_name == plan.planner.name)
 
-@injection_test
-def test_that_correct_active_status_is_shown_when_plan_is_inactive(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(activation_date=None)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_active == False)
+    def test_that_correct_planner_id_is_shown(self):
+        plan = self.plan_generator.create_plan(planner=self.company)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.planner_id == plan.planner.id)
 
+    def test_that_correct_active_status_is_shown_when_plan_is_inactive(self):
+        plan = self.plan_generator.create_plan(activation_date=None)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_active == False)
 
-@injection_test
-def test_that_correct_active_status_is_shown_when_plan_is_active(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(activation_date=datetime.min)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_active == True)
+    def test_that_correct_active_status_is_shown_when_plan_is_active(self):
+        plan = self.plan_generator.create_plan(activation_date=datetime.min)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_active == True)
 
-
-@injection_test
-def test_that_correct_production_costs_are_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
+    def test_that_correct_production_costs_are_shown(self):
+        plan = self.plan_generator.create_plan(
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            )
         )
-    )
-    summary = get_plan_summary_member(plan.id)
-    assert_success(
-        summary,
-        lambda s: all(
-            [
-                s.means_cost == Decimal(1),
-                s.labour_cost == Decimal(2),
-                s.resources_cost == Decimal(3),
-            ]
-        ),
-    )
+        summary = self.use_case(plan.id)
+        self.assert_success(
+            summary,
+            lambda s: all(
+                [
+                    s.means_cost == Decimal(1),
+                    s.labour_cost == Decimal(2),
+                    s.resources_cost == Decimal(3),
+                ]
+            ),
+        )
 
+    def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(self):
+        plan = self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.price_per_unit == Decimal(0))
 
-@injection_test
-def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(
-        is_public_service=True,
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
-        ),
-    )
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.price_per_unit == Decimal(0))
+    def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(self):
+        plan = self.plan_generator.create_plan(
+            is_public_service=False,
+            amount=2,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.price_per_unit == Decimal(3))
 
+    def test_that_correct_product_name_is_shown(self):
+        plan = self.plan_generator.create_plan(product_name="test product")
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.product_name == "test product")
 
-@injection_test
-def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(
-        is_public_service=False,
-        amount=2,
-        costs=ProductionCosts(
-            means_cost=Decimal(1),
-            labour_cost=Decimal(2),
-            resource_cost=Decimal(3),
-        ),
-    )
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.price_per_unit == Decimal(3))
+    def test_that_correct_product_description_is_shown(self):
+        plan = self.plan_generator.create_plan(description="test description")
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.description == "test description")
 
+    def test_that_correct_product_unit_is_shown(self):
+        plan = self.plan_generator.create_plan(production_unit="test unit")
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.production_unit == "test unit")
 
-@injection_test
-def test_that_correct_product_name_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(product_name="test product")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.product_name == "test product")
+    def test_that_correct_amount_is_shown(self):
+        plan = self.plan_generator.create_plan(amount=123)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.amount == 123)
 
+    def test_that_correct_public_service_is_shown(self):
+        plan = self.plan_generator.create_plan(is_public_service=True)
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_public_service == True)
 
-@injection_test
-def test_that_correct_product_description_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(description="test description")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.description == "test description")
+    def test_that_none_is_returned_when_plan_does_not_exist(self) -> None:
+        self.assertIsNone(self.use_case(uuid4()))
 
+    def test_that_correct_availability_is_shown(self):
+        plan = self.plan_generator.create_plan()
+        assert plan.is_available
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_available == True)
 
-@injection_test
-def test_that_correct_product_unit_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(production_unit="test unit")
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.production_unit == "test unit")
+    def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(self):
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=None
+        )
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_cooperating == False)
+        self.assert_success(summary, lambda s: s.cooperation is None)
 
+    def test_that_correct_cooperation_is_shown(self):
+        coop_generator = self.injector.get(CooperationGenerator)
+        coop = coop_generator.create_cooperation()
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=coop
+        )
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.is_cooperating == True)
+        self.assert_success(summary, lambda s: s.cooperation == coop.id)
 
-@injection_test
-def test_that_correct_amount_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(amount=123)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.amount == 123)
+    def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self):
+        plan = self.plan_generator.create_plan(activation_date=None)
+        self.payout_use_case()
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.active_days == 0)
 
+    def test_that_zero_active_days_is_shown_if_plan_is_active_since_less_than_one_day(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now()
+        )
+        self.payout_use_case()
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.active_days == 0)
 
-@injection_test
-def test_that_correct_public_service_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(is_public_service=True)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_public_service == True)
+    def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_25_hours()
+        )
+        self.payout_use_case()
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.active_days == 1)
 
+    def test_that_a_plans_timeframe_is_shown_as_active_days_if_plan_is_expired(
+        self,
+    ):
+        timeframe = 7
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_ten_days(),
+            timeframe=timeframe,
+        )
+        self.payout_use_case()
+        summary = self.use_case(plan.id)
+        self.assert_success(summary, lambda s: s.active_days == timeframe)
 
-@injection_test
-def test_that_none_is_returned_when_plan_does_not_exist(
-    get_plan_summary_member: GetPlanSummaryMember,
-) -> None:
-    assert get_plan_summary_member(uuid4()) is None
-
-
-@injection_test
-def test_that_correct_availability_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan()
-    assert plan.is_available
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_available == True)
-
-
-@injection_test
-def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-):
-    plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=None)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_cooperating == False)
-    assert_success(summary, lambda s: s.cooperation is None)
-
-
-@injection_test
-def test_that_correct_cooperation_is_shown(
-    plan_generator: PlanGenerator,
-    get_plan_summary_member: GetPlanSummaryMember,
-    coop_generator: CooperationGenerator,
-):
-    coop = coop_generator.create_cooperation()
-    plan = plan_generator.create_plan(activation_date=datetime.min, cooperation=coop)
-    summary = get_plan_summary_member(plan.id)
-    assert_success(summary, lambda s: s.is_cooperating == True)
-    assert_success(summary, lambda s: s.cooperation == coop.id)
-
-
-def assert_success(
-    response: PlanSummaryResponse, assertion: Callable[[BusinessPlanSummary], bool]
-) -> None:
-    assert isinstance(response, PlanSummarySuccess)
-    assert isinstance(response.plan_summary, BusinessPlanSummary)
-    assert assertion(response.plan_summary)
+    def assert_success(
+        self,
+        response: PlanSummaryResponse,
+        assertion: Callable[[BusinessPlanSummary], bool],
+    ) -> None:
+        assert isinstance(response, PlanSummarySuccess)
+        assert isinstance(response.plan_summary, BusinessPlanSummary)
+        assert assertion(response.plan_summary)


### PR DESCRIPTION
This PR changes the plan summary page by
1) applying the "tile" layout
2) adding a timeframe information to the plan summary page (how many days of the planning timeframe have passed?)
3) some refactoring, cleaning up and renaming on the back end side

The web design/style can of course be discussed. I think it's less intimitating than simple table rows with data.

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c

![image](https://user-images.githubusercontent.com/61537351/171055610-540540b0-8c04-4a87-abf6-082628e9113d.png)
