### PR TITLE
Reworking "my plans" overview

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -816,13 +816,12 @@ class FlaskModule(Module):
     def provide_show_my_plans_presenter(
         self,
         plan_index: PlanSummaryUrlIndex,
-        coop_index: CoopSummaryUrlIndex,
         renew_plan_index: RenewPlanUrlIndex,
         hide_plan_index: HidePlanUrlIndex,
         translator: Translator,
     ) -> ShowMyPlansPresenter:
         return ShowMyPlansPresenter(
-            plan_index, coop_index, renew_plan_index, hide_plan_index, translator
+            plan_index, renew_plan_index, hide_plan_index, translator
         )
 
     @provider

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -5,15 +5,16 @@
 {% endblock %}
 
 {% block content %}
-<div class="section has-text-centered">
-  <div class="content">
-    <h1>{{ gettext("My plans") }}</h1>
-  </div>
-  <h1 class="title is-4">{{ gettext("Active")}}</h1>
+<div class="content has-text-centered">
+  <h1>{{ gettext("My plans") }}</h1>
+</div>
+
+<div class="section">
+  <h1 class="title is-4 has-text-centered">{{ gettext("Active")}}</h1>
   {% if show_active_plans %}
-  {% for plan in active_plans.rows %}
   <div class="columns is-centered has-text-left">
     <div class="column is-one-third">
+      {% for plan in active_plans.rows %}
       <article class="media">
         <div class="media-content">
           <div class="content">
@@ -39,20 +40,21 @@
           </div>
         </div>
         <div class="media-right">
-          <p class="is-size-5">
+          <p class="is-size-5 pt-1">
             {{ plan.price_per_unit }}
           </p>
         </div>
       </article>
+      {% endfor %}
     </div>
   </div>
-  {% endfor %}
   {% else %}
-  <p>{{ gettext("You don't have active plans.")}}</p>
+  <p class="has-text-centered">{{ gettext("You don't have active plans.")}}</p>
   {% endif %}
+</div>
 
-  <h1 class="title is-4">{{ gettext("Waiting")}}</h1>
-
+<div class="section">
+  <h1 class="title is-4 has-text-centered">{{ gettext("Waiting")}}</h1>
   <div class="table-container">
     {% if show_non_active_plans %}
     <table class="table is-fullwidth">
@@ -76,43 +78,42 @@
       </tbody>
     </table>
     {% else %}
-    <p>{{ gettext("You don't have plans waiting for activation.")}}</p>
+    <p class="has-text-centered">{{ gettext("You don't have plans waiting for activation.")}}</p>
     {% endif %}
   </div>
+</div>
 
-  <h1 class="title is-4">{{ gettext("Expired")}}</h1>
-
-  <div class="table-container">
-    {% if show_expired_plans %}
-    <table class="table is-fullwidth">
-      <thead>
-        <tr>
-          <th></th>
-          <th>{{ gettext("Type") }}</th>
-          <th>{{ gettext("Plan created") }}</th>
-          <th>{{ gettext("Renew plan") }}</th>
-          <th>{{ gettext("Hide plan")}}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for plan in expired_plans.rows %}
-        <tr>
-          <td><a href="{{ plan.plan_summary_url }}">{{ plan.prd_name }}</a></td>
-          <td>{{ plan.type_of_plan }}</td>
-          <td>{{ plan.plan_creation_date }}</td>
-          <td>
-            <a href="{{ plan.renew_plan_url }}"><i class="{{ 'fas fa-redo' }}"></i></a>
-          </td>
-          <td>
+<div class="section">
+  <h1 class="title is-4 has-text-centered">{{ gettext("Expired")}}</h1>
+  {% if show_expired_plans %}
+  <div class="columns is-centered has-text-left">
+    <div class="column is-one-third">
+      {% for plan in expired_plans.rows %}
+      <article class="media">
+        <div class="media-content">
+          <div class="content">
+            <p>
+              <strong class="is-size-5">
+                <a href="{{ plan.plan_summary_url }}">{{ plan.prd_name }}</a>
+              </strong>
+              <br>
+              <small><i class="fa-solid fa-calendar"></i>&nbsp;{{ plan.plan_creation_date }}</small>
+            </p>
+          </div>
+        </div>
+        <div class="media-right">
+          <div class="content pt-1">
+            <a href="{{ plan.renew_plan_url }}"><i class="fas fa-redo"></i></a>
+            &nbsp;
             <a href="{{ plan.hide_plan_url }}"><i class="fas fa-trash"></i></a>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    {% else %}
-    <p>{{ gettext("You don't have expired plans.") }}</p>
-    {% endif %}
+          </div>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
   </div>
+  {% else %}
+  <p class="has-text-centered">{{ gettext("You don't have expired plans.") }}</p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -10,46 +10,46 @@
     <h1>{{ gettext("My plans") }}</h1>
   </div>
   <h1 class="title is-4">{{ gettext("Active")}}</h1>
-  <div class="table-container">
-    {% if show_active_plans %}
-    <table class="table is-fullwidth">
-      <thead>
-        <tr>
-          <th></th>
-          <th>{{ gettext("Costs")}}</th>
-          <th>{{ gettext("Type")}}</th>
-          <th>{{ gettext("Planning timeframe")}}</th>
-          <th>{{ gettext("Ends in (days)")}}</th>
-          <th>{{ gettext("Product available")}}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for plan in active_plans.rows %}
-        <tr>
-          <td><a href="{{ plan.plan_summary_url }}">{{ plan.prd_name }}</a></td>
-          <td>{{ plan.price_per_unit }} {% if plan.is_cooperating %} <span><a href="{{ plan.coop_summary_url }}"><i
-                  class="fas fa-hands-helping"></i></a></span>{%
-            endif %}
-          </td>
-          <td>{{ plan.type_of_plan }}</td>
-          <td>{{ plan.activation_date }} - {{ plan.expiration_date }}</td>
-          <td>{{ plan.expiration_relative }}</td>
-          {% if plan.is_available %}
-          <td>
-            <span class="icon has-text-success"><i class="fas fa-circle"></i></span>
-          </td>
-          {% else %}
-          <td>
-            <span class="icon has-text-danger"><i class="fas fa-circle"></i></span>
-          </td>
-          {% endif %}
-          {% endfor %}
-      </tbody>
-    </table>
-    {% else %}
-    <p>{{ gettext("You don't have active plans.")}}</p>
-    {% endif %}
+  {% if show_active_plans %}
+  {% for plan in active_plans.rows %}
+  <div class="columns is-centered has-text-left">
+    <div class="column is-one-third">
+      <article class="media">
+        <div class="media-content">
+          <div class="content">
+            <p>
+              <strong class="is-size-5">
+                <a href="{{ plan.plan_summary_url }}">{{ plan.prd_name }}</a>
+              </strong>
+              <br>
+              <small><i class="fa-solid fa-calendar"></i>&nbsp;{{ plan.activation_date }}</small>
+              <small><i class="fa-solid fa-hourglass"></i>&nbsp;{{ plan.expiration_relative }}</small>
+            </p>
+          </div>
+          <div>
+            {% if not plan.is_available %}
+            <span class="tag is-danger">{{ gettext("Product not available") }}</span>
+            {% endif %}
+            {% if plan.is_cooperating %}
+            <span class="tag is-primary">{{ gettext("Cooperating plan") }}</span>
+            {% endif %}
+            {% if plan.is_public_service %}
+            <span class="tag is-warning">{{ gettext("Public") }}</span>
+            {% endif %}
+          </div>
+        </div>
+        <div class="media-right">
+          <p class="is-size-5">
+            {{ plan.price_per_unit }}
+          </p>
+        </div>
+      </article>
+    </div>
   </div>
+  {% endfor %}
+  {% else %}
+  <p>{{ gettext("You don't have active plans.")}}</p>
+  {% endif %}
 
   <h1 class="title is-4">{{ gettext("Waiting")}}</h1>
 

--- a/arbeitszeit_web/show_my_plans.py
+++ b/arbeitszeit_web/show_my_plans.py
@@ -45,10 +45,10 @@ class NonActivePlansTable:
 class ExpiredPlansRow:
     plan_summary_url: str
     prd_name: str
-    type_of_plan: str
     plan_creation_date: str
     renew_plan_url: str
     hide_plan_url: str
+    is_public_service: bool
 
 
 @dataclass
@@ -123,7 +123,7 @@ class ShowMyPlansPresenter:
                     ExpiredPlansRow(
                         plan_summary_url=self.url_index.get_plan_summary_url(plan.id),
                         prd_name=f"{plan.prd_name}",
-                        type_of_plan=self.__get_type_of_plan(plan.is_public_service),
+                        is_public_service=plan.is_public_service,
                         plan_creation_date=self.__format_date(plan.plan_creation_date),
                         renew_plan_url=self.renew_plan_url_index.get_renew_plan_url(
                             plan.id

--- a/arbeitszeit_web/show_my_plans.py
+++ b/arbeitszeit_web/show_my_plans.py
@@ -6,26 +6,20 @@ from typing import Any, Dict, List, Optional
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansResponse
 from arbeitszeit_web.translator import Translator
 
-from .url_index import (
-    CoopSummaryUrlIndex,
-    HidePlanUrlIndex,
-    PlanSummaryUrlIndex,
-    RenewPlanUrlIndex,
-)
+from .url_index import HidePlanUrlIndex, PlanSummaryUrlIndex, RenewPlanUrlIndex
 
 
 @dataclass
 class ActivePlansRow:
     plan_summary_url: str
-    coop_summary_url: Optional[str]
     prd_name: str
     price_per_unit: str
-    type_of_plan: str
     activation_date: str
     expiration_date: str
     expiration_relative: str
     is_available: bool
     is_cooperating: bool
+    is_public_service: bool
 
 
 @dataclass
@@ -79,7 +73,6 @@ class ShowMyPlansViewModel:
 @dataclass
 class ShowMyPlansPresenter:
     url_index: PlanSummaryUrlIndex
-    coop_url_index: CoopSummaryUrlIndex
     renew_plan_url_index: RenewPlanUrlIndex
     hide_plan_url_index: HidePlanUrlIndex
     translator: Translator
@@ -97,14 +90,8 @@ class ShowMyPlansPresenter:
                 rows=[
                     ActivePlansRow(
                         plan_summary_url=self.url_index.get_plan_summary_url(plan.id),
-                        coop_summary_url=self.coop_url_index.get_coop_summary_url(
-                            plan.cooperation
-                        )
-                        if plan.cooperation
-                        else None,
                         prd_name=f"{plan.prd_name}",
                         price_per_unit=self.__format_price(plan.price_per_unit),
-                        type_of_plan=self.__get_type_of_plan(plan.is_public_service),
                         activation_date=self.__format_date(plan.activation_date),
                         expiration_date=self.__format_date(plan.expiration_date),
                         expiration_relative=f"{plan.expiration_relative}"
@@ -112,6 +99,7 @@ class ShowMyPlansPresenter:
                         else "–",
                         is_available=plan.is_available,
                         is_cooperating=plan.is_cooperating,
+                        is_public_service=plan.is_public_service,
                     )
                     for plan in response.active_plans
                 ],

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -381,14 +381,12 @@ class PresenterTestsInjector(Module):
     def provide_show_my_plans_presenter(
         self,
         plan_url_index: PlanSummaryUrlIndexTestImpl,
-        coop_url_index: CoopSummaryUrlIndexTestImpl,
         renew_plan_url_index: RenewPlanUrlIndex,
         hide_plan_url_index: HidePlanUrlIndex,
         translator: FakeTranslator,
     ) -> ShowMyPlansPresenter:
         return ShowMyPlansPresenter(
             url_index=plan_url_index,
-            coop_url_index=coop_url_index,
             renew_plan_url_index=renew_plan_url_index,
             hide_plan_url_index=hide_plan_url_index,
             translator=translator,

--- a/tests/presenters/test_show_my_plans_presenter.py
+++ b/tests/presenters/test_show_my_plans_presenter.py
@@ -161,7 +161,7 @@ class ShowMyPlansPresenterTests(TestCase):
             row1.prd_name,
             expected_plan.prd_name,
         )
-        self.assertEqual(row1.type_of_plan, self.translator.gettext("Productive"))
+        self.assertEqual(row1.is_public_service, plan.is_public_service)
         self.assertEqual(
             row1.renew_plan_url, self.renew_plan_url_index.get_renew_plan_url(plan.id)
         )

--- a/tests/presenters/test_show_my_plans_presenter.py
+++ b/tests/presenters/test_show_my_plans_presenter.py
@@ -9,12 +9,7 @@ from tests.data_generators import CooperationGenerator, PlanGenerator
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
-from .url_index import (
-    CoopSummaryUrlIndexTestImpl,
-    HidePlanUrlIndex,
-    PlanSummaryUrlIndexTestImpl,
-    RenewPlanUrlIndex,
-)
+from .url_index import HidePlanUrlIndex, PlanSummaryUrlIndexTestImpl, RenewPlanUrlIndex
 
 
 def _convert_into_plan_info(plan: Plan) -> PlanInfo:
@@ -76,7 +71,6 @@ class ShowMyPlansPresenterTests(TestCase):
     def setUp(self):
         self.injector = get_dependency_injector()
         self.plan_url_index = self.injector.get(PlanSummaryUrlIndexTestImpl)
-        self.coop_url_index = self.injector.get(CoopSummaryUrlIndexTestImpl)
         self.renew_plan_url_index = self.injector.get(RenewPlanUrlIndex)
         self.hide_plan_url_index = self.injector.get(HidePlanUrlIndex)
         self.translator = self.injector.get(FakeTranslator)
@@ -123,17 +117,13 @@ class ShowMyPlansPresenterTests(TestCase):
             presentation.active_plans.rows[0].plan_summary_url,
             self.plan_url_index.get_plan_summary_url(plan.id),
         )
-        self.assertEqual(presentation.active_plans.rows[0].coop_summary_url, None)
         self.assertEqual(presentation.active_plans.rows[0].prd_name, plan.prd_name)
         self.assertEqual(
             presentation.active_plans.rows[0].price_per_unit,
             str("10.00"),
         )
         self.assertEqual(
-            presentation.active_plans.rows[0].type_of_plan,
-            self.translator.gettext("Public")
-            if plan.is_public_service
-            else self.translator.gettext("Productive"),
+            presentation.active_plans.rows[0].is_public_service, plan.is_public_service
         )
         self.assertEqual(
             presentation.active_plans.rows[0].is_available,
@@ -152,10 +142,6 @@ class ShowMyPlansPresenterTests(TestCase):
 
         RESPONSE_WITH_COOPERATING_PLAN = response_with_one_active_plan(plan)
         presentation = self.presenter.present(RESPONSE_WITH_COOPERATING_PLAN)
-        self.assertEqual(
-            presentation.active_plans.rows[0].coop_summary_url,
-            self.coop_url_index.get_coop_summary_url(coop.id),
-        )
         self.assertEqual(
             presentation.active_plans.rows[0].is_cooperating,
             True,


### PR DESCRIPTION
This PR changes the front end design of the "my plans" overview, making it responsive, very similar to "all plans" overview that has been redesigned already. 

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c