### PR TITLE
Move datetime formatting into presenters

### DIFF
--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -202,9 +202,11 @@ class CompanyPresenterModule(Module):
 
     @provider
     def provide_get_company_transactions_presenter(
-        self, translator: Translator
+        self, translator: Translator, datetime_service: DatetimeService
     ) -> GetCompanyTransactionsPresenter:
-        return GetCompanyTransactionsPresenter(translator=translator)
+        return GetCompanyTransactionsPresenter(
+            translator=translator, datetime_service=datetime_service
+        )
 
 
 class PresenterModule(Module):

--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -467,9 +467,10 @@ class PresenterModule(Module):
         plan_index: PlanSummaryUrlIndex,
         translator: Translator,
         control_thresholds: ControlThresholdsFlask,
+        datetime_service: DatetimeService,
     ) -> GetCompanySummarySuccessPresenter:
         return GetCompanySummarySuccessPresenter(
-            plan_index, translator, control_thresholds
+            plan_index, translator, control_thresholds, datetime_service
         )
 
     @provider

--- a/arbeitszeit_flask/templates/company/list_all_transactions.html
+++ b/arbeitszeit_flask/templates/company/list_all_transactions.html
@@ -32,7 +32,7 @@
                 {% if all_transactions is defined and all_transactions|length %}
                 {% for trans_info in all_transactions %}
                 <tr>
-                    <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>
+                    <td>{{ trans_info.date }}</td>
                     <td class="{{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">{{
                         trans_info.transaction_volume }}
                     </td>

--- a/arbeitszeit_flask/templates/macros/company_summary.html
+++ b/arbeitszeit_flask/templates/macros/company_summary.html
@@ -26,9 +26,7 @@
                         </tr>
                         <tr>
                             <td class="has-text-left has-text-weight-semibold">{{ gettext("Registered since") }}</td>
-                            <td class="has-text-left">{{ view_model.registered_on |
-                                format_datetime(zone='Europe/Berlin',
-                                fmt='%d.%m.%Y') }}</td>
+                            <td class="has-text-left">{{ view_model.registered_on }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/arbeitszeit_web/get_company_summary.py
+++ b/arbeitszeit_web/get_company_summary.py
@@ -1,8 +1,8 @@
 from dataclasses import asdict, dataclass
-from datetime import datetime
 from typing import Any, Dict, List
 
 from arbeitszeit.control_thresholds import ControlThresholds
+from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.get_company_summary import (
     GetCompanySummarySuccess,
     PlanDetails,
@@ -33,7 +33,7 @@ class GetCompanySummaryViewModel:
     id: str
     name: str
     email: str
-    registered_on: datetime
+    registered_on: str
     expectations: List[str]
     account_balances: List[str]
     deviations_relative: List[Deviation]
@@ -48,6 +48,7 @@ class GetCompanySummarySuccessPresenter:
     plan_index: PlanSummaryUrlIndex
     translator: Translator
     control_thresholds: ControlThresholds
+    datetime_service: DatetimeService
 
     def present(
         self, use_case_response: GetCompanySummarySuccess
@@ -56,7 +57,9 @@ class GetCompanySummarySuccessPresenter:
             id=str(use_case_response.id),
             name=use_case_response.name,
             email=use_case_response.email,
-            registered_on=use_case_response.registered_on,
+            registered_on=self.datetime_service.format_datetime(
+                use_case_response.registered_on, zone="Europe/Berlin", fmt="%d.%m.%Y"
+            ),
             expectations=[
                 "%(num).2f" % dict(num=use_case_response.expectations.means),
                 "%(num).2f" % dict(num=use_case_response.expectations.raw_material),

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -468,10 +468,10 @@ class PresenterTestsInjector(Module):
 
     @provider
     def provide_get_company_transactions_presenter(
-        self, translator: FakeTranslator
+        self, translator: FakeTranslator, datetime_service: FakeDatetimeService
     ) -> GetCompanyTransactionsPresenter:
         return GetCompanyTransactionsPresenter(
-            translator=translator,
+            translator=translator, datetime_service=datetime_service
         )
 
     @provider

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -211,11 +211,13 @@ class PresenterTestsInjector(Module):
         plan_index: PlanSummaryUrlIndexTestImpl,
         translator: FakeTranslator,
         control_thresholds: ControlThresholdsTestImpl,
+        datetime_service: FakeDatetimeService,
     ) -> GetCompanySummarySuccessPresenter:
         return GetCompanySummarySuccessPresenter(
             plan_index=plan_index,
             translator=translator,
             control_thresholds=control_thresholds,
+            datetime_service=datetime_service,
         )
 
     @provider

--- a/tests/presenters/test_get_company_summary_presenter.py
+++ b/tests/presenters/test_get_company_summary_presenter.py
@@ -75,9 +75,9 @@ class GetCompanySummaryPresenterTests(TestCase):
         view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
         self.assertEqual(view_model.email, RESPONSE_WITH_2_PLANS.email)
 
-    def test_company_register_date_is_shown(self):
+    def test_company_register_date_is_formatted_correctly(self):
         view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
-        self.assertEqual(view_model.registered_on, RESPONSE_WITH_2_PLANS.registered_on)
+        self.assertEqual(view_model.registered_on, "02.01.2022")
 
     def test_expectations_are_shown_as_list_of_strings(self):
         view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)

--- a/tests/presenters/test_get_company_transactions.py
+++ b/tests/presenters/test_get_company_transactions.py
@@ -9,25 +9,10 @@ from arbeitszeit.use_cases.get_company_transactions import (
     TransactionInfo,
 )
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
+from tests.datetime_service import FakeDatetimeService
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
-
-DEFAULT_INFO1 = TransactionInfo(
-    transaction_type=TransactionTypes.credit_for_fixed_means,
-    date=datetime.now(),
-    transaction_volume=Decimal(10),
-    account_type=AccountTypes.p,
-    purpose="Test purpose",
-)
-
-DEFAULT_INFO2 = TransactionInfo(
-    transaction_type=TransactionTypes.credit_for_wages,
-    date=datetime.now(),
-    transaction_volume=Decimal(20),
-    account_type=AccountTypes.a,
-    purpose="Test purpose",
-)
 
 
 class CompanyTransactionsPresenterTests(TestCase):
@@ -35,40 +20,149 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.injector = get_dependency_injector()
         self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(GetCompanyTransactionsPresenter)
+        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_return_empty_list_when_no_transactions_took_place(self):
         response = GetCompanyTransactionsResponse(transactions=[])
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.transactions, [])
 
-    def test_return_correct_info_when_one_transaction_took_place(self):
-        response = GetCompanyTransactionsResponse(transactions=[DEFAULT_INFO1])
+    def test_show_details_of_one_transaction_when_one_transaction_took_place(self):
+        expected_transaction = self._get_single_transaction_info()
+        response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
         view_model = self.presenter.present(response)
         self.assertTrue(len(view_model.transactions), 1)
-        trans = view_model.transactions[0]
-        self.assertEqual(
-            trans.transaction_type,
-            self._get_transaction_name(DEFAULT_INFO1.transaction_type),
+
+    def test_that_correct_string_is_shown_for_each_transaction_type(self):
+        transaction_types = [
+            TransactionTypes.credit_for_fixed_means,
+            TransactionTypes.credit_for_liquid_means,
+            TransactionTypes.credit_for_wages,
+            TransactionTypes.payment_of_fixed_means,
+            TransactionTypes.payment_of_liquid_means,
+            TransactionTypes.payment_of_wages,
+            TransactionTypes.expected_sales,
+            TransactionTypes.sale_of_consumer_product,
+            TransactionTypes.sale_of_fixed_means,
+            TransactionTypes.sale_of_liquid_means,
+        ]
+        for transaction_type in transaction_types:
+            with self.subTest():
+                expected_transaction = self._get_single_transaction_info(
+                    transaction_type=transaction_type
+                )
+                response = GetCompanyTransactionsResponse(
+                    transactions=[expected_transaction]
+                )
+                view_model = self.presenter.present(response)
+                presented_transaction = view_model.transactions[0]
+                self.assertEqual(
+                    presented_transaction.transaction_type,
+                    self._get_transaction_name(transaction_type),
+                )
+
+    def test_that_transaction_date_is_formatted_as_string(self):
+        expected_transaction = self._get_single_transaction_info()
+        response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
+        view_model = self.presenter.present(response)
+        presented_transaction = view_model.transactions[0]
+        self.assertIsInstance(presented_transaction.date, str)
+
+    def test_that_transaction_date_is_formatted_correctly(self):
+        expected_time = datetime(1998, 12, 1, 22, 5)
+        expected_transaction = self._get_single_transaction_info(date=expected_time)
+        response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
+        view_model = self.presenter.present(response)
+        presented_transaction = view_model.transactions[0]
+        self.assertEqual(presented_transaction.date, "01.12.1998 22:05")
+
+    def test_that_transaction_volume_is_shown_as_correct_decimal(self):
+        expected_transaction_volume = Decimal(10)
+        expected_transaction = self._get_single_transaction_info(
+            transaction_volume=expected_transaction_volume
         )
-        self.assertIsInstance(trans.date, datetime)
-        self.assertEqual(trans.transaction_volume, DEFAULT_INFO1.transaction_volume)
+        response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
+        view_model = self.presenter.present(response)
+        presented_transaction = view_model.transactions[0]
+        self.assertIsInstance(presented_transaction.transaction_volume, Decimal)
         self.assertEqual(
-            trans.account, self._get_account_name(DEFAULT_INFO1.account_type)
+            presented_transaction.transaction_volume,
+            expected_transaction_volume,
         )
-        self.assertIsInstance(trans.purpose, str)
+
+    def test_that_correct_string_is_shown_for_each_account_type(self):
+        account_types = [
+            AccountTypes.p,
+            AccountTypes.r,
+            AccountTypes.a,
+            AccountTypes.prd,
+        ]
+        for account_type in account_types:
+            with self.subTest():
+                expected_transaction = self._get_single_transaction_info(
+                    account_type=account_type
+                )
+                response = GetCompanyTransactionsResponse(
+                    transactions=[expected_transaction]
+                )
+                view_model = self.presenter.present(response)
+                presented_transaction = view_model.transactions[0]
+                self.assertEqual(
+                    presented_transaction.account,
+                    self._get_account_name(account_type),
+                )
+
+    def test_that_transaction_purpose_is_shown_as_correct_string(self):
+        expected_purpose = "purpose test"
+        expected_transaction = self._get_single_transaction_info(
+            purpose=expected_purpose
+        )
+        response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
+        view_model = self.presenter.present(response)
+        presented_transaction = view_model.transactions[0]
+        self.assertIsInstance(presented_transaction.purpose, str)
+        self.assertEqual(presented_transaction.purpose, expected_purpose)
 
     def test_return_two_transactions_when_two_transactions_took_place(self):
         response = GetCompanyTransactionsResponse(
-            transactions=[DEFAULT_INFO1, DEFAULT_INFO2]
+            transactions=[
+                self._get_single_transaction_info(),
+                self._get_single_transaction_info(),
+            ]
         )
         view_model = self.presenter.present(response)
         self.assertTrue(len(view_model.transactions), 2)
+
+    def _get_single_transaction_info(
+        self,
+        transaction_type: TransactionTypes = None,
+        date: datetime = None,
+        transaction_volume: Decimal = None,
+        account_type: AccountTypes = None,
+        purpose: str = None,
+    ) -> TransactionInfo:
+        if transaction_type is None:
+            transaction_type = TransactionTypes.credit_for_fixed_means
+        if date is None:
+            date = datetime.now()
+        if transaction_volume is None:
+            transaction_volume = Decimal(10)
+        if account_type is None:
+            account_type = AccountTypes.p
+        if purpose is None:
+            purpose = "Test purpose"
+        return TransactionInfo(
+            transaction_type=transaction_type,
+            date=date,
+            transaction_volume=transaction_volume,
+            account_type=account_type,
+            purpose=purpose,
+        )
 
     def _get_transaction_name(self, transaction_type: TransactionTypes):
         transaction_dict_test_impl = dict(
             credit_for_wages=self.translator.gettext("Credit for wages"),
             payment_of_wages=self.translator.gettext("Payment of wages"),
-            incoming_wages=self.translator.gettext("Incoming wages"),
             credit_for_fixed_means=self.translator.gettext(
                 "Credit for fixed means of production"
             ),
@@ -84,9 +178,6 @@ class CompanyTransactionsPresenterTests(TestCase):
             expected_sales=self.translator.gettext("Debit expected sales"),
             sale_of_consumer_product=self.translator.gettext(
                 "Sale of consumer product"
-            ),
-            payment_of_consumer_product=self.translator.gettext(
-                "Payment of consumer product"
             ),
             sale_of_fixed_means=self.translator.gettext(
                 "Sale of fixed means of production"

--- a/tests/presenters/test_get_company_transactions.py
+++ b/tests/presenters/test_get_company_transactions.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from decimal import Decimal
 from unittest import TestCase
 
+from dateutil import tz
+
 from arbeitszeit.entities import AccountTypes
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.get_company_transactions import (
@@ -69,7 +71,7 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertIsInstance(presented_transaction.date, str)
 
     def test_that_transaction_date_is_formatted_correctly(self):
-        expected_time = datetime(1998, 12, 1, 22, 5)
+        expected_time = datetime(1998, 12, 1, 22, 5, tzinfo=tz.gettz("Europe/Berlin"))
         expected_transaction = self._get_single_transaction_info(date=expected_time)
         response = GetCompanyTransactionsResponse(transactions=[expected_transaction])
         view_model = self.presenter.present(response)

--- a/tests/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/presenters/test_get_member_dashboard_presenter.py
@@ -4,6 +4,8 @@ from typing import List
 from unittest import TestCase
 from uuid import UUID, uuid4
 
+from dateutil import tz
+
 from arbeitszeit.use_cases.get_member_dashboard import GetMemberDashboard
 from arbeitszeit_web.presenters.get_member_dashboard_presenter import (
     GetMemberDashboardPresenter,
@@ -94,7 +96,7 @@ class GetMemberDashboardPresenterTests(TestCase):
         self.assertEqual(presentation.three_latest_plans[0].prd_name, expected_name)
 
     def test_activation_date_of_latest_plans_is_correctly_formatted(self):
-        now = datetime.now()
+        now = datetime.now(tz=tz.gettz("Europe/Berlin"))
         response = self.get_response(
             three_latest_plans=[
                 GetMemberDashboard.PlanDetails(


### PR DESCRIPTION
This PR does a bit of refactoring, moving datetime formatting from two html templates into corresponding presenters (`GetCompanySummarySuccessPresenter` and `GetCompanyTransactionsPresenter`). I also adjusted tests. 

P.S: I noticed that we are using unittest.subTest(), but pytest cannot take advantage of them. At some point we could think about using a pytest plugin (https://pypi.org/project/pytest-subtests/). 

Plan-ID: 26f2e3f6-233a-4ef1-a1a0-39c5d411b38c