### PR TITLE
Reworking overview of all plans

### DIFF
--- a/arbeitszeit/use_cases/query_plans.py
+++ b/arbeitszeit/use_cases/query_plans.py
@@ -33,10 +33,8 @@ class QueriedPlan:
     description: str
     price_per_unit: Decimal
     is_public_service: bool
-    expiration_relative: Optional[int]
     is_available: bool
     is_cooperating: bool
-    cooperation: Optional[UUID]
 
 
 class QueryPlansRequest(ABC):
@@ -81,8 +79,6 @@ class QueryPlans:
             description=plan.description,
             price_per_unit=price_per_unit,
             is_public_service=plan.is_public_service,
-            expiration_relative=plan.expiration_relative,
             is_available=plan.is_available,
             is_cooperating=bool(plan.cooperation),
-            cooperation=plan.cooperation,
         )

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -834,14 +834,10 @@ class FlaskModule(Module):
     def provide_query_plans_presenter(
         self,
         plan_index: PlanSummaryUrlIndex,
-        company_index: CompanySummaryUrlIndex,
-        coop_index: CoopSummaryUrlIndex,
         notifier: Notifier,
         trans: Translator,
     ) -> QueryPlansPresenter:
-        return QueryPlansPresenter(
-            plan_index, company_index, coop_index, notifier, trans
-        )
+        return QueryPlansPresenter(plan_index, notifier, trans)
 
     @provider
     def provide_user_action_resolver(

--- a/arbeitszeit_flask/templates/macros/query_plans.html
+++ b/arbeitszeit_flask/templates/macros/query_plans.html
@@ -34,22 +34,19 @@
         <table class="table is-fullwidth">
             <thead>
                 <tr>
-                    <th>{{ gettext("Plan ID") }}</th>
-                    <th>{{ gettext("Product name") }}</th>
+                    <th>{{ gettext("Plan") }}</th>
                     <th>{{ gettext("Company") }}</th>
                     <th>{{ gettext("Description") }}</th>
                     <th>{{ gettext("Price per unit") }}</th>
                     <th>{{ gettext("Type") }}</th>
-                    <th>{{ gettext("Ends in")}}</th>
                     <th>{{ gettext("Available")}}</th>
                 </tr>
             </thead>
             <tbody>
                 {% for column in view_model.results.rows %}
                 <tr>
-                    <td><a href="{{ column.plan_summary_url }}">{{ column.plan_id }}</a>
+                    <td><a href="{{ column.plan_summary_url }}">{{ column.product_name }}</a>
                     </td>
-                    <td>{{ column.product_name }}</td>
                     <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
                     <td>{% for paragraph in column.description %}{{ paragraph }}<br>{% endfor %}</td>
                     <td>{{ column.price_per_unit }} {% if column.is_cooperating %} <span>
@@ -57,7 +54,6 @@
                         endif %}
                     </td>
                     <td>{{ column.type_of_plan }}</td>
-                    <td>{{ column.ends_in }}</td>
                     {% if column.is_available %}
                     <td>
                         <span class="icon has-text-success"><i class="fas fa-circle"></i></span>

--- a/arbeitszeit_flask/templates/macros/query_plans.html
+++ b/arbeitszeit_flask/templates/macros/query_plans.html
@@ -55,6 +55,9 @@
                         {% if column.is_cooperating %}
                         <span class="tag is-primary">{{ gettext("Cooperating plan") }}</span>
                         {% endif %}
+                        {% if column.is_public_service %}
+                        <span class="tag is-warning">{{ gettext("Public") }}</span>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="media-right">

--- a/arbeitszeit_flask/templates/macros/query_plans.html
+++ b/arbeitszeit_flask/templates/macros/query_plans.html
@@ -26,48 +26,44 @@
             </form>
         </div>
     </div>
-    {% if view_model.show_results %}
     <h1 class="title">
         Ergebnisse
     </h1>
-    <div class="table-container">
-        <table class="table is-fullwidth">
-            <thead>
-                <tr>
-                    <th>{{ gettext("Plan") }}</th>
-                    <th>{{ gettext("Company") }}</th>
-                    <th>{{ gettext("Description") }}</th>
-                    <th>{{ gettext("Price per unit") }}</th>
-                    <th>{{ gettext("Type") }}</th>
-                    <th>{{ gettext("Available")}}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for column in view_model.results.rows %}
-                <tr>
-                    <td><a href="{{ column.plan_summary_url }}">{{ column.product_name }}</a>
-                    </td>
-                    <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
-                    <td>{% for paragraph in column.description %}{{ paragraph }}<br>{% endfor %}</td>
-                    <td>{{ column.price_per_unit }} {% if column.is_cooperating %} <span>
-                            <a href="{{ column.coop_summary_url }}"><i class="fas fa-hands-helping"></i></a></span>{%
-                        endif %}
-                    </td>
-                    <td>{{ column.type_of_plan }}</td>
-                    {% if column.is_available %}
-                    <td>
-                        <span class="icon has-text-success"><i class="fas fa-circle"></i></span>
-                    </td>
-                    {% else %}
-                    <td>
-                        <span class="icon has-text-danger"><i class="fas fa-circle"></i></span>
-                    </td>
-                    {% endif %}
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    {% endif %}
 </div>
+
+{% if view_model.show_results %}
+<div class="section">
+    <div class="columns is-centered">
+        <div class="column is-one-third">
+            {% for column in view_model.results.rows %}
+            <article class="media">
+                <div class="media-content">
+                    <div class="content">
+                        <p>
+                            <strong><a href="{{ column.plan_summary_url }}">{{ column.product_name }}</a></strong>
+                            <small class="is-italic">{{ column.type_of_plan }}</small>
+                            <br>
+                            <small>@{{ column.company_name }}</small>
+                            <br>
+                            {% for paragraph in column.description %}{{ paragraph }}<br>{% endfor %}
+                        </p>
+                    </div>
+                    <div>
+                        {% if not column.is_available %}
+                        <span class="tag is-danger">{{ gettext("Product not available") }}</span>
+                        {% endif %}
+                        {% if column.is_cooperating %}
+                        <span class="tag is-primary">{{ gettext("Cooperating plan") }}</span>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="media-right">
+                    {{ column.price_per_unit }}
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
 {% endmacro %}

--- a/arbeitszeit_flask/templates/macros/query_plans.html
+++ b/arbeitszeit_flask/templates/macros/query_plans.html
@@ -40,12 +40,15 @@
                 <div class="media-content">
                     <div class="content">
                         <p>
-                            <strong><a href="{{ column.plan_summary_url }}">{{ column.product_name }}</a></strong>
-                            <small class="is-italic">{{ column.type_of_plan }}</small>
+                            <strong class="is-size-5">
+                                <a href="{{ column.plan_summary_url }}">{{ column.product_name }}</a>
+                            </strong>
                             <br>
                             <small>@{{ column.company_name }}</small>
                             <br>
-                            {% for paragraph in column.description %}{{ paragraph }}<br>{% endfor %}
+                            <span>
+                                {{ column.description }}
+                            </span>
                         </p>
                     </div>
                     <div>
@@ -61,7 +64,9 @@
                     </div>
                 </div>
                 <div class="media-right">
-                    {{ column.price_per_unit }}
+                    <p class="is-size-5">
+                        {{ column.price_per_unit }}
+                    </p>
                 </div>
             </article>
             {% endfor %}

--- a/arbeitszeit_web/query_plans.py
+++ b/arbeitszeit_web/query_plans.py
@@ -51,7 +51,7 @@ class ResultTableRow:
     plan_summary_url: str
     company_name: str
     product_name: str
-    description: List[str]
+    description: str
     price_per_unit: str
     is_public_service: bool
     is_available: bool
@@ -91,7 +91,7 @@ class QueryPlansPresenter:
                         ),
                         company_name=result.company_name,
                         product_name=result.product_name,
-                        description=result.description.splitlines(),
+                        description="".join(result.description.splitlines())[:150],
                         price_per_unit=str(round(result.price_per_unit, 2)),
                         is_public_service=result.is_public_service,
                         is_available=result.is_available,

--- a/arbeitszeit_web/query_plans.py
+++ b/arbeitszeit_web/query_plans.py
@@ -9,7 +9,7 @@ from arbeitszeit.use_cases.query_plans import (
 from arbeitszeit_web.translator import Translator
 
 from .notification import Notifier
-from .url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndex, PlanSummaryUrlIndex
+from .url_index import PlanSummaryUrlIndex
 
 
 class QueryPlansFormData(Protocol):
@@ -48,16 +48,12 @@ class QueryPlansController:
 
 @dataclass
 class ResultTableRow:
-    plan_id: str
     plan_summary_url: str
-    company_summary_url: str
-    coop_summary_url: Optional[str]
     company_name: str
     product_name: str
     description: List[str]
     price_per_unit: str
     type_of_plan: str
-    ends_in: str
     is_available: bool
     is_cooperating: bool
 
@@ -79,8 +75,6 @@ class QueryPlansViewModel:
 @dataclass
 class QueryPlansPresenter:
     plan_url_index: PlanSummaryUrlIndex
-    company_url_index: CompanySummaryUrlIndex
-    coop_url_index: CoopSummaryUrlIndex
     user_notifier: Notifier
     trans: Translator
 
@@ -92,18 +86,9 @@ class QueryPlansPresenter:
             results=ResultsTable(
                 rows=[
                     ResultTableRow(
-                        plan_id=str(result.plan_id),
                         plan_summary_url=self.plan_url_index.get_plan_summary_url(
                             result.plan_id
                         ),
-                        company_summary_url=self.company_url_index.get_company_summary_url(
-                            result.company_id
-                        ),
-                        coop_summary_url=self.coop_url_index.get_coop_summary_url(
-                            result.cooperation
-                        )
-                        if result.cooperation
-                        else None,
                         company_name=result.company_name,
                         product_name=result.product_name,
                         description=result.description.splitlines(),
@@ -111,10 +96,6 @@ class QueryPlansPresenter:
                         type_of_plan=self.trans.gettext("Public")
                         if result.is_public_service
                         else self.trans.gettext("Productive"),
-                        ends_in=self.trans.gettext("%(num)d days")
-                        % dict(num=result.expiration_relative)
-                        if result.expiration_relative is not None
-                        else "–",
                         is_available=result.is_available,
                         is_cooperating=result.is_cooperating,
                     )

--- a/arbeitszeit_web/query_plans.py
+++ b/arbeitszeit_web/query_plans.py
@@ -53,7 +53,7 @@ class ResultTableRow:
     product_name: str
     description: List[str]
     price_per_unit: str
-    type_of_plan: str
+    is_public_service: bool
     is_available: bool
     is_cooperating: bool
 
@@ -93,9 +93,7 @@ class QueryPlansPresenter:
                         product_name=result.product_name,
                         description=result.description.splitlines(),
                         price_per_unit=str(round(result.price_per_unit, 2)),
-                        type_of_plan=self.trans.gettext("Public")
-                        if result.is_public_service
-                        else self.trans.gettext("Productive"),
+                        is_public_service=result.is_public_service,
                         is_available=result.is_available,
                         is_cooperating=result.is_cooperating,
                     )

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -338,15 +338,11 @@ class PresenterTestsInjector(Module):
     def provide_query_plans_presenter(
         self,
         notifier: Notifier,
-        coop_url_index: CoopSummaryUrlIndexTestImpl,
         plan_url_index: PlanSummaryUrlIndexTestImpl,
-        company_url_index: CompanySummaryUrlIndex,
         translator: FakeTranslator,
     ) -> QueryPlansPresenter:
         return QueryPlansPresenter(
             plan_url_index=plan_url_index,
-            company_url_index=company_url_index,
-            coop_url_index=coop_url_index,
             user_notifier=notifier,
             trans=translator,
         )

--- a/tests/presenters/test_query_plans_presenter.py
+++ b/tests/presenters/test_query_plans_presenter.py
@@ -107,3 +107,11 @@ class QueryPlansPresenterTests(TestCase):
             table_row.is_cooperating,
             True,
         )
+
+    def test_public_service_bool_is_passed_on_to_view_model(self) -> None:
+        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
+        table_row = presentation.results.rows[0]
+        self.assertEqual(
+            table_row.is_public_service,
+            False,
+        )

--- a/tests/presenters/test_query_plans_presenter.py
+++ b/tests/presenters/test_query_plans_presenter.py
@@ -21,7 +21,7 @@ RESPONSE_WITH_ONE_RESULT = PlanQueryResponse(
             company_name="Planner name",
             company_id=uuid4(),
             product_name="Bread",
-            description="For eating",
+            description="For eating\nNext paragraph\rThird one Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.",
             price_per_unit=Decimal(5),
             is_public_service=False,
             is_available=True,
@@ -37,7 +37,7 @@ RESPONSE_WITH_ONE_COOPERATING_RESULT = PlanQueryResponse(
             company_name="Planner name",
             company_id=uuid4(),
             product_name="Bread",
-            description="For eating",
+            description="For eating\nNext paragraph\rThird one",
             price_per_unit=Decimal(5),
             is_public_service=False,
             is_available=True,
@@ -115,3 +115,16 @@ class QueryPlansPresenterTests(TestCase):
             table_row.is_public_service,
             False,
         )
+
+    def test_that_description_is_shown_without_line_returns(self) -> None:
+        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
+        table_row = presentation.results.rows[0]
+        self.assertIn("For eatingNext paragraphThird one", table_row.description)
+
+    def test_that_only_first_few_chars_of_description_are_shown(self) -> None:
+        expected_string = "For eatingNext paragraphThird one"
+        unexpected_string = "et accusam et justo duo dolores."
+        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
+        table_row = presentation.results.rows[0]
+        self.assertIn(expected_string, table_row.description)
+        self.assertNotIn(unexpected_string, table_row.description)

--- a/tests/presenters/test_query_plans_presenter.py
+++ b/tests/presenters/test_query_plans_presenter.py
@@ -24,10 +24,8 @@ RESPONSE_WITH_ONE_RESULT = PlanQueryResponse(
             description="For eating",
             price_per_unit=Decimal(5),
             is_public_service=False,
-            expiration_relative=14,
             is_available=True,
             is_cooperating=False,
-            cooperation=None,
         )
     ]
 )
@@ -42,10 +40,8 @@ RESPONSE_WITH_ONE_COOPERATING_RESULT = PlanQueryResponse(
             description="For eating",
             price_per_unit=Decimal(5),
             is_public_service=False,
-            expiration_relative=14,
             is_available=True,
             is_cooperating=True,
-            cooperation=uuid4(),
         )
     ]
 )
@@ -89,29 +85,25 @@ class QueryPlansPresenterTests(TestCase):
             self.plan_url_index.get_plan_summary_url(plan_id),
         )
 
-    def test_company_url(self) -> None:
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
-        company_id = RESPONSE_WITH_ONE_RESULT.results[0].company_id
-        table_row = presentation.results.rows[0]
-        self.assertEqual(
-            table_row.company_summary_url,
-            self.company_url_index.get_company_summary_url(company_id),
-        )
-
-    def test_no_coop_url_is_shown_with_one_non_cooperating_plan(self) -> None:
+    def test_company_name(self) -> None:
         presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
         table_row = presentation.results.rows[0]
         self.assertEqual(
-            table_row.coop_summary_url,
-            None,
+            table_row.company_name, RESPONSE_WITH_ONE_RESULT.results[0].company_name
         )
 
-    def test_coop_url_is_shown_with_one_cooperating_plan(self) -> None:
-        coop_id = RESPONSE_WITH_ONE_COOPERATING_RESULT.results[0].cooperation
-        assert coop_id
+    def test_no_coop_is_shown_with_one_non_cooperating_plan(self) -> None:
+        presentation = self.presenter.present(RESPONSE_WITH_ONE_RESULT)
+        table_row = presentation.results.rows[0]
+        self.assertEqual(
+            table_row.is_cooperating,
+            False,
+        )
+
+    def test_coop_is_shown_with_one_cooperating_plan(self) -> None:
         presentation = self.presenter.present(RESPONSE_WITH_ONE_COOPERATING_RESULT)
         table_row = presentation.results.rows[0]
         self.assertEqual(
-            table_row.coop_summary_url,
-            self.coop_url_index.get_coop_summary_url(coop_id),
+            table_row.is_cooperating,
+            True,
         )


### PR DESCRIPTION
This PR changes the look and some of the content of the query_plans page (overview of all active plans).

The idea is that only the info is shown that a user needs to see. The rest of the plan details are shown when the user clicks on the plan link.

What is not shown anymore:

- the complete description (only first 150 chars are shown)
- expiration info
- the plan id (it is still possible to search for the plan id though)
- url to company summary 
- url to coop summary

What is shown:

- Plan name
- Plan summary url
- Price
- Company name
- First 150 chars of plan description

In the following cases there is a "tag" (or badge) shown to provide additional information:

- if plan is public
- if plan is cooperating
- if product of plan is NOT available 

The layout has been changed by using Bulma's "Media Object" layout: https://bulma.io/documentation/layout/media-object/.

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c