### PR TITLE
Change command in requirements.txt from -c to -r

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ injector
 is_safe_url
 matplotlib
 
--c constraints.txt
+-r constraints.txt


### PR DESCRIPTION
After #444 there is a small problem with deploying on Heroku: Apparently Heroku does not accept our `-c constraints.txt` command in our `requirements.txt` file, so our deployment failed. 

Heroku writes: 
```
If you would like to utilize multiple requirements files in your codebase, you can include the contents of another requirements file with pip:

`-r ./path/to/prod-requirements.txt`
```
https://devcenter.heroku.com/articles/python-pip

Changing our `-c constraints.txt` command to `-r constraints.txt` did the job. If there is not a specific reason to use `-c` i'd suggest with this PR to apply this change in our code.

No certs needed.