### PR TITLE
show name and link of coordinator in coop summary

### DIFF
--- a/arbeitszeit/use_cases/get_coop_summary.py
+++ b/arbeitszeit/use_cases/get_coop_summary.py
@@ -30,6 +30,7 @@ class GetCoopSummarySuccess:
     coop_name: str
     coop_definition: str
     coordinator_id: UUID
+    coordinator_name: str
 
     plans: List[AssociatedPlan]
 
@@ -69,5 +70,6 @@ class GetCoopSummary:
             coop_name=coop.name,
             coop_definition=coop.definition,
             coordinator_id=coop.coordinator.id,
+            coordinator_name=coop.coordinator.name,
             plans=plans,
         )

--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -464,9 +464,14 @@ class PresenterModule(Module):
 
     @provider
     def provide_get_coop_summary_success_presenter(
-        self, plan_index: PlanSummaryUrlIndex, end_coop_index: EndCoopUrlIndex
+        self,
+        plan_index: PlanSummaryUrlIndex,
+        end_coop_index: EndCoopUrlIndex,
+        company_summary_url_index: CompanySummaryUrlIndex,
     ) -> GetCoopSummarySuccessPresenter:
-        return GetCoopSummarySuccessPresenter(plan_index, end_coop_index)
+        return GetCoopSummarySuccessPresenter(
+            plan_index, end_coop_index, company_summary_url_index
+        )
 
     @provider
     def provide_get_company_summary_success_presenter(

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -26,7 +26,8 @@
                 </tr>
                 <tr>
                     <td class="has-text-left has-text-weight-semibold">{{ gettext("Coordinator") }}</td>
-                    <td class="has-text-left">{{ view_model.coordinator_id }}</td>
+                    <td class="has-text-left"><a
+                            href="{{ view_model.coordinator_link }}">{{ view_model.coordinator_name }}</a></td>
                 </tr>
             </tbody>
         </table>

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -27,7 +27,7 @@
                 <tr>
                     <td class="has-text-left has-text-weight-semibold">{{ gettext("Coordinator") }}</td>
                     <td class="has-text-left"><a
-                            href="{{ view_model.coordinator_link }}">{{ view_model.coordinator_name }}</a></td>
+                            href="{{ view_model.coordinator_url }}">{{ view_model.coordinator_name }}</a></td>
                 </tr>
             </tbody>
         </table>

--- a/arbeitszeit_web/get_coop_summary.py
+++ b/arbeitszeit_web/get_coop_summary.py
@@ -24,7 +24,7 @@ class GetCoopSummaryViewModel:
     coop_definition: List[str]
     coordinator_id: str
     coordinator_name: str
-    coordinator_link: str
+    coordinator_url: str
 
     plans: List[AssociatedPlanPresentation]
 
@@ -46,7 +46,7 @@ class GetCoopSummarySuccessPresenter:
             coop_definition=response.coop_definition.splitlines(),
             coordinator_id=str(response.coordinator_id),
             coordinator_name=response.coordinator_name,
-            coordinator_link=self.company_summary_url_index.get_company_summary_url(
+            coordinator_url=self.company_summary_url_index.get_company_summary_url(
                 response.coordinator_id
             ),
             plans=[

--- a/arbeitszeit_web/get_coop_summary.py
+++ b/arbeitszeit_web/get_coop_summary.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from arbeitszeit.use_cases.get_coop_summary import GetCoopSummarySuccess
 
-from .url_index import EndCoopUrlIndex, PlanSummaryUrlIndex
+from .url_index import CompanySummaryUrlIndex, EndCoopUrlIndex, PlanSummaryUrlIndex
 
 
 @dataclass
@@ -23,6 +23,8 @@ class GetCoopSummaryViewModel:
     coop_name: str
     coop_definition: List[str]
     coordinator_id: str
+    coordinator_name: str
+    coordinator_link: str
 
     plans: List[AssociatedPlanPresentation]
 
@@ -34,6 +36,7 @@ class GetCoopSummaryViewModel:
 class GetCoopSummarySuccessPresenter:
     plan_url_index: PlanSummaryUrlIndex
     end_coop_url_index: EndCoopUrlIndex
+    company_summary_url_index: CompanySummaryUrlIndex
 
     def present(self, response: GetCoopSummarySuccess) -> GetCoopSummaryViewModel:
         return GetCoopSummaryViewModel(
@@ -42,6 +45,10 @@ class GetCoopSummarySuccessPresenter:
             coop_name=response.coop_name,
             coop_definition=response.coop_definition.splitlines(),
             coordinator_id=str(response.coordinator_id),
+            coordinator_name=response.coordinator_name,
+            coordinator_link=self.company_summary_url_index.get_company_summary_url(
+                response.coordinator_id
+            ),
             plans=[
                 AssociatedPlanPresentation(
                     plan_name=plan.plan_name,

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -192,10 +192,12 @@ class PresenterTestsInjector(Module):
         self,
         plan_url_index: PlanSummaryUrlIndexTestImpl,
         end_coop_url_index: EndCoopUrlIndexTestImpl,
+        company_summary_url_index: CompanySummaryUrlIndex,
     ) -> GetCoopSummarySuccessPresenter:
         return GetCoopSummarySuccessPresenter(
             plan_url_index=plan_url_index,
             end_coop_url_index=end_coop_url_index,
+            company_summary_url_index=company_summary_url_index,
         )
 
     @provider

--- a/tests/presenters/test_get_coop_summary_presenter.py
+++ b/tests/presenters/test_get_coop_summary_presenter.py
@@ -78,7 +78,7 @@ class GetCoopSummarySuccessPresenterTests(TestCase):
     def test_link_to_coordinators_company_summary_page_is_displayed_correctly(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
-            view_model.coordinator_link,
+            view_model.coordinator_url,
             self.company_summary_url_index.get_company_summary_url(
                 TESTING_RESPONSE_MODEL.coordinator_id
             ),

--- a/tests/presenters/test_get_coop_summary_presenter.py
+++ b/tests/presenters/test_get_coop_summary_presenter.py
@@ -7,7 +7,11 @@ from arbeitszeit.use_cases.get_coop_summary import AssociatedPlan, GetCoopSummar
 from arbeitszeit_web.get_coop_summary import GetCoopSummarySuccessPresenter
 
 from .dependency_injection import get_dependency_injector
-from .url_index import EndCoopUrlIndexTestImpl, PlanSummaryUrlIndexTestImpl
+from .url_index import (
+    CompanySummaryUrlIndex,
+    EndCoopUrlIndexTestImpl,
+    PlanSummaryUrlIndexTestImpl,
+)
 
 TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
     requester_is_coordinator=True,
@@ -15,6 +19,7 @@ TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
     coop_name="coop name",
     coop_definition="coop def\ncoop def2",
     coordinator_id=uuid4(),
+    coordinator_name="coordinator name",
     plans=[
         AssociatedPlan(
             plan_id=uuid4(),
@@ -30,6 +35,7 @@ class GetCoopSummarySuccessPresenterTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
         self.plan_url_index = self.injector.get(PlanSummaryUrlIndexTestImpl)
+        self.company_summary_url_index = self.injector.get(CompanySummaryUrlIndex)
         self.end_coop_url_index = self.injector.get(EndCoopUrlIndexTestImpl)
         self.presenter = self.injector.get(GetCoopSummarySuccessPresenter)
 
@@ -61,6 +67,21 @@ class GetCoopSummarySuccessPresenterTests(TestCase):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
             view_model.coordinator_id, str(TESTING_RESPONSE_MODEL.coordinator_id)
+        )
+
+    def test_coordinator_name_is_displayed_correctly(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertEqual(
+            view_model.coordinator_name, TESTING_RESPONSE_MODEL.coordinator_name
+        )
+
+    def test_link_to_coordinators_company_summary_page_is_displayed_correctly(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertEqual(
+            view_model.coordinator_link,
+            self.company_summary_url_index.get_company_summary_url(
+                TESTING_RESPONSE_MODEL.coordinator_id
+            ),
         )
 
     def test_first_plans_name_is_displayed_correctly(self):

--- a/tests/use_cases/test_get_coop_summary.py
+++ b/tests/use_cases/test_get_coop_summary.py
@@ -81,6 +81,21 @@ def test_that_correct_coordinator_id_is_shown(
 
 
 @injection_test
+def test_that_correct_coordinator_name_is_shown(
+    get_coop_summary: GetCoopSummary,
+    company_generator: CompanyGenerator,
+    cooperation_generator: CooperationGenerator,
+    plan_generator: PlanGenerator,
+):
+    requester = company_generator.create_company()
+    plan1 = plan_generator.create_plan(activation_date=datetime.min)
+    plan2 = plan_generator.create_plan(activation_date=datetime.min)
+    coop = cooperation_generator.create_cooperation(plans=[plan1, plan2])
+    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+    assert_success(summary, lambda s: s.coordinator_name == coop.coordinator.name)
+
+
+@injection_test
 def test_that_correct_info_of_associated_plan_is_shown(
     get_coop_summary: GetCoopSummary,
     company_generator: CompanyGenerator,


### PR DESCRIPTION
fixes #481

show name and link of coordinator in coop summary (see issue #481).

Still using here the old style of dependency injection to prevent merge conflicts.