### PR TITLE
Reformat html tables

### DIFF
--- a/arbeitszeit_flask/templates/company/account_a.html
+++ b/arbeitszeit_flask/templates/company/account_a.html
@@ -27,7 +27,7 @@
     </div>
 
     <div class="table-container">
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th></th>
@@ -47,7 +47,7 @@
                     </td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
-                        class="has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
+                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
                         {{ trans_info.transaction_volume }}
                     </td>
                 </tr>

--- a/arbeitszeit_flask/templates/company/account_p.html
+++ b/arbeitszeit_flask/templates/company/account_p.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="table-container">
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th></th>
@@ -45,7 +45,7 @@
                     </td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
-                        class="has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
+                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
                         {{
                         trans_info.transaction_volume }}
                     </td>

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -24,7 +24,7 @@
     </div>
 
     <div class="table-container">
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th></th>
@@ -43,7 +43,7 @@
                     </td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
-                        class="has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
+                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
                         {{
                         trans_info.transaction_volume }}
                     </td>

--- a/arbeitszeit_flask/templates/company/account_r.html
+++ b/arbeitszeit_flask/templates/company/account_r.html
@@ -25,8 +25,8 @@
         <img src="{{ view_model.plot_url }}" alt="plot of r account">
     </div>
 
-    <div class="table-container has-text-left">
-        <table class="table is-fullwidth">
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th></th>

--- a/arbeitszeit_flask/templates/company/draft_list.html
+++ b/arbeitszeit_flask/templates/company/draft_list.html
@@ -20,7 +20,7 @@
 
     <div class="table-container">
         {% if show_results %}
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th>{{ gettext("Date") }}</th>
@@ -37,9 +37,9 @@
                     <td>{{ row.product_name }}</td>
                     <td>{% for paragraph in row.description %}{{ paragraph }}<br>{% endfor %}</td>
                     <td>
-                      <a href="{{ row.details_url }}">
-                        <i class="fas fa-edit"></i>
-                      </a>
+                        <a href="{{ row.details_url }}">
+                            <i class="fas fa-edit"></i>
+                        </a>
                     </td>
                     <td>X</td>
                 </tr>

--- a/arbeitszeit_flask/templates/company/invite_worker_to_company.html
+++ b/arbeitszeit_flask/templates/company/invite_worker_to_company.html
@@ -25,7 +25,7 @@
         {% if view_model.is_show_workers %}
         <h1 class="title">{{ gettext("Workers of the company") }}</h1>
         <div class="table-container">
-          <table class="table is-full-width">
+          <table class="table has-text-left mx-auto">
             <thead>
               <th>{{ gettext("Member ID")}}</th>
               <th>{{ gettext("Name") }}</th>

--- a/arbeitszeit_flask/templates/company/list_all_cooperations.html
+++ b/arbeitszeit_flask/templates/company/list_all_cooperations.html
@@ -10,34 +10,29 @@
     <h1 class="title">
         {{ gettext("All cooperations") }}
     </h1>
-    <div class="columns">
-        <div class="column"></div>
-        <div class="column is-10">
-            {% if view_model.show_results %}
-            <div class="table-container">
-                <table class="table has-text-left mx-auto">
-                    <thead>
-                        <tr>
-                            <th>{{ gettext("Name") }}</th>
-                            <th>{{ gettext("Number of plans") }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for coop in view_model.cooperations %}
-                        <tr>
-                            <td><a href="{{ coop.coop_summary_url }}">{{ coop.name }}</a>
-                            </td>
-                            <td>{{ coop.plan_count }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-            {% else %}
-            <p>{{ gettext("No cooperations found") }}</p>
-            {% endif %}
-        </div>
-        <div class="column"></div>
+    {% if view_model.show_results %}
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
+            <thead>
+                <tr>
+                    <th>{{ gettext("Name") }}</th>
+                    <th>{{ gettext("Number of plans") }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for coop in view_model.cooperations %}
+                <tr>
+                    <td><a href="{{ coop.coop_summary_url }}">{{ coop.name }}</a>
+                    </td>
+                    <td>{{ coop.plan_count }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+    {% else %}
+    <p>{{ gettext("No cooperations found") }}</p>
+    {% endif %}
+</div>
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/list_all_cooperations.html
+++ b/arbeitszeit_flask/templates/company/list_all_cooperations.html
@@ -15,7 +15,7 @@
         <div class="column is-10">
             {% if view_model.show_results %}
             <div class="table-container">
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th>{{ gettext("Name") }}</th>

--- a/arbeitszeit_flask/templates/company/list_all_transactions.html
+++ b/arbeitszeit_flask/templates/company/list_all_transactions.html
@@ -17,14 +17,14 @@
         <p>{{ gettext("Here are all transactions you have made or received so far.") }}</p>
     </div>
     <div class="table-container">
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
-                    <th></th>
                     <th></th>
                     <th>{{ gettext("Account") }}</th>
                     <th>{{ gettext("Type") }}</th>
                     <th>{{ gettext("Details") }}</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -33,12 +33,13 @@
                 {% for trans_info in all_transactions %}
                 <tr>
                     <td>{{ trans_info.date }}</td>
-                    <td class="{{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">{{
-                        trans_info.transaction_volume }}
-                    </td>
                     <td>{{ trans_info.account }}</td>
                     <td>{{ trans_info.transaction_type }}</td>
                     <td>{{ trans_info.purpose }}</td>
+                    <td
+                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">{{
+                        trans_info.transaction_volume }}
+                    </td>
                 </tr>
                 {% endfor %}
                 {% endif %}

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -20,7 +20,7 @@
             </div>
             <br>
             <div class="table-container">
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th></th>

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -11,76 +11,71 @@
         {{ gettext("Accounts") }}
     </h1>
     <br>
-    <div class="columns">
-        <div class="column"></div>
-        <div class="column is-6">
-            <div class="box has-background-info-light has-text-info-dark">
-                <div class="icon"><i class="fas fa-info-circle"></i></div>
-                <p>{{ gettext("You have four different accounts.") }}</p>
-            </div>
-            <br>
-            <div class="table-container">
-                <table class="table has-text-left mx-auto">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th></th>
-                            <th></th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_p') }}">{{
-                                    gettext("Account p") }}</a>
-                            </td>
-                            <td><i class="fas fa-industry"></i></td>
-                            <td class="is-italic has-text-left">{{ gettext("Account for fixed means of production") }}
-                            </td>
-                            <td
-                                class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
-                                {{ view_model.balance_fixed }}</td>
-                        </tr>
-                        <tr>
-                            <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_r') }}">{{
-                                    gettext("Account r") }}</a>
-                            </td>
-                            <td><i class="fas fa-oil-can"></i></td>
-                            <td class="is-italic has-text-left">{{ gettext("Account for liquid means of production")}}
-                            </td>
-                            <td
-                                class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
-                                {{ view_model.balance_liquid }}</td>
-                        </tr>
-                        <tr>
-                            <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_a') }}">{{
-                                    gettext("Account a") }}</a>
-                            </td>
-                            <td><i class="fas fa-users"></i></td>
-                            <td class="is-italic has-text-left">{{ gettext("Account for work certificates (wages)") }}
-                            </td>
-                            <td
-                                class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
-                                {{ view_model.balance_work }}</td>
-                        </tr>
-                        <tr>
-                            <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">{{
-                                    gettext("Account prd") }}</a></td>
-                            <td><i class="fas fa-exchange-alt"></i></td>
-                            <td class="is-italic has-text-left">{{ gettext("Account for product transfers (sales)") }}
-                            </td>
-                            <td
-                                class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
-                                {{ view_model.balance_product }}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <p><a href="{{ url_for('main_company.list_all_transactions') }}">{{ gettext("List all transactions") }}</a>
-            </p>
-        </div>
-        <div class="column"></div>
+    <div class="box has-background-info-light has-text-info-dark">
+        <div class="icon"><i class="fas fa-info-circle"></i></div>
+        <p>{{ gettext("You have four different accounts.") }}</p>
     </div>
+    <br>
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_p') }}">{{
+                                    gettext("Account p") }}</a>
+                    </td>
+                    <td><i class="fas fa-industry"></i></td>
+                    <td class="is-italic has-text-left">{{ gettext("Account for fixed means of production") }}
+                    </td>
+                    <td
+                        class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
+                        {{ view_model.balance_fixed }}</td>
+                </tr>
+                <tr>
+                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_r') }}">{{
+                                    gettext("Account r") }}</a>
+                    </td>
+                    <td><i class="fas fa-oil-can"></i></td>
+                    <td class="is-italic has-text-left">{{ gettext("Account for liquid means of production")}}
+                    </td>
+                    <td
+                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
+                        {{ view_model.balance_liquid }}</td>
+                </tr>
+                <tr>
+                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_a') }}">{{
+                                    gettext("Account a") }}</a>
+                    </td>
+                    <td><i class="fas fa-users"></i></td>
+                    <td class="is-italic has-text-left">{{ gettext("Account for work certificates (wages)") }}
+                    </td>
+                    <td
+                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
+                        {{ view_model.balance_work }}</td>
+                </tr>
+                <tr>
+                    <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">{{
+                                    gettext("Account prd") }}</a></td>
+                    <td><i class="fas fa-exchange-alt"></i></td>
+                    <td class="is-italic has-text-left">{{ gettext("Account for product transfers (sales)") }}
+                    </td>
+                    <td
+                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
+                        {{ view_model.balance_product }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <p><a href="{{ url_for('main_company.list_all_transactions') }}">{{ gettext("List all transactions") }}</a>
+    </p>
+</div>
 </div>
 
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -44,7 +44,7 @@
 
     <div class="table-container">
         {% if list_of_coordinations.rows %}
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th>{{ gettext("Cooperation") }}</th>
@@ -75,7 +75,7 @@
     </div>
     <div class="table-container">
         {% if list_of_inbound_coop_requests.rows %}
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th>{{ gettext("My cooperation") }}</th>
@@ -133,7 +133,7 @@
 
     <div class="table-container">
         {% if list_of_outbound_coop_requests.rows %}
-        <table class="table is-fullwidth">
+        <table class="table has-text-left mx-auto">
             <thead>
                 <tr>
                     <th>{{ gettext("My requesting plan")}}</th>

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -57,7 +57,7 @@
   <h1 class="title is-4 has-text-centered">{{ gettext("Waiting")}}</h1>
   <div class="table-container">
     {% if show_non_active_plans %}
-    <table class="table is-fullwidth">
+    <table class="table has-text-left mx-auto">
       <thead>
         <tr>
           <th></th>

--- a/arbeitszeit_flask/templates/company/my_purchases.html
+++ b/arbeitszeit_flask/templates/company/my_purchases.html
@@ -20,7 +20,7 @@
   </div>
 
   <div class="table-container">
-    <table class="table is-fullwidth">
+    <table class="table has-text-left mx-auto">
       <thead>
         <tr>
           <th>{{ gettext("Date") }}</th>

--- a/arbeitszeit_flask/templates/macros/company_summary.html
+++ b/arbeitszeit_flask/templates/macros/company_summary.html
@@ -7,36 +7,31 @@
                 {{ gettext("Company overview") }}
             </h1>
         </div>
-        <div class="section">
-            <div class="columns is-centered">
-                <div class="column is-two-thirds">
-                    <div class="table-container">
-                        <table class="table has-text-left mx-auto">
-                            <tbody>
-                                <tr>
-                                    <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
-                                    <td class="has-text-left">{{ view_model.id }}</td>
-                                </tr>
-                                <tr>
-                                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Name") }}</td>
-                                    <td class="has-text-left">{{ view_model.name }}</td>
-                                </tr>
-                                <tr>
-                                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Email") }}</td>
-                                    <td class="has-text-left">{{ view_model.email }}</td>
-                                </tr>
-                                <tr>
-                                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Registered since") }}
-                                    </td>
-                                    <td class="has-text-left">{{ view_model.registered_on }}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
-                </div>
+        <br>
+        <div class="section box">
+            <div class="table-container">
+                <table class="table has-text-left mx-auto">
+                    <tbody>
+                        <tr>
+                            <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
+                            <td class="has-text-left">{{ view_model.id }}</td>
+                        </tr>
+                        <tr>
+                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Name") }}</td>
+                            <td class="has-text-left">{{ view_model.name }}</td>
+                        </tr>
+                        <tr>
+                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Email") }}</td>
+                            <td class="has-text-left">{{ view_model.email }}</td>
+                        </tr>
+                        <tr>
+                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Registered since") }}
+                            </td>
+                            <td class="has-text-left">{{ view_model.registered_on }}</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-
         </div>
         <div class="section box">
             <div class="has-text-centered">
@@ -45,52 +40,45 @@
                 </h1>
             </div>
             <br>
-            <div class="columns is-centered">
-                <div class="column is-two-thirds">
-                    <div class="table-container">
-                        <table class="table has-text-left mx-auto">
-                            <thead class="has-text-centered">
-                                <tr>
-                                    <th></th>
-                                    <th><span class="icon"><i
-                                                class="fas fa-industry"></i></span><br>{{ gettext("Account p") }}
-                                    </th>
-                                    <th><span class="icon"><i
-                                                class="fas fa-oil-can"></i></span><br>{{ gettext("Account r") }}
-                                    </th>
-                                    <th><span class="icon"><i
-                                                class="fas fa-users"></i></span><br>{{ gettext("Account a") }}
-                                    </th>
-                                    <th><span class="icon"><i class="fas fa-exchange-alt"></i></span>
-                                        <br>{{ gettext("Account prd") }}
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td>{{ gettext("Expectations") }}</td>
-                                    {% for exp in view_model.expectations %}
-                                    <td><span class="tag is-medium">{{ exp }}</span></td>
-                                    {% endfor %}
-                                </tr>
-                                <tr>
-                                    <td>{{ gettext("Balances") }}</td>
-                                    {% for bal in view_model.account_balances %}
-                                    <td><span class="tag is-medium">{{ bal }}</span></td>
-                                    {% endfor %}
-                                </tr>
-                                <tr>
-                                    <td class="has-text-weight-semibold">{{ gettext("Deviation (&percnt;)") }}</td>
-                                    {% for dev_rel in view_model.deviations_relative %}
-                                    <td><span
-                                            class="tag is-light is-medium {{ 'is-danger' if dev_rel.is_critical else 'is-primary'  }}">{{
+            <div class="table-container">
+                <table class="table has-text-left mx-auto">
+                    <thead class="has-text-centered">
+                        <tr>
+                            <th></th>
+                            <th><span class="icon"><i class="fas fa-industry"></i></span><br>{{ gettext("Account p") }}
+                            </th>
+                            <th><span class="icon"><i class="fas fa-oil-can"></i></span><br>{{ gettext("Account r") }}
+                            </th>
+                            <th><span class="icon"><i class="fas fa-users"></i></span><br>{{ gettext("Account a") }}
+                            </th>
+                            <th><span class="icon"><i class="fas fa-exchange-alt"></i></span>
+                                <br>{{ gettext("Account prd") }}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>{{ gettext("Expectations") }}</td>
+                            {% for exp in view_model.expectations %}
+                            <td><span class="tag is-medium">{{ exp }}</span></td>
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td>{{ gettext("Balances") }}</td>
+                            {% for bal in view_model.account_balances %}
+                            <td><span class="tag is-medium">{{ bal }}</span></td>
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td class="has-text-weight-semibold">{{ gettext("Deviation (&percnt;)") }}</td>
+                            {% for dev_rel in view_model.deviations_relative %}
+                            <td><span
+                                    class="tag is-light is-medium {{ 'is-danger' if dev_rel.is_critical else 'is-primary'  }}">{{
                                             dev_rel.percentage }}</span></td>
-                                    {% endfor %}
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                            {% endfor %}
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
         <div class="section box has-text-centered">

--- a/arbeitszeit_flask/templates/macros/company_summary.html
+++ b/arbeitszeit_flask/templates/macros/company_summary.html
@@ -11,7 +11,7 @@
             <div class="columns is-centered">
                 <div class="column is-two-thirds">
                     <div class="table-container">
-                        <table class="table is-fullwidth">
+                        <table class="table has-text-left mx-auto">
                             <tbody>
                                 <tr>
                                     <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
@@ -48,7 +48,7 @@
             <div class="columns is-centered">
                 <div class="column is-two-thirds">
                     <div class="table-container">
-                        <table class="table is-fullwidth has-text-left">
+                        <table class="table has-text-left mx-auto">
                             <thead class="has-text-centered">
                                 <tr>
                                     <th></th>
@@ -121,7 +121,7 @@
             </div>
             <br>
             <div class="table-container">
-                <table class="table has-text-left">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th></th>

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -10,7 +10,7 @@
             </div>
             <br>
             <div class="table-container">
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <tbody>
                         <tr>
                             <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
@@ -35,7 +35,7 @@
                 <h1 class="title is-4">
                     {{ gettext("Participating plans") }}
                 </h1>
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th>{{ gettext("Plan") }}</th>

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -1,73 +1,69 @@
 {% macro coop_summary(view_model) %}
 
 <div class="section has-text-centered">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
-            <div class="content">
-                <h1 class="title">
-                    {{ gettext("Cooperation") }}
-                </h1>
-            </div>
-            <br>
-            <div class="table-container">
-                <table class="table has-text-left mx-auto">
-                    <tbody>
-                        <tr>
-                            <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
-                            <td class="has-text-left">{{ view_model.coop_id }}</td>
-                        </tr>
-                        <tr>
-                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Name") }}</td>
-                            <td class="has-text-left">{{ view_model.coop_name }}</td>
-                        </tr>
-                        <tr>
-                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Definition") }}</td>
-                            <td class="has-text-left">{% for parag in view_model.coop_definition %} {{ parag }} {%
+    <div class="content">
+        <h1 class="title">
+            {{ gettext("Cooperation") }}
+        </h1>
+    </div>
+    <br>
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
+            <tbody>
+                <tr>
+                    <td class="has-text-left has-text-weight-semibold">{{ gettext("ID") }}</td>
+                    <td class="has-text-left">{{ view_model.coop_id }}</td>
+                </tr>
+                <tr>
+                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Name") }}</td>
+                    <td class="has-text-left">{{ view_model.coop_name }}</td>
+                </tr>
+                <tr>
+                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Definition") }}</td>
+                    <td class="has-text-left">{% for parag in view_model.coop_definition %} {{ parag }} {%
                                 endfor %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="has-text-left has-text-weight-semibold">{{ gettext("Coordinator") }}</td>
-                            <td class="has-text-left">{{ view_model.coordinator_id }}</td>
-                        </tr>
-                    </tbody>
-                </table>
-                <h1 class="title is-4">
-                    {{ gettext("Participating plans") }}
-                </h1>
-                <table class="table has-text-left mx-auto">
-                    <thead>
-                        <tr>
-                            <th>{{ gettext("Plan") }}</th>
-                            <th>{{ gettext("Individual price") }}</th>
-                            <th>{{ gettext("Cooperation price") }}</th>
-                            {% if view_model.show_end_coop_button %}
-                            <th>{{ gettext("End cooperation") }}</th>
-                            {% endif %}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for plan in view_model.plans %}
-                        <tr>
-                            <td><a href="{{ plan.plan_url }}">{{ plan.plan_name }}</a></td>
-                            <td>{{ plan.plan_individual_price }}</td>
-                            <td>{{ plan.plan_coop_price }}</td>
-                            {% if view_model.show_end_coop_button %}
-                            <td>
-                                <a class="button is-small is-danger" href="{{ plan.end_coop_url }}">
-                                    <span class="icon">
-                                        <i class="fas fa-times"></i>
-                                    </span>
-                                    <span>{{ gettext("End") }}</span>
-                                </a>
-                            </td>
-                            {% endif %}
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="has-text-left has-text-weight-semibold">{{ gettext("Coordinator") }}</td>
+                    <td class="has-text-left">{{ view_model.coordinator_id }}</td>
+                </tr>
+            </tbody>
+        </table>
+        <h1 class="title is-4">
+            {{ gettext("Participating plans") }}
+        </h1>
+        <table class="table has-text-left mx-auto">
+            <thead>
+                <tr>
+                    <th>{{ gettext("Plan") }}</th>
+                    <th>{{ gettext("Individual price") }}</th>
+                    <th>{{ gettext("Cooperation price") }}</th>
+                    {% if view_model.show_end_coop_button %}
+                    <th>{{ gettext("End cooperation") }}</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for plan in view_model.plans %}
+                <tr>
+                    <td><a href="{{ plan.plan_url }}">{{ plan.plan_name }}</a></td>
+                    <td>{{ plan.plan_individual_price }}</td>
+                    <td>{{ plan.plan_coop_price }}</td>
+                    {% if view_model.show_end_coop_button %}
+                    <td>
+                        <a class="button is-small is-danger" href="{{ plan.end_coop_url }}">
+                            <span class="icon">
+                                <i class="fas fa-times"></i>
+                            </span>
+                            <span>{{ gettext("End") }}</span>
+                        </a>
+                    </td>
+                    {% endif %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>
 {% endmacro %}

--- a/arbeitszeit_flask/templates/macros/query_companies.html
+++ b/arbeitszeit_flask/templates/macros/query_companies.html
@@ -32,9 +32,9 @@
     </h1>
     <div class="columns">
         <div class="column"></div>
-        <div class="column is-8">
+        <div class="column is-5">
             <div class="table-container">
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th>{{ gettext("Name") }}</th>

--- a/arbeitszeit_flask/templates/macros/query_companies.html
+++ b/arbeitszeit_flask/templates/macros/query_companies.html
@@ -30,30 +30,26 @@
     <h1 class="title">
         {{ gettext("Results") }}
     </h1>
-    <div class="columns">
-        <div class="column"></div>
-        <div class="column is-5">
-            <div class="table-container">
-                <table class="table has-text-left mx-auto">
-                    <thead>
-                        <tr>
-                            <th>{{ gettext("Name") }}</th>
-                            <th>{{ gettext("Email")}}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for column in view_model.results.rows %}
-                        <tr>
-                            <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
-                            <td>{{ column.company_email }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="column"></div>
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
+            <thead>
+                <tr>
+                    <th>{{ gettext("Name") }}</th>
+                    <th>{{ gettext("Email")}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for column in view_model.results.rows %}
+                <tr>
+                    <td><a href="{{ column.company_summary_url }}">{{ column.company_name }}</a></td>
+                    <td>{{ column.company_email }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
-    {% endif %}
+</div>
+
+{% endif %}
 </div>
 {% endmacro %}

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -10,45 +10,40 @@
     <h1 class="title">
         {{ gettext("My Account") }}
     </h1>
-    <div class="columns">
-        <div class="column"></div>
-        <div class="column is-10">
-            <div>
-                <p>{{ gettext("Current balance") }}:</p>
-                <p class="py-2 has-text-weight-bold {{ 'has-text-primary' if my_balance >= 0 else 'has-text-danger' }}">
-                    {{ my_balance }}
-                </p>
-            </div>
-            <div class="table-container">
-                <table class="table has-text-left mx-auto">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th></th>
-                            <th></th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% if all_transactions_info is defined and all_transactions_info|length %}
-                        {% for trans_info in all_transactions_info %}
-                        <tr>
-                            <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>
-                            <td>{{ trans_info.peer_name }}</td>
-                            <td>{{ trans_info.purpose }}</td>
-                            <td
-                                class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">
-                                {{
-                                trans_info.transaction_volume }}
-                            </td>
-                        </tr>
-                        {% endfor %}
-                        {% endif %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="column"></div>
+    <div>
+        <p>{{ gettext("Current balance") }}:</p>
+        <p class="py-2 has-text-weight-bold {{ 'has-text-primary' if my_balance >= 0 else 'has-text-danger' }}">
+            {{ my_balance }}
+        </p>
     </div>
+    <div class="table-container">
+        <table class="table has-text-left mx-auto">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if all_transactions_info is defined and all_transactions_info|length %}
+                {% for trans_info in all_transactions_info %}
+                <tr>
+                    <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>
+                    <td>{{ trans_info.peer_name }}</td>
+                    <td>{{ trans_info.purpose }}</td>
+                    <td
+                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">
+                        {{
+                                trans_info.transaction_volume }}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -20,7 +20,7 @@
                 </p>
             </div>
             <div class="table-container">
-                <table class="table is-fullwidth">
+                <table class="table has-text-left mx-auto">
                     <thead>
                         <tr>
                             <th></th>
@@ -35,12 +35,12 @@
                         <tr>
                             <td>{{ trans_info.date|format_datetime(zone='Europe/Berlin', fmt='%d.%m.%Y %H:%M') }}</td>
                             <td>{{ trans_info.peer_name }}</td>
+                            <td>{{ trans_info.purpose }}</td>
                             <td
-                                class="has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">
+                                class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume >= 0 else 'has-text-danger' }}">
                                 {{
                                 trans_info.transaction_volume }}
                             </td>
-                            <td>{{ trans_info.purpose }}</td>
                         </tr>
                         {% endfor %}
                         {% endif %}

--- a/arbeitszeit_flask/templates/member/my_purchases.html
+++ b/arbeitszeit_flask/templates/member/my_purchases.html
@@ -20,7 +20,7 @@
   </div>
 
   <div class="table-container">
-    <table class="table is-fullwidth">
+    <table class="table has-text-left mx-auto">
       <thead>
         <tr>
           <th>{{ gettext("Date") }}</th>


### PR DESCRIPTION
There are some formatting issues with the thml tables in the current code (e.g. table content is centered, while headers aren't). 

I applied now the same bulma based formatting to all tables: `<table class="table has-text-left mx-auto">` 

This garantees that text is by default aligned to the left, which makes it easy to read, while the table takes only as much space as it needs.

Plan-ID: ed6eb89f-0633-4544-9ddc-94466b7d5e82