### PR TITLE
Add more time information to plan summary

### DIFF
--- a/arbeitszeit/plan_summary.py
+++ b/arbeitszeit/plan_summary.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
@@ -30,6 +31,9 @@ class PlanSummary:
     is_available: bool
     is_cooperating: bool
     cooperation: Optional[UUID]
+    creation_date: datetime
+    approval_date: Optional[datetime]
+    expiration_date: Optional[datetime]
 
 
 @inject
@@ -60,4 +64,7 @@ class PlanSummaryService:
             is_available=plan.is_available,
             is_cooperating=bool(plan.cooperation),
             cooperation=plan.cooperation or None,
+            creation_date=plan.plan_creation_date,
+            approval_date=plan.approval_date,
+            expiration_date=plan.expiration_date,
         )

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -818,8 +818,11 @@ class FlaskModule(Module):
         coop_url_index: CoopSummaryUrlIndex,
         company_url_index: CompanySummaryUrlIndex,
         translator: Translator,
+        datetime_service: RealtimeDatetimeService,
     ) -> PlanSummaryServiceImpl:
-        return PlanSummaryServiceImpl(coop_url_index, company_url_index, translator)
+        return PlanSummaryServiceImpl(
+            coop_url_index, company_url_index, translator, datetime_service
+        )
 
     @provider
     def provide_query_companies_presenter(

--- a/arbeitszeit_flask/templates/macros/plan_summary.html
+++ b/arbeitszeit_flask/templates/macros/plan_summary.html
@@ -15,18 +15,21 @@
                                 <p class="title is-4">{{ view_model.summary.plan_id[0] }}</p>
                                 <p class="subtitle">{{ view_model.summary.plan_id[1] }}</p>
                             </article>
-                            <article class="tile is-child notification">
-                                <p class="title is-4">{{ view_model.summary.planner[0] }}</p>
-                                <p class="subtitle"><a href="{{ view_model.summary.planner[2] }}">{{
+                            <div class="tile">
+                                <div class="tile is-parent">
+                                    <article class="tile is-child notification">
+                                        <p class="title is-4">{{ view_model.summary.product_name[0] }}</p>
+                                        <p class="subtitle">{{ view_model.summary.product_name[1] }}</p>
+                                    </article>
+                                </div>
+                                <div class="tile is-parent">
+                                    <article class="tile is-child notification">
+                                        <p class="title is-4">{{ view_model.summary.planner[0] }}</p>
+                                        <p class="subtitle"><a href="{{ view_model.summary.planner[2] }}">{{
                                         view_model.summary.planner[3] }}</a></p>
-                            </article>
-                        </div>
-                        <div class="tile is-parent is-vertical">
-                            <article class="tile is-child notification">
-                                <p class="title is-4">{{ view_model.summary.product_name[0] }}</p>
-                                <p class="subtitle">{{ view_model.summary.product_name[1] }}</p>
-                            </article>
-                            <article class="tile is-child notification"></article>
+                                    </article>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/arbeitszeit_flask/templates/macros/plan_summary.html
+++ b/arbeitszeit_flask/templates/macros/plan_summary.html
@@ -64,7 +64,23 @@
                     </div>
                 </div>
             </div>
-
+            <div class="tile is-ancestor">
+                <div class="tile is-parent">
+                    <article class="tile is-child notification">
+                        <div class="columns subtitle is-italic">
+                            <div class="column"><span
+                                    class="has-text-weight-semibold">{{  gettext("Plan creation") }}</span>
+                                {{ view_model.summary.creation_date }}</div>
+                            <div class="column"><span
+                                    class="has-text-weight-semibold">{{  gettext("Plan approval") }}</span>
+                                {{ view_model.summary.approval_date }}</div>
+                            <div class="column"><span
+                                    class="has-text-weight-semibold">{{  gettext("Plan expiration") }}</span>
+                                {{ view_model.summary.expiration_date }}</div>
+                        </div>
+                    </article>
+                </div>
+            </div>
         </div>
 
         <div class="box">

--- a/arbeitszeit_web/plan_summary_service.py
+++ b/arbeitszeit_web/plan_summary_service.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Optional, Protocol, Tuple
 
+from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit_web.url_index import CompanySummaryUrlIndex, CoopSummaryUrlIndex
 
@@ -25,6 +26,9 @@ class PlanSummaryWeb:
     type_of_plan: Tuple[str, str]
     price_per_unit: Tuple[str, str, bool, Optional[str]]
     availability_string: Tuple[str, str]
+    creation_date: str
+    approval_date: str
+    expiration_date: str
 
 
 class PlanSummaryService(Protocol):
@@ -37,6 +41,7 @@ class PlanSummaryServiceImpl:
     coop_url_index: CoopSummaryUrlIndex
     company_url_index: CompanySummaryUrlIndex
     translator: Translator
+    datetime_service: DatetimeService
 
     def get_plan_summary(self, plan_summary: PlanSummary) -> PlanSummaryWeb:
         return PlanSummaryWeb(
@@ -103,6 +108,25 @@ class PlanSummaryServiceImpl:
                 if plan_summary.is_available
                 else self.translator.gettext("No"),
             ),
+            creation_date=self.datetime_service.format_datetime(
+                date=plan_summary.creation_date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
+            ),
+            approval_date=self.datetime_service.format_datetime(
+                date=plan_summary.approval_date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
+            )
+            if plan_summary.approval_date
+            else "-",
+            expiration_date=self.datetime_service.format_datetime(
+                date=plan_summary.expiration_date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
+            )
+            if plan_summary.expiration_date
+            else "-",
         )
 
     def _format_price(self, price_per_unit: Decimal) -> str:

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -239,11 +239,13 @@ class PresenterTestsInjector(Module):
         coop_url_index: CoopSummaryUrlIndexTestImpl,
         company_url_index: CompanySummaryUrlIndex,
         translator: FakeTranslator,
+        datetime_service: FakeDatetimeService,
     ) -> PlanSummaryService:
         return PlanSummaryServiceImpl(
             coop_url_index=coop_url_index,
             company_url_index=company_url_index,
             translator=translator,
+            datetime_service=datetime_service,
         )
 
     @provider
@@ -326,11 +328,13 @@ class PresenterTestsInjector(Module):
         coop_url_index: CoopSummaryUrlIndexTestImpl,
         company_url_index: CompanySummaryUrlIndex,
         translator: FakeTranslator,
+        datetime_service: FakeDatetimeService,
     ) -> PlanSummaryServiceImpl:
         return PlanSummaryServiceImpl(
             coop_url_index=coop_url_index,
             company_url_index=company_url_index,
             translator=translator,
+            datetime_service=datetime_service,
         )
 
     @provider

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from datetime import datetime
 from decimal import Decimal
 from unittest import TestCase
 from uuid import uuid4
@@ -36,6 +37,9 @@ TESTING_RESPONSE_MODEL = GetPlanSummaryCompany.Success(
         is_available=True,
         is_cooperating=True,
         cooperation=uuid4(),
+        creation_date=datetime.now(),
+        approval_date=None,
+        expiration_date=None,
     ),
     current_user_is_planner=True,
 )

--- a/tests/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/presenters/test_get_prefilled_draft_data_presenter.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -26,6 +27,9 @@ PLAN_SUMMARY = PlanSummary(
     is_available=True,
     is_cooperating=False,
     cooperation=None,
+    creation_date=datetime.now(),
+    approval_date=None,
+    expiration_date=None,
 )
 
 TEST_DRAFT_SUMMARY_SUCCESS = DraftSummarySuccess(

--- a/tests/services/test_plan_summary_service.py
+++ b/tests/services/test_plan_summary_service.py
@@ -1,0 +1,158 @@
+from datetime import datetime
+from decimal import Decimal
+from unittest import TestCase
+
+from arbeitszeit.entities import ProductionCosts
+from arbeitszeit.plan_summary import PlanSummaryService
+from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
+from tests.data_generators import CooperationGenerator, PlanGenerator
+from tests.datetime_service import FakeDatetimeService
+from tests.use_cases.dependency_injection import get_dependency_injector
+
+
+class PlanSummaryServiceTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.service = self.injector.get(PlanSummaryService)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.coop_generator = self.injector.get(CooperationGenerator)
+        self.plan = self.plan_generator.create_plan()
+        self.summary = self.service.get_summary_from_plan(self.plan)
+        self.payout_use_case = self.injector.get(UpdatePlansAndPayout)
+        self.datetime_service = self.injector.get(FakeDatetimeService)
+
+    def test_that_correct_planner_id_is_shown(self):
+        self.assertEqual(self.summary.plan_id, self.plan.id)
+
+    def test_that_correct_planner_name_is_shown(self):
+        self.assertEqual(self.summary.planner_name, self.plan.planner.name)
+
+    def test_that_correct_active_status_is_shown_when_plan_is_inactive(self):
+        assert not self.plan.is_active
+        self.assertFalse(self.summary.is_active)
+
+    def test_that_correct_active_status_is_shown_when_plan_is_active(self):
+        plan = self.plan_generator.create_plan(activation_date=datetime.min)
+        assert plan.is_active
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertTrue(summary.is_active)
+
+    def test_that_correct_production_costs_are_shown(self):
+        plan = self.plan_generator.create_plan(
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            )
+        )
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.means_cost, Decimal(1))
+        self.assertEqual(summary.labour_cost, Decimal(2))
+        self.assertEqual(summary.resources_cost, Decimal(3))
+
+    def test_that_correct_price_per_unit_of_zero_is_shown_when_plan_is_public_service(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.price_per_unit, Decimal(0))
+
+    def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(self):
+        plan = self.plan_generator.create_plan(
+            is_public_service=False,
+            amount=2,
+            costs=ProductionCosts(
+                means_cost=Decimal(1),
+                labour_cost=Decimal(2),
+                resource_cost=Decimal(3),
+            ),
+        )
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.price_per_unit, Decimal(3))
+
+    def test_that_correct_product_name_is_shown(self):
+        self.assertEqual(self.summary.product_name, self.plan.prd_name)
+
+    def test_that_correct_product_description_is_shown(self):
+        self.assertEqual(self.summary.description, self.plan.description)
+
+    def test_that_correct_product_unit_is_shown(self):
+        self.assertEqual(self.summary.production_unit, self.plan.prd_unit)
+
+    def test_that_correct_amount_is_shown(self):
+        plan = self.plan_generator.create_plan(amount=123)
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.amount, 123)
+
+    def test_that_correct_public_service_is_shown(self):
+        plan = self.plan_generator.create_plan(is_public_service=True)
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertTrue(summary.is_public_service)
+
+    def test_that_correct_availability_is_shown(self):
+        plan = self.plan_generator.create_plan()
+        assert plan.is_available
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertTrue(summary.is_available)
+
+    def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(self):
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=None
+        )
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertFalse(summary.is_cooperating)
+        self.assertIsNone(summary.cooperation)
+
+    def test_that_correct_cooperation_is_shown(self):
+        coop = self.coop_generator.create_cooperation()
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.min, cooperation=coop
+        )
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertTrue(summary.is_cooperating)
+        self.assertEqual(summary.cooperation, coop.id)
+
+    def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self):
+        plan = self.plan_generator.create_plan(activation_date=None)
+        self.payout_use_case()
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.active_days, 0)
+
+    def test_that_zero_active_days_is_shown_if_plan_is_active_since_less_than_one_day(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now()
+        )
+        self.payout_use_case()
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.active_days, 0)
+
+    def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_25_hours()
+        )
+        self.payout_use_case()
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.active_days, 1)
+
+    def test_that_a_plans_timeframe_is_shown_as_active_days_if_plan_is_expired(
+        self,
+    ):
+        timeframe = 7
+        plan = self.plan_generator.create_plan(
+            activation_date=self.datetime_service.now_minus_ten_days(),
+            timeframe=timeframe,
+        )
+        self.payout_use_case()
+        summary = self.service.get_summary_from_plan(plan)
+        self.assertEqual(summary.active_days, timeframe)

--- a/tests/use_cases/test_get_plan_summary_company.py
+++ b/tests/use_cases/test_get_plan_summary_company.py
@@ -1,15 +1,8 @@
-from datetime import datetime
-from decimal import Decimal
-from typing import Callable, Union
 from unittest import TestCase
 from uuid import uuid4
 
-from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit.use_cases import GetPlanSummaryCompany
-from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.data_generators import CompanyGenerator, PlanGenerator
 
 from .dependency_injection import get_dependency_injector
 
@@ -20,8 +13,6 @@ class Tests(TestCase):
         self.plan_generator = self.injector.get(PlanGenerator)
         self.get_plan_summary_company = self.injector.get(GetPlanSummaryCompany)
         self.company_generator = self.injector.get(CompanyGenerator)
-        self.payout_use_case = self.injector.get(UpdatePlansAndPayout)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_current_user_is_correctly_shown_as_planner(self):
         planner_and_current_user = self.company_generator.create_company()
@@ -37,102 +28,6 @@ class Tests(TestCase):
         assert isinstance(response, GetPlanSummaryCompany.Success)
         assert not response.current_user_is_planner
 
-    def test_that_correct_planner_id_is_shown(self):
-        planner = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(planner=planner)
-        response = self.get_plan_summary_company(plan.id, planner.id)
-        assert_success(response, lambda s: s.planner_id == plan.planner.id)
-
-    def test_that_correct_active_status_is_shown_when_plan_is_inactive(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(activation_date=None)
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_active == False)
-
-    def test_that_correct_active_status_is_shown_when_plan_is_active(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(activation_date=datetime.min)
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_active == True)
-
-    def test_that_correct_production_costs_are_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            )
-        )
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(
-            response,
-            lambda s: all(
-                [
-                    s.means_cost == Decimal(1),
-                    s.labour_cost == Decimal(2),
-                    s.resources_cost == Decimal(3),
-                ]
-            ),
-        )
-
-    def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            is_public_service=True,
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            ),
-        )
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.price_per_unit == Decimal(0))
-
-    def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            is_public_service=False,
-            amount=2,
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            ),
-        )
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.price_per_unit == Decimal(3))
-
-    def test_that_correct_product_name_is_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(product_name="test product")
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.product_name == "test product")
-
-    def test_that_correct_product_description_is_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(description="test description")
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.description == "test description")
-
-    def test_that_correct_product_unit_is_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(production_unit="test unit")
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.production_unit == "test unit")
-
-    def test_that_correct_amount_is_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(amount=123)
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.amount == 123)
-
-    def test_that_correct_public_service_is_shown(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(is_public_service=True)
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_public_service == True)
-
     def test_that_failure_is_returned_when_plan_does_not_exist(self):
         current_user = self.company_generator.create_company()
         self.assertIsInstance(
@@ -140,80 +35,17 @@ class Tests(TestCase):
             GetPlanSummaryCompany.Failure,
         )
 
-    def test_that_correct_availability_is_shown(self):
+    def test_plan_summary_success_is_returned_when_plan_exists(self):
         current_user = self.company_generator.create_company()
         plan = self.plan_generator.create_plan()
-        assert plan.is_available
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_available == True)
-
-    def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            activation_date=datetime.min, cooperation=None
+        self.assertIsInstance(
+            self.get_plan_summary_company(plan.id, current_user.id),
+            GetPlanSummaryCompany.Success,
         )
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_cooperating == False)
-        assert_success(response, lambda s: s.cooperation is None)
 
-    def test_that_correct_cooperation_is_shown(self):
-        coop_generator = self.injector.get(CooperationGenerator)
+    def test_plan_summary_is_returned_when_plan_exists(self):
         current_user = self.company_generator.create_company()
-        coop = coop_generator.create_cooperation()
-        plan = self.plan_generator.create_plan(
-            activation_date=datetime.min, cooperation=coop
-        )
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.is_cooperating == True)
-        assert_success(response, lambda s: s.cooperation == coop.id)
-
-    def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(activation_date=None)
-        self.payout_use_case()
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.active_days == 0)
-
-    def test_that_zero_active_days_is_shown_if_plan_is_active_since_less_than_one_day(
-        self,
-    ):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now()
-        )
-        self.payout_use_case()
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.active_days == 0)
-
-    def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
-        self,
-    ):
-        current_user = self.company_generator.create_company()
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now_minus_25_hours()
-        )
-        self.payout_use_case()
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.active_days == 1)
-
-    def test_that_a_plans_timeframe_is_shown_as_active_days_if_plan_is_expired(
-        self,
-    ):
-        current_user = self.company_generator.create_company()
-        timeframe = 7
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now_minus_ten_days(),
-            timeframe=timeframe,
-        )
-        self.payout_use_case()
-        response = self.get_plan_summary_company(plan.id, current_user.id)
-        assert_success(response, lambda s: s.active_days == timeframe)
-
-
-def assert_success(
-    response: Union[GetPlanSummaryCompany.Success, GetPlanSummaryCompany.Failure],
-    assertion: Callable[[PlanSummary], bool],
-) -> None:
-    assert isinstance(response, GetPlanSummaryCompany.Success)
-    assert isinstance(response.plan_summary, PlanSummary)
-    assert assertion(response.plan_summary)
+        plan = self.plan_generator.create_plan()
+        plan_summary_success = self.get_plan_summary_company(plan.id, current_user.id)
+        assert isinstance(plan_summary_success, GetPlanSummaryCompany.Success)
+        self.assertTrue(plan_summary_success.plan_summary)

--- a/tests/use_cases/test_get_plan_summary_member.py
+++ b/tests/use_cases/test_get_plan_summary_member.py
@@ -1,15 +1,8 @@
-from datetime import datetime
-from decimal import Decimal
-from typing import Callable, Union
 from unittest import TestCase
 from uuid import uuid4
 
-from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit.use_cases import GetPlanSummaryMember
-from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.data_generators import CompanyGenerator, PlanGenerator
 
 from .dependency_injection import get_dependency_injector
 
@@ -17,173 +10,20 @@ from .dependency_injection import get_dependency_injector
 class UseCaseTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.company_generator = self.injector.get(CompanyGenerator)
         self.use_case = self.injector.get(GetPlanSummaryMember)
-        self.payout_use_case = self.injector.get(UpdatePlansAndPayout)
         self.company = self.company_generator.create_company()
-
-    def test_that_correct_planner_name_is_shown(self):
-        plan = self.plan_generator.create_plan(planner=self.company)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.planner_name == plan.planner.name)
-
-    def test_that_correct_planner_id_is_shown(self):
-        plan = self.plan_generator.create_plan(planner=self.company)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.planner_id == plan.planner.id)
-
-    def test_that_correct_active_status_is_shown_when_plan_is_inactive(self):
-        plan = self.plan_generator.create_plan(activation_date=None)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_active == False)
-
-    def test_that_correct_active_status_is_shown_when_plan_is_active(self):
-        plan = self.plan_generator.create_plan(activation_date=datetime.min)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_active == True)
-
-    def test_that_correct_production_costs_are_shown(self):
-        plan = self.plan_generator.create_plan(
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            )
-        )
-        summary = self.use_case(plan.id)
-        self.assert_success(
-            summary,
-            lambda s: all(
-                [
-                    s.means_cost == Decimal(1),
-                    s.labour_cost == Decimal(2),
-                    s.resources_cost == Decimal(3),
-                ]
-            ),
-        )
-
-    def test_that_correct_price_per_unit_is_shown_when_plan_is_public_service(self):
-        plan = self.plan_generator.create_plan(
-            is_public_service=True,
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            ),
-        )
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.price_per_unit == Decimal(0))
-
-    def test_that_correct_price_per_unit_is_shown_when_plan_is_productive(self):
-        plan = self.plan_generator.create_plan(
-            is_public_service=False,
-            amount=2,
-            costs=ProductionCosts(
-                means_cost=Decimal(1),
-                labour_cost=Decimal(2),
-                resource_cost=Decimal(3),
-            ),
-        )
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.price_per_unit == Decimal(3))
-
-    def test_that_correct_product_name_is_shown(self):
-        plan = self.plan_generator.create_plan(product_name="test product")
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.product_name == "test product")
-
-    def test_that_correct_product_description_is_shown(self):
-        plan = self.plan_generator.create_plan(description="test description")
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.description == "test description")
-
-    def test_that_correct_product_unit_is_shown(self):
-        plan = self.plan_generator.create_plan(production_unit="test unit")
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.production_unit == "test unit")
-
-    def test_that_correct_amount_is_shown(self):
-        plan = self.plan_generator.create_plan(amount=123)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.amount == 123)
-
-    def test_that_correct_public_service_is_shown(self):
-        plan = self.plan_generator.create_plan(is_public_service=True)
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_public_service == True)
 
     def test_that_failure_is_returned_when_plan_does_not_exist(self) -> None:
         self.assertIsInstance(self.use_case(uuid4()), GetPlanSummaryMember.Failure)
 
-    def test_that_correct_availability_is_shown(self):
+    def test_plan_summary_success_is_returned_when_plan_exists(self):
         plan = self.plan_generator.create_plan()
-        assert plan.is_available
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_available == True)
+        self.assertIsInstance(self.use_case(plan.id), GetPlanSummaryMember.Success)
 
-    def test_that_no_cooperation_is_shown_when_plan_is_not_cooperating(self):
-        plan = self.plan_generator.create_plan(
-            activation_date=datetime.min, cooperation=None
-        )
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_cooperating == False)
-        self.assert_success(summary, lambda s: s.cooperation is None)
-
-    def test_that_correct_cooperation_is_shown(self):
-        coop_generator = self.injector.get(CooperationGenerator)
-        coop = coop_generator.create_cooperation()
-        plan = self.plan_generator.create_plan(
-            activation_date=datetime.min, cooperation=coop
-        )
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.is_cooperating == True)
-        self.assert_success(summary, lambda s: s.cooperation == coop.id)
-
-    def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self):
-        plan = self.plan_generator.create_plan(activation_date=None)
-        self.payout_use_case()
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.active_days == 0)
-
-    def test_that_zero_active_days_is_shown_if_plan_is_active_since_less_than_one_day(
-        self,
-    ):
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now()
-        )
-        self.payout_use_case()
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.active_days == 0)
-
-    def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
-        self,
-    ):
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now_minus_25_hours()
-        )
-        self.payout_use_case()
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.active_days == 1)
-
-    def test_that_a_plans_timeframe_is_shown_as_active_days_if_plan_is_expired(
-        self,
-    ):
-        timeframe = 7
-        plan = self.plan_generator.create_plan(
-            activation_date=self.datetime_service.now_minus_ten_days(),
-            timeframe=timeframe,
-        )
-        self.payout_use_case()
-        summary = self.use_case(plan.id)
-        self.assert_success(summary, lambda s: s.active_days == timeframe)
-
-    def assert_success(
-        self,
-        response: Union[GetPlanSummaryMember.Success, GetPlanSummaryMember.Failure],
-        assertion: Callable[[PlanSummary], bool],
-    ) -> None:
-        assert isinstance(response, GetPlanSummaryMember.Success)
-        assert isinstance(response.plan_summary, PlanSummary)
-        assert assertion(response.plan_summary)
+    def test_plan_summary_is_returned_when_plan_exists(self):
+        plan = self.plan_generator.create_plan()
+        plan_summary_success = self.use_case(plan.id)
+        assert isinstance(plan_summary_success, GetPlanSummaryMember.Success)
+        self.assertTrue(plan_summary_success.plan_summary)


### PR DESCRIPTION
This PR adds some more essential information to the plan summary page, namely plan creation, plan approval and plan expiration dates. 

Also some refactoring of the plan summary use case tests have been made which reduced code duplication.

Plan-ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c

![image](https://user-images.githubusercontent.com/61537351/174507030-c53ee896-8266-405b-a2b0-2abf4bc9e944.png)
