### PR TITLE
fix(#428): ROUND PAST PRICE OF COMPANIES

### DIFF
--- a/arbeitszeit_flask/templates/company/my_purchases.html
+++ b/arbeitszeit_flask/templates/company/my_purchases.html
@@ -40,9 +40,9 @@
           <td>{{ purchase.product_name }}</td>
           <td>{{ purchase.product_description }}</td>
           <td>{{ purchase.purpose }}</td>
-          <td>{{ purchase.price_per_unit }}</td>
+          <td>{{ purchase.price_per_unit|round(1) }}</td>
           <th>{{ purchase.amount }}</th>
-          <th>{{ purchase.price_total }}</th>
+          <th>{{ purchase.price_total|round(1) }}</th>
         </tr>
         {% endfor %}
         {% else %}


### PR DESCRIPTION
Update jinja2 template to round `price_per_unit` and `price_total` to 1 decimal place.

https://github.com/arbeitszeit/arbeitszeitapp/issues/428