### PR TITLE
Enabling sorting of results of QueryPlans

### DIFF
--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -58,11 +58,25 @@ class PlanSearchForm(Form):
         ],
     )
 
+    choices_radio = [
+        ("activation", trans.lazy_gettext("Newest")),
+        ("company_name", trans.lazy_gettext("Company name")),
+        ("price", trans.lazy_gettext("Lowest cost")),
+    ]
+    radio = RadioField(
+        choices=choices_radio,
+        default="activation",
+        validators=[FieldMustExist(message=trans.lazy_gettext("Required"))],
+    )
+
     def get_query_string(self) -> str:
         return self.data["search"]
 
     def get_category_string(self) -> str:
         return self.data["select"]
+
+    def get_radio_string(self) -> str:
+        return self.data["radio"]
 
 
 class RegisterForm(Form):

--- a/arbeitszeit_flask/templates/macros/query_plans.html
+++ b/arbeitszeit_flask/templates/macros/query_plans.html
@@ -20,6 +20,14 @@
                         {{ form.search(class_="input is-large") }}
                     </div>
                 </div>
+                <p class="has-text-weight-semibold">Sort by:</p>
+                <div class="field">
+                    <div class="control">
+                        {% for subfield in form.radio %}
+                        <span>{{ subfield }} {{ subfield.label }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
                 <button class="button is-block is-primary is-large is-fullwidth">
                     Suche
                 </button>

--- a/tests/controllers/test_query_plans_controller.py
+++ b/tests/controllers/test_query_plans_controller.py
@@ -5,6 +5,7 @@ from typing import Optional
 from unittest import TestCase
 
 from arbeitszeit.use_cases import PlanFilter
+from arbeitszeit.use_cases.query_plans import PlanSorting
 from arbeitszeit_web.query_plans import QueryPlansController
 
 
@@ -58,12 +59,46 @@ class QueryPlansControllerTests(TestCase):
         request = self.controller.import_form_data(form=None)
         self.assertTrue(request.get_query_string() is None)
 
+    def test_that_empty_sorting_field_results_in_sorting_by_activation_date(
+        self,
+    ) -> None:
+        request = self.controller.import_form_data(form=None)
+        self.assertEqual(request.get_sorting_category(), PlanSorting.by_activation)
+
+    def test_that_nonexisting_sorting_field_results_in_sorting_by_activation_date(
+        self,
+    ) -> None:
+        request = self.controller.import_form_data(
+            form=make_fake_form(sorting_category="somethingjsbjbsd")
+        )
+        self.assertEqual(request.get_sorting_category(), PlanSorting.by_activation)
+
+    def test_that_company_name_in_sorting_field_results_in_sorting_by_company_name(
+        self,
+    ) -> None:
+        request = self.controller.import_form_data(
+            form=make_fake_form(sorting_category="company_name")
+        )
+        self.assertEqual(request.get_sorting_category(), PlanSorting.by_company_name)
+
+    def test_that_price_in_sorting_field_results_in_sorting_by_price(
+        self,
+    ) -> None:
+        request = self.controller.import_form_data(
+            form=make_fake_form(sorting_category="price")
+        )
+        self.assertEqual(request.get_sorting_category(), PlanSorting.by_price)
+
 
 def make_fake_form(
-    query: Optional[str] = None, filter_category: Optional[str] = None
+    query: Optional[str] = None,
+    filter_category: Optional[str] = None,
+    sorting_category: Optional[str] = None,
 ) -> FakeQueryPlansForm:
     return FakeQueryPlansForm(
-        query=query or "", products_filter=filter_category or "Produktname"
+        query=query or "",
+        products_filter=filter_category or "Produktname",
+        sorting_category=sorting_category or "activation",
     )
 
 
@@ -71,9 +106,13 @@ def make_fake_form(
 class FakeQueryPlansForm:
     query: str
     products_filter: str
+    sorting_category: str
 
     def get_query_string(self) -> str:
         return self.query
 
     def get_category_string(self) -> str:
         return self.products_filter
+
+    def get_radio_string(self) -> str:
+        return self.sorting_category

--- a/tests/flask_integration/test_query_plan_view.py
+++ b/tests/flask_integration/test_query_plan_view.py
@@ -6,10 +6,7 @@ class AuthenticatedMemberTests(ViewTestCase):
         super().setUp()
         self.url = "/member/query_plans"
         self.company_url = "/company/query_plans"
-        self.default_data = dict(
-            select="Produktname",
-            search="",
-        )
+        self.default_data = dict(select="Produktname", search="", radio="activation")
         self.member, _, self.email = self.login_member()
         self.member = self.confirm_member(member=self.member, email=self.email)
 
@@ -17,13 +14,18 @@ class AuthenticatedMemberTests(ViewTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
-    def test_can_posting_empty_search_string_is_valid(self):
+    def test_posting_empty_search_string_is_valid(self):
         self.default_data["search"] = ""
         response = self.client.post(self.url, data=self.default_data)
         self.assertEqual(response.status_code, 200)
 
     def test_posting_query_without_query_string_is_invalid(self):
         self.default_data.pop("search")
+        response = self.client.post(self.url, data=self.default_data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_posting_query_without_sorting_category_is_invalid(self):
+        self.default_data.pop("radio")
         response = self.client.post(self.url, data=self.default_data)
         self.assertEqual(response.status_code, 400)
 

--- a/tests/presenters/test_query_plans_presenter.py
+++ b/tests/presenters/test_query_plans_presenter.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 from typing import List
 from unittest import TestCase
@@ -142,6 +143,7 @@ class QueryPlansPresenterTests(TestCase):
             is_public_service=False,
             is_available=True,
             is_cooperating=is_cooperating,
+            activation_date=datetime.min,
         )
 
     def _get_response(self, queried_plans: List[QueriedPlan]) -> PlanQueryResponse:

--- a/tests/use_cases/test_query_plans.py
+++ b/tests/use_cases/test_query_plans.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional
 
-from arbeitszeit.entities import Plan
+from arbeitszeit.entities import Plan, ProductionCosts
 from arbeitszeit.use_cases import (
     PlanFilter,
     PlanQueryResponse,
     QueryPlans,
     QueryPlansRequest,
 )
-from tests.data_generators import PlanGenerator
+from arbeitszeit.use_cases.query_plans import PlanSorting
+from tests.data_generators import CompanyGenerator, PlanGenerator
+from tests.datetime_service import FakeDatetimeService
 
 from .dependency_injection import injection_test
 
@@ -20,6 +23,7 @@ def plan_in_results(plan: Plan, response: PlanQueryResponse) -> bool:
             plan.id == result.plan_id
             and plan.prd_name == result.product_name
             and plan.planner.id == result.company_id
+            and plan.activation_date == result.activation_date
             for result in response.results
         )
     )
@@ -120,10 +124,114 @@ def test_query_with_substring_of_product_is_case_insensitive(
     assert plan_in_results(expected_plan, response)
 
 
-def make_request(query: Optional[str], category: PlanFilter):
+@injection_test
+def test_that_plans_are_returned_in_order_of_activation_when_requested_with_newest_plan_first(
+    query_plans: QueryPlans,
+    plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+):
+    expected_second = plan_generator.create_plan(
+        activation_date=datetime_service.now_minus_20_hours()
+    )
+    expected_first = plan_generator.create_plan(activation_date=datetime_service.now())
+    expected_third = plan_generator.create_plan(
+        activation_date=datetime_service.now_minus_two_days()
+    )
+    response = query_plans(make_request(sorting=PlanSorting.by_activation))
+    assert response.results[0].plan_id == expected_first.id
+    assert response.results[1].plan_id == expected_second.id
+    assert response.results[2].plan_id == expected_third.id
+
+
+@injection_test
+def test_that_plans_are_returned_in_order_of_price_when_requested_with_cheapest_product_first(
+    query_plans: QueryPlans,
+    plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+):
+    expected_second = plan_generator.create_plan(
+        activation_date=datetime_service.now(),
+        costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+    )
+    expected_first = plan_generator.create_plan(
+        activation_date=datetime_service.now(),
+        costs=ProductionCosts(Decimal(0), Decimal(0), Decimal(0)),
+    )
+    expected_third = plan_generator.create_plan(
+        activation_date=datetime_service.now(),
+        costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+    )
+    response = query_plans(make_request(sorting=PlanSorting.by_price))
+    assert response.results[0].plan_id == expected_first.id
+    assert response.results[1].plan_id == expected_second.id
+    assert response.results[2].plan_id == expected_third.id
+
+
+@injection_test
+def test_that_plans_are_returned_in_order_of_company_name_when_requested(
+    query_plans: QueryPlans,
+    plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    company_generator: CompanyGenerator,
+):
+    for name in ["c_name", "a_name", "B_name"]:
+        plan_generator.create_plan(
+            activation_date=datetime_service.now(),
+            planner=company_generator.create_company(name=name),
+        )
+    response = query_plans(make_request(sorting=PlanSorting.by_company_name))
+    assert response.results[0].company_name == "a_name"
+    assert response.results[1].company_name == "B_name"
+    assert response.results[2].company_name == "c_name"
+
+
+@injection_test
+def test_that_filtered_plans_by_name_are_returned_in_order_of_activation(
+    query_plans: QueryPlans,
+    plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+):
+    expected_second = plan_generator.create_plan(
+        activation_date=datetime_service.now_minus_20_hours(), product_name="abcde"
+    )
+    expected_first = plan_generator.create_plan(
+        activation_date=datetime_service.now(), product_name="xyabc"
+    )
+    # unexpected plan
+    plan_generator.create_plan(
+        activation_date=datetime_service.now_minus_two_days(), product_name="cba"
+    )
+    response = query_plans(
+        make_request(
+            sorting=PlanSorting.by_activation,
+            category=PlanFilter.by_product_name,
+            query="abc",
+        )
+    )
+    assert len(response.results) == 2
+    assert response.results[0].plan_id == expected_first.id
+    assert response.results[1].plan_id == expected_second.id
+
+
+@injection_test
+def test_that_correct_price_per_unit_of_zero_is_displayed_for_a_public_plan(
+    query_plans: QueryPlans,
+    plan_generator: PlanGenerator,
+):
+    plan_generator.create_plan(is_public_service=True, activation_date=datetime.min)
+    response = query_plans(make_request())
+    assert response.results[0].price_per_unit == 0
+
+
+def make_request(
+    query: Optional[str] = None,
+    category: PlanFilter = None,
+    sorting: PlanSorting = None,
+):
     return QueryPlansRequestTestImpl(
-        query=query,
-        filter_category=category,
+        query=query or "",
+        filter_category=category or PlanFilter.by_product_name,
+        sorting_category=sorting or PlanSorting.by_activation,
     )
 
 
@@ -131,9 +239,13 @@ def make_request(query: Optional[str], category: PlanFilter):
 class QueryPlansRequestTestImpl(QueryPlansRequest):
     query: Optional[str]
     filter_category: PlanFilter
+    sorting_category: PlanSorting
 
     def get_query_string(self) -> Optional[str]:
         return self.query
 
     def get_filter_category(self) -> PlanFilter:
         return self.filter_category
+
+    def get_sorting_category(self) -> PlanSorting:
+        return self.sorting_category


### PR DESCRIPTION
fixes #418

This PR enables sorting when querying all active plans. The user can sort the results by activation date, company name or price. By default plans are sorted by activation date (newest plans first).

This PR should close #418. It is still an open question though if we need product categories. 

Plan ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c