### PR TITLE
Make paying means of production from plan possible

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -24,7 +24,6 @@ from arbeitszeit.use_cases.get_company_dashboard import GetCompanyDashboardUseCa
 from arbeitszeit.use_cases.list_available_languages import ListAvailableLanguagesUseCase
 from arbeitszeit.use_cases.log_in_company import LogInCompanyUseCase
 from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
-from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProduction
 from arbeitszeit.use_cases.show_my_accounts import ShowMyAccounts
 from arbeitszeit_flask.control_thresholds import ControlThresholdsFlask
 from arbeitszeit_flask.database import get_social_accounting
@@ -78,9 +77,6 @@ from arbeitszeit_web.controllers.end_cooperation_controller import (
     EndCooperationController,
 )
 from arbeitszeit_web.controllers.list_workers_controller import ListWorkersController
-from arbeitszeit_web.controllers.pay_means_of_production_controller import (
-    PayMeansOfProductionController,
-)
 from arbeitszeit_web.controllers.send_work_certificates_to_worker_controller import (
     SendWorkCertificatesToWorkerController,
 )
@@ -205,16 +201,11 @@ class CompanyModule(CompanyPresenterModule):
         return SendWorkCertificatesToWorkerController(session, request)
 
     @provider
-    def provide_pay_means_of_production_controller(
-        self, session: FlaskSession, request: FlaskRequest
-    ) -> PayMeansOfProductionController:
-        return PayMeansOfProductionController(session, request)
-
-    @provider
     def provide_prefilled_draft_data_controller(
         self, session: Session
     ) -> CreateDraftController:
         return CreateDraftController(session=session)
+
 
 class FlaskModule(PresenterModule):
     @provider

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -107,11 +107,8 @@ from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import (
     ConfirmationUrlIndex,
-    EndCoopUrlIndex,
     HidePlanUrlIndex,
     RenewPlanUrlIndex,
-    RequestCoopUrlIndex,
-    TogglePlanAvailabilityUrlIndex,
     UrlIndex,
 )
 
@@ -131,18 +128,6 @@ class MemberModule(Module):
         return member_index
 
     @provider
-    def provide_request_coop_url_index(
-        self, member_index: MemberUrlIndex
-    ) -> RequestCoopUrlIndex:
-        return member_index
-
-    @provider
-    def provide_end_coop_url_index(
-        self, member_index: MemberUrlIndex
-    ) -> EndCoopUrlIndex:
-        return member_index
-
-    @provider
     def provide_template_index(self) -> TemplateIndex:
         return MemberTemplateIndex()
 
@@ -155,12 +140,6 @@ class CompanyModule(CompanyPresenterModule):
         return company_index
 
     @provider
-    def provide_toggle_plan_availability_url_index(
-        self, company_index: CompanyUrlIndex
-    ) -> TogglePlanAvailabilityUrlIndex:
-        return company_index
-
-    @provider
     def provide_renew_plan_url_index(
         self, company_index: CompanyUrlIndex
     ) -> RenewPlanUrlIndex:
@@ -170,18 +149,6 @@ class CompanyModule(CompanyPresenterModule):
     def provide_hide_plan_url_index(
         self, company_index: CompanyUrlIndex
     ) -> HidePlanUrlIndex:
-        return company_index
-
-    @provider
-    def provide_request_coop_url_index(
-        self, company_index: CompanyUrlIndex
-    ) -> RequestCoopUrlIndex:
-        return company_index
-
-    @provider
-    def provide_end_coop_url_index(
-        self, company_index: CompanyUrlIndex
-    ) -> EndCoopUrlIndex:
         return company_index
 
     @provider

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -24,6 +24,7 @@ from arbeitszeit.use_cases.get_company_dashboard import GetCompanyDashboardUseCa
 from arbeitszeit.use_cases.list_available_languages import ListAvailableLanguagesUseCase
 from arbeitszeit.use_cases.log_in_company import LogInCompanyUseCase
 from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
+from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProduction
 from arbeitszeit.use_cases.show_my_accounts import ShowMyAccounts
 from arbeitszeit_flask.control_thresholds import ControlThresholdsFlask
 from arbeitszeit_flask.database import get_social_accounting
@@ -214,7 +215,6 @@ class CompanyModule(CompanyPresenterModule):
         self, session: Session
     ) -> CreateDraftController:
         return CreateDraftController(session=session)
-
 
 class FlaskModule(PresenterModule):
     @provider

--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -10,13 +10,12 @@ from arbeitszeit.use_cases.register_member.member_registration_message_presenter
 from arbeitszeit.use_cases.send_accountant_registration_token.accountant_invitation_presenter import (
     AccountantInvitationPresenter,
 )
-from arbeitszeit_flask.url_index import CompanyUrlIndex, GeneralUrlIndex
+from arbeitszeit_flask.url_index import GeneralUrlIndex
 from arbeitszeit_web.email import EmailConfiguration, MailService, UserAddressBook
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
 from arbeitszeit_web.invite_worker_to_company import InviteWorkerToCompanyPresenter
 from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
-from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresenter
 from arbeitszeit_web.presenters.accountant_invitation_presenter import (
     AccountantInvitationEmailPresenter,
     AccountantInvitationEmailView,
@@ -50,14 +49,6 @@ from arbeitszeit_web.url_index import ConfirmationUrlIndex
 
 
 class CompanyPresenterModule(Module):
-    @provider
-    def provide_pay_means_of_production_presenter(
-        self, notifier: Notifier, trans: Translator, company_url_index: CompanyUrlIndex
-    ) -> PayMeansOfProductionPresenter:
-        return PayMeansOfProductionPresenter(
-            notifier, trans, pay_means_of_production_url_index=company_url_index
-        )
-
     @provider
     def provide_request_cooperation_presenter(
         self,

--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -12,11 +12,7 @@ from arbeitszeit.use_cases.send_accountant_registration_token.accountant_invitat
 )
 from arbeitszeit_flask.url_index import CompanyUrlIndex, GeneralUrlIndex
 from arbeitszeit_web.email import EmailConfiguration, MailService, UserAddressBook
-from arbeitszeit_web.formatters.plan_summary_formatter import PlanSummaryFormatter
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
-from arbeitszeit_web.get_plan_summary_company import (
-    GetPlanSummaryCompanySuccessPresenter,
-)
 from arbeitszeit_web.invite_worker_to_company import InviteWorkerToCompanyPresenter
 from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
@@ -50,12 +46,7 @@ from arbeitszeit_web.presenters.send_work_certificates_to_worker_presenter impor
 from arbeitszeit_web.request_cooperation import RequestCooperationPresenter
 from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.url_index import (
-    ConfirmationUrlIndex,
-    EndCoopUrlIndex,
-    RequestCoopUrlIndex,
-    TogglePlanAvailabilityUrlIndex,
-)
+from arbeitszeit_web.url_index import ConfirmationUrlIndex
 
 
 class CompanyPresenterModule(Module):
@@ -199,23 +190,6 @@ class PresenterModule(Module):
             url_index=url_index,
             email_configuration=email_configuration,
             translator=translator,
-        )
-
-    @provider
-    def provide_get_plan_summary_company_success_presenter(
-        self,
-        toggle_availability_index: TogglePlanAvailabilityUrlIndex,
-        end_coop_url_index: EndCoopUrlIndex,
-        request_coop_url_index: RequestCoopUrlIndex,
-        trans: Translator,
-        plan_summary_service: PlanSummaryFormatter,
-    ) -> GetPlanSummaryCompanySuccessPresenter:
-        return GetPlanSummaryCompanySuccessPresenter(
-            toggle_availability_index,
-            end_coop_url_index,
-            request_coop_url_index,
-            trans,
-            plan_summary_service,
         )
 
     @provider

--- a/arbeitszeit_flask/dependency_injection/views.py
+++ b/arbeitszeit_flask/dependency_injection/views.py
@@ -311,15 +311,3 @@ class ViewsModule(Module):
             presenter,
             list_workers,
         )
-
-    @provider
-    def provide_pay_means_of_production_view(
-        self,
-        controller: PayMeansOfProductionController,
-        pay_means_of_production: PayMeansOfProduction,
-        presenter: PayMeansOfProductionPresenter,
-        template_renderer: UserTemplateRenderer,
-    ) -> PayMeansOfProductionView:
-        return PayMeansOfProductionView(
-            controller, pay_means_of_production, presenter, template_renderer
-        )

--- a/arbeitszeit_flask/dependency_injection/views.py
+++ b/arbeitszeit_flask/dependency_injection/views.py
@@ -9,7 +9,6 @@ from arbeitszeit.use_cases.create_cooperation import CreateCooperation
 from arbeitszeit.use_cases.end_cooperation import EndCooperation
 from arbeitszeit.use_cases.get_company_dashboard import GetCompanyDashboardUseCase
 from arbeitszeit.use_cases.list_workers import ListWorkers
-from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProduction
 from arbeitszeit.use_cases.register_accountant import RegisterAccountantUseCase
 from arbeitszeit.use_cases.register_company import RegisterCompany
 from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
@@ -40,7 +39,6 @@ from arbeitszeit_flask.views.invite_worker_to_company import (
     InviteWorkerGetRequestHandler,
     InviteWorkerPostRequestHandler,
 )
-from arbeitszeit_flask.views.pay_means_of_production import PayMeansOfProductionView
 from arbeitszeit_flask.views.show_my_accounts_view import ShowMyAccountsView
 from arbeitszeit_flask.views.signup_accountant_view import SignupAccountantView
 from arbeitszeit_flask.views.signup_company_view import SignupCompanyView
@@ -54,9 +52,6 @@ from arbeitszeit_web.controllers.end_cooperation_controller import (
     EndCooperationController,
 )
 from arbeitszeit_web.controllers.list_workers_controller import ListWorkersController
-from arbeitszeit_web.controllers.pay_means_of_production_controller import (
-    PayMeansOfProductionController,
-)
 from arbeitszeit_web.controllers.register_accountant_controller import (
     RegisterAccountantController,
 )
@@ -75,7 +70,6 @@ from arbeitszeit_web.invite_worker_to_company import (
     InviteWorkerToCompanyController,
     InviteWorkerToCompanyPresenter,
 )
-from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresenter
 from arbeitszeit_web.presenters.accountant_invitation_presenter import (
     AccountantInvitationEmailView,
 )

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -354,33 +354,36 @@ class PayMeansOfProductionForm(Form):
         render_kw={"placeholder": trans.lazy_gettext("Plan ID")},
         validators=[
             validators.InputRequired(),
-            validators.UUID(message=error_msgs["uuid"]),
         ],
     )
-    amount = IntegerField(
+    amount = StringField(
         render_kw={"placeholder": trans.lazy_gettext("Amount")},
         validators=[
             validators.InputRequired(),
-            validators.NumberRange(min=0, message=error_msgs["num_range_min_0"]),
         ],
     )
     choices = [
+        ("", ""),
         ("Fixed", trans.lazy_gettext(trans.lazy_gettext("Fixed means of production"))),
         (
             "Liquid",
             trans.lazy_gettext("Liquid means of production"),
         ),
     ]
-    category = SelectField(choices=choices, validators=[validators.DataRequired()])
+    category = SelectField(
+        trans.lazy_gettext("Type of payment"),
+        choices=choices,
+        validators=[validators.DataRequired()],
+    )
 
-    def get_amount_field(self) -> int:
-        return self.data["amount"]
+    def amount_field(self) -> WtFormField[str]:
+        return WtFormField(form=self, field_name="amount")
 
-    def get_plan_id_field(self) -> str:
-        return self.data["plan_id"].strip()
+    def plan_id_field(self) -> WtFormField[str]:
+        return WtFormField(form=self, field_name="plan_id")
 
-    def get_category_field(self) -> str:
-        return self.data["category"]
+    def category_field(self) -> WtFormField[str]:
+        return WtFormField(form=self, field_name="category")
 
 
 class AnswerCompanyWorkInviteForm(Form):

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -33,7 +33,7 @@
         </div>
     </div>
     {% endif %}
-    {% if view_model.show_action_section %}
+    {% if view_model.show_own_plan_action_section %}
     <div class="column is-offset-2 is-8">
         <div class="box">
             <div class="tile is-ancestor">
@@ -42,23 +42,23 @@
                         <div class="tile is-child box has-background-danger-light">
                             <h1 class="title is-4">{{ gettext("Change availability:") }}</h1>
                             <div
-                                class="icon is-large {{ 'has-text-success' if view_model.action.is_available_bool else 'has-text-danger' }}">
+                                class="icon is-large {{ 'has-text-success' if view_model.own_plan_action.is_available_bool else 'has-text-danger' }}">
                                 <a style="text-decoration: none; color: inherit;"
-                                    href="{{ view_model.action.toggle_availability_url }}"><i
-                                        class="{{ 'fas fa-lg fa-toggle-on' if view_model.action.is_available_bool else 'fas fa-lg fa-toggle-off' }}"></i></a>
+                                    href="{{ view_model.own_plan_action.toggle_availability_url }}"><i
+                                        class="{{ 'fas fa-lg fa-toggle-on' if view_model.own_plan_action.is_available_bool else 'fas fa-lg fa-toggle-off' }}"></i></a>
                             </div>
                         </div>
                     </div>
                     <div class="tile is-parent" href="">
                         <div class="tile is-child box has-background-danger-light">
-                            {% if view_model.action.is_cooperating %}
+                            {% if view_model.own_plan_action.is_cooperating %}
                             <h1 class="title is-4">{{ gettext("End cooperation:") }}</h1>
-                            <a class="button is-danger" href="{{ view_model.action.end_coop_url }}">
+                            <a class="button is-danger" href="{{ view_model.own_plan_action.end_coop_url }}">
                                 <span>{{ gettext("End") }}</span>
                             </a>
                             {% else %}
                             <h1 class="title is-4">{{ gettext("Join a cooperation") }} </h1>
-                            <a class="button is-primary" href="{{ view_model.action.request_coop_url }}">
+                            <a class="button is-primary" href="{{ view_model.own_plan_action.request_coop_url }}">
                                 <span>{{ gettext("Join") }}</span>
                             </a>
                             {% endif %}

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -10,12 +10,30 @@
 {{ plan_summary(view_model) }}
 
 <div class="section has-text-centered">
-    {% if view_model.show_action_section %}
     <div class="content">
         <h1 class="title">
             {{ gettext("Actions") }}
         </h1>
     </div>
+    {% if view_model.show_payment_url %}
+    <div class="column is-offset-2 is-8">
+        <div class="box">
+            <div class="tile is-ancestor">
+                <div class="tile is-vertical">
+                    <div class="tile is-parent" href="">
+                        <div class="tile is-child box has-background-danger-light">
+                            <h1 class="title is-4">{{ gettext("Pay product") }}</h1>
+                            <a class="button is-primary" href="{{ view_model.payment_url }}">
+                                <span>{{ gettext("Pay product") }}</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    {% if view_model.show_action_section %}
     <div class="column is-offset-2 is-8">
         <div class="box">
             <div class="tile is-ancestor">

--- a/arbeitszeit_flask/templates/company/transfer_to_company.html
+++ b/arbeitszeit_flask/templates/company/transfer_to_company.html
@@ -14,25 +14,29 @@
                     {{ gettext("Payment of fixed and liquid means of production") }}
                 </h1>
             </div>
+            {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+            {% for error in field_errors %}
+            <div class="notification is-danger">
+                {{ form[field_name].label }}: {{ error }}
+            </div>
+            {% endfor %}
+            {% endfor %}
             <form method="post">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="field">
+                    <label class="label">{{ gettext("Plan ID") }}</label>
                     <div class="control">
                         {{ form.plan_id(class_="input") }}
-			{% for error in form.errors['plan_id'] %}
-			<div class="notification is-danger">{{ error }}</div>
-			{% endfor %}
                     </div>
                 </div>
                 <div class="field">
+                    <label class="label">{{ gettext("Amount") }}</label>
                     <div class="control">
                         {{ form.amount(class_="input") }}
-			{% for error in form.errors['amount'] %}
-			<div class="notification is-danger">{{ error }}</div>
-			{% endfor %}
                     </div>
                 </div>
                 <div class="field">
+                    <label class="label">{{ form.category.label }}</label>
                     <div class="control">
                         <div class="select">
                             <select name="category" required>

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -118,7 +118,7 @@ class GeneralUrlIndex:
             company_id=str(company_id),
         )
 
-    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+    def get_pay_means_of_production_url(self, plan_id: Optional[UUID] = None) -> str:
         return url_for(endpoint="main_company.transfer_to_company", plan_id=plan_id)
 
     def get_toggle_availability_url(self, plan_id: UUID) -> str:
@@ -164,6 +164,3 @@ class CompanyUrlIndex:
         return url_for(
             endpoint="auth.confirm_email_company", token=token, _external=True
         )
-
-    def get_pay_means_of_production_url(self) -> str:
-        return url_for(endpoint="main_company.transfer_to_company")

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -118,21 +118,28 @@ class GeneralUrlIndex:
             company_id=str(company_id),
         )
 
+    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+        return url_for(endpoint="main_company.transfer_to_company", plan_id=plan_id)
+
+    def get_toggle_availability_url(self, plan_id: UUID) -> str:
+        return url_for("main_company.toggle_availability", plan_id=plan_id)
+
+    def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
+        return url_for(
+            "main_company.end_cooperation",
+            plan_id=plan_id,
+            cooperation_id=cooperation_id,
+        )
+
+    def get_request_coop_url(self) -> str:
+        return url_for("main_company.request_cooperation")
+
 
 class MemberUrlIndex:
-    def get_toggle_availability_url(self, plan_id: UUID) -> str:
-        ...
-
     def get_renew_plan_url(self, plan_id: UUID) -> str:
         ...
 
     def get_hide_plan_url(self, plan_id: UUID) -> str:
-        ...
-
-    def get_request_coop_url(self) -> str:
-        ...
-
-    def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         ...
 
     def get_confirmation_url(self, token: str) -> str:
@@ -142,24 +149,11 @@ class MemberUrlIndex:
 
 
 class CompanyUrlIndex:
-    def get_toggle_availability_url(self, plan_id: UUID) -> str:
-        return url_for("main_company.toggle_availability", plan_id=plan_id)
-
     def get_renew_plan_url(self, plan_id: UUID) -> str:
         return url_for("main_company.create_draft_from_plan", plan_id=plan_id)
 
     def get_hide_plan_url(self, plan_id: UUID) -> str:
         return url_for("main_company.hide_plan", plan_id=plan_id)
-
-    def get_request_coop_url(self) -> str:
-        return url_for("main_company.request_cooperation")
-
-    def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
-        return url_for(
-            "main_company.end_cooperation",
-            plan_id=plan_id,
-            cooperation_id=cooperation_id,
-        )
 
     def get_work_invite_url(self, invite_id: UUID) -> str:
         # since invites don't make sense for a company, we redirect

--- a/arbeitszeit_flask/views/pay_means_of_production.py
+++ b/arbeitszeit_flask/views/pay_means_of_production.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from flask import Response, redirect
+from injector import inject
 
 from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProduction
 from arbeitszeit_flask.forms import PayMeansOfProductionForm
@@ -11,6 +12,7 @@ from arbeitszeit_web.controllers.pay_means_of_production_controller import (
 from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresenter
 
 
+@inject
 @dataclass
 class PayMeansOfProductionView:
     controller: PayMeansOfProductionController

--- a/arbeitszeit_flask/views/pay_means_of_production.py
+++ b/arbeitszeit_flask/views/pay_means_of_production.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
+from typing import Optional
 
-from flask import Response, redirect
+from flask import Response as FlaskResponse
+from flask import redirect, request
 from injector import inject
 
 from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProduction
 from arbeitszeit_flask.forms import PayMeansOfProductionForm
 from arbeitszeit_flask.template import UserTemplateRenderer
+from arbeitszeit_flask.types import Response
 from arbeitszeit_web.controllers.pay_means_of_production_controller import (
     PayMeansOfProductionController,
 )
@@ -20,21 +23,29 @@ class PayMeansOfProductionView:
     presenter: PayMeansOfProductionPresenter
     template_renderer: UserTemplateRenderer
 
-    def respond_to_get(self, form: PayMeansOfProductionForm):
-        return Response(self._render_template(form), status=200)
+    def respond_to_get(self, form: PayMeansOfProductionForm) -> Response:
+        plan_id: Optional[str] = request.args.get("plan_id")
+        if plan_id:
+            form.plan_id_field().set_value(plan_id)
+        return FlaskResponse(self._render_template(form), status=200)
 
-    def respond_to_post(self, form: PayMeansOfProductionForm):
-        if form.validate():
+    def respond_to_post(self, form: PayMeansOfProductionForm) -> Response:
+        if not form.validate():
+            return self._handle_invalid_form(form)
+        try:
             data = self.controller.process_input_data(form)
-            use_case_response = self.pay_means_of_production(data)
-            view_model = self.presenter.present(use_case_response)
-            if view_model.redirect_url:
-                return redirect(view_model.redirect_url)
-            return Response(self._render_template(form), status=200)
-        else:
-            return Response(self._render_template(form), status=400)
+        except self.controller.FormError:
+            return self._handle_invalid_form(form)
+        use_case_response = self.pay_means_of_production(data)
+        view_model = self.presenter.present(use_case_response)
+        if view_model.redirect_url:
+            return redirect(view_model.redirect_url)
+        return FlaskResponse(self._render_template(form), status=200)
 
     def _render_template(self, form: PayMeansOfProductionForm) -> str:
         return self.template_renderer.render_template(
             "company/transfer_to_company.html", context=dict(form=form)
         )
+
+    def _handle_invalid_form(self, form: PayMeansOfProductionForm) -> Response:
+        return FlaskResponse(self._render_template(form), status=400)

--- a/arbeitszeit_web/controllers/pay_means_of_production_controller.py
+++ b/arbeitszeit_web/controllers/pay_means_of_production_controller.py
@@ -1,39 +1,55 @@
 from dataclasses import dataclass
-from typing import Protocol
 from uuid import UUID
+
+from injector import inject
 
 from arbeitszeit.entities import PurposesOfPurchases
 from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProductionRequest
-from arbeitszeit_web.request import Request
+from arbeitszeit_web.forms import PayMeansOfProductionForm
 from arbeitszeit_web.session import Session
+from arbeitszeit_web.translator import Translator
 
 
-class PayMeansOfProductionForm(Protocol):
-    def get_plan_id_field(self) -> UUID:
-        ...
-
-    def get_amount_field(self) -> int:
-        ...
-
-    def get_category_field(self) -> str:
-        ...
-
-
+@inject
 @dataclass
 class PayMeansOfProductionController:
+    class FormError(Exception):
+        pass
+
     session: Session
-    request: Request
+    translator: Translator
 
     def process_input_data(
         self, form: PayMeansOfProductionForm
     ) -> PayMeansOfProductionRequest:
         buyer = self.session.get_current_user()
         assert buyer
-        plan = form.get_plan_id_field()
-        amount = form.get_amount_field()
+        try:
+            plan = UUID(form.plan_id_field().get_value().strip())
+        except ValueError:
+            form.plan_id_field().attach_error(self.translator.gettext("Invalid ID."))
+            raise self.FormError()
+        try:
+            amount = int(form.amount_field().get_value())
+            if amount <= 0:
+                form.amount_field().attach_error(
+                    self.translator.gettext("Must be a number larger than zero.")
+                )
+                raise self.FormError()
+        except ValueError:
+            form.amount_field().attach_error(
+                self.translator.gettext("This is not an integer.")
+            )
+            raise self.FormError()
+        category = form.category_field().get_value()
+        if not category:
+            form.category_field().attach_error(
+                self.translator.gettext("This field is required.")
+            )
+            raise self.FormError()
         purpose = (
             PurposesOfPurchases.means_of_prod
-            if form.get_category_field() == "Fixed"
+            if category == "Fixed"
             else PurposesOfPurchases.raw_materials
         )
         return PayMeansOfProductionRequest(buyer, plan, amount, purpose)

--- a/arbeitszeit_web/controllers/pay_means_of_production_controller.py
+++ b/arbeitszeit_web/controllers/pay_means_of_production_controller.py
@@ -31,14 +31,14 @@ class PayMeansOfProductionController:
             raise self.FormError()
         try:
             amount = int(form.amount_field().get_value())
-            if amount <= 0:
-                form.amount_field().attach_error(
-                    self.translator.gettext("Must be a number larger than zero.")
-                )
-                raise self.FormError()
         except ValueError:
             form.amount_field().attach_error(
                 self.translator.gettext("This is not an integer.")
+            )
+            raise self.FormError()
+        if amount <= 0:
+            form.amount_field().attach_error(
+                self.translator.gettext("Must be a number larger than zero.")
             )
             raise self.FormError()
         category = form.category_field().get_value()

--- a/arbeitszeit_web/forms.py
+++ b/arbeitszeit_web/forms.py
@@ -61,3 +61,14 @@ class PayConsumerProductForm(Protocol):
 
     def plan_id_field(self) -> FormField[str]:
         ...
+
+
+class PayMeansOfProductionForm(Protocol):
+    def amount_field(self) -> FormField[str]:
+        ...
+
+    def plan_id_field(self) -> FormField[str]:
+        ...
+
+    def category_field(self) -> FormField[str]:
+        ...

--- a/arbeitszeit_web/get_coop_summary.py
+++ b/arbeitszeit_web/get_coop_summary.py
@@ -7,7 +7,7 @@ from injector import inject
 from arbeitszeit.use_cases.get_coop_summary import GetCoopSummarySuccess
 from arbeitszeit_web.session import Session
 
-from .url_index import EndCoopUrlIndex, UrlIndex, UserUrlIndex
+from .url_index import UrlIndex, UserUrlIndex
 
 
 @dataclass
@@ -39,7 +39,6 @@ class GetCoopSummaryViewModel:
 @dataclass
 class GetCoopSummarySuccessPresenter:
     user_url_index: UserUrlIndex
-    end_coop_url_index: EndCoopUrlIndex
     url_index: UrlIndex
     session: Session
 
@@ -63,7 +62,7 @@ class GetCoopSummarySuccessPresenter:
                         plan.plan_individual_price
                     ),
                     plan_coop_price=self.__format_price(plan.plan_coop_price),
-                    end_coop_url=self.end_coop_url_index.get_end_coop_url(
+                    end_coop_url=self.url_index.get_end_coop_url(
                         plan_id=plan.plan_id, cooperation_id=response.coop_id
                     ),
                 )

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -14,7 +14,7 @@ from .url_index import UrlIndex
 
 
 @dataclass
-class Action:
+class OwnPlanAction:
     is_available_bool: bool
     toggle_availability_url: str
     is_cooperating: bool
@@ -25,8 +25,8 @@ class Action:
 @dataclass
 class GetPlanSummaryCompanyViewModel:
     summary: PlanSummaryWeb
-    show_action_section: bool
-    action: Action
+    show_own_plan_action_section: bool
+    own_plan_action: OwnPlanAction
     show_payment_url: bool
     payment_url: str
 
@@ -51,8 +51,8 @@ class GetPlanSummaryCompanySuccessPresenter:
         is_cooperating = plan_summary.is_cooperating
         return GetPlanSummaryCompanyViewModel(
             summary=self.plan_summary_service.format_plan_summary(plan_summary),
-            show_action_section=response.current_user_is_planner,
-            action=Action(
+            show_own_plan_action_section=response.current_user_is_planner,
+            own_plan_action=OwnPlanAction(
                 is_available_bool=plan_summary.is_available,
                 toggle_availability_url=self.url_index.get_toggle_availability_url(
                     plan_id

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -66,7 +66,5 @@ class GetPlanSummaryCompanySuccessPresenter:
                 else None,
             ),
             show_payment_url=True if not response.current_user_is_planner else False,
-            payment_url=self.url_index.get_pay_means_of_production_with_plan_parameter_url(
-                plan_id
-            ),
+            payment_url=self.url_index.get_pay_means_of_production_url(plan_id),
         )

--- a/arbeitszeit_web/pay_means_of_production.py
+++ b/arbeitszeit_web/pay_means_of_production.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from injector import inject
+
 from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProductionResponse
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.url_index import PayMeansOfProductionUrlIndex
+from arbeitszeit_web.url_index import UrlIndex
 
 from .notification import Notifier
 
 
+@inject
 @dataclass
 class PayMeansOfProductionPresenter:
     @dataclass
@@ -18,7 +21,7 @@ class PayMeansOfProductionPresenter:
 
     user_notifier: Notifier
     trans: Translator
-    pay_means_of_production_url_index: PayMeansOfProductionUrlIndex
+    url_index: UrlIndex
 
     def present(self, use_case_response: PayMeansOfProductionResponse) -> ViewModel:
         redirect_url: Optional[str] = None
@@ -26,9 +29,7 @@ class PayMeansOfProductionPresenter:
         reasons = use_case_response.RejectionReason
         if use_case_response.rejection_reason is None:
             self.user_notifier.display_info(self.trans.gettext("Successfully paid."))
-            redirect_url = (
-                self.pay_means_of_production_url_index.get_pay_means_of_production_url()
-            )
+            redirect_url = self.url_index.get_pay_means_of_production_url()
         elif use_case_response.rejection_reason == reasons.plan_not_found:
             self.user_notifier.display_warning(
                 self.trans.gettext("Plan does not exist.")

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -77,9 +77,16 @@ class UrlIndex(Protocol):
     def get_pay_consumer_product_url(self, amount: int, plan_id: UUID) -> str:
         ...
 
+    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+        ...
 
-class TogglePlanAvailabilityUrlIndex(Protocol):
     def get_toggle_availability_url(self, plan_id: UUID) -> str:
+        ...
+
+    def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
+        ...
+
+    def get_request_coop_url(self) -> str:
         ...
 
 
@@ -90,16 +97,6 @@ class RenewPlanUrlIndex(Protocol):
 
 class HidePlanUrlIndex(Protocol):
     def get_hide_plan_url(self, plan_id: UUID) -> str:
-        ...
-
-
-class RequestCoopUrlIndex(Protocol):
-    def get_request_coop_url(self) -> str:
-        ...
-
-
-class EndCoopUrlIndex(Protocol):
-    def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         ...
 
 

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -77,7 +77,7 @@ class UrlIndex(Protocol):
     def get_pay_consumer_product_url(self, amount: int, plan_id: UUID) -> str:
         ...
 
-    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+    def get_pay_means_of_production_url(self, plan_id: Optional[UUID] = None) -> str:
         ...
 
     def get_toggle_availability_url(self, plan_id: UUID) -> str:
@@ -107,11 +107,6 @@ class ConfirmationUrlIndex(Protocol):
 
 class AccountantInvitationUrlIndex(Protocol):
     def get_accountant_invitation_url(self, token: str) -> str:
-        ...
-
-
-class PayMeansOfProductionUrlIndex(Protocol):
-    def get_pay_means_of_production_url(self) -> str:
         ...
 
 

--- a/tests/controllers/dependency_injection.py
+++ b/tests/controllers/dependency_injection.py
@@ -4,9 +4,6 @@ from arbeitszeit_web.answer_company_work_invite import AnswerCompanyWorkInviteCo
 from arbeitszeit_web.controllers.end_cooperation_controller import (
     EndCooperationController,
 )
-from arbeitszeit_web.controllers.pay_means_of_production_controller import (
-    PayMeansOfProductionController,
-)
 from arbeitszeit_web.controllers.send_work_certificates_to_worker_controller import (
     SendWorkCertificatesToWorkerController,
 )
@@ -60,15 +57,6 @@ class ControllerTestsModule(Module):
     ) -> PayConsumerProductController:
         return PayConsumerProductController(
             translator=translator,
-        )
-
-    @provider
-    def provide_pay_means_of_production_controller(
-        self, session: FakeSession, request: FakeRequest
-    ) -> PayMeansOfProductionController:
-        return PayMeansOfProductionController(
-            session=session,
-            request=request,
         )
 
     @provider

--- a/tests/controllers/test_pay_means_of_production_controller.py
+++ b/tests/controllers/test_pay_means_of_production_controller.py
@@ -82,7 +82,7 @@ class AuthenticatedCompanyTests(TestCase):
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
         self.assertEqual(
-            form.amount_errors,
+            form.amount_field().errors,
             [self.translator.gettext("Must be a number larger than zero.")],
         )
 
@@ -91,7 +91,7 @@ class AuthenticatedCompanyTests(TestCase):
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
         self.assertEqual(
-            form.amount_errors,
+            form.amount_field().errors,
             [self.translator.gettext("This is not an integer.")],
         )
 
@@ -102,7 +102,7 @@ class AuthenticatedCompanyTests(TestCase):
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
         self.assertEqual(
-            form.amount_errors,
+            form.amount_field().errors,
             [self.translator.gettext("This is not an integer.")],
         )
 
@@ -112,7 +112,9 @@ class AuthenticatedCompanyTests(TestCase):
         form = self.get_fake_form(plan_id="")
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
-        self.assertEqual(form.plan_id_errors, [self.translator.gettext("Invalid ID.")])
+        self.assertEqual(
+            form.plan_id_field().errors, [self.translator.gettext("Invalid ID.")]
+        )
 
     def test_correct_error_message_returned_when_plan_id_is_invalid_uuid(
         self,
@@ -121,7 +123,7 @@ class AuthenticatedCompanyTests(TestCase):
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
         self.assertEqual(
-            form.plan_id_errors,
+            form.plan_id_field().errors,
             [self.translator.gettext("Invalid ID.")],
         )
 
@@ -132,7 +134,8 @@ class AuthenticatedCompanyTests(TestCase):
         with self.assertRaises(self.controller.FormError):
             self.controller.process_input_data(form)
         self.assertEqual(
-            form.category_errors, [self.translator.gettext("This field is required.")]
+            form.category_field().errors,
+            [self.translator.gettext("This field is required.")],
         )
 
     def get_fake_form(

--- a/tests/controllers/test_pay_means_of_production_controller.py
+++ b/tests/controllers/test_pay_means_of_production_controller.py
@@ -1,79 +1,141 @@
-from typing import Dict, List
 from unittest import TestCase
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from arbeitszeit.entities import PurposesOfPurchases
 from arbeitszeit.use_cases.pay_means_of_production import PayMeansOfProductionRequest
 from arbeitszeit_web.controllers.pay_means_of_production_controller import (
     PayMeansOfProductionController,
 )
-from tests.request import FakeRequest
+from tests.forms import PayMeansFakeForm
 from tests.session import FakeSession
+from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
-
-
-class FakePayMeansForm:
-    def __init__(self, amount: int, plan_id: UUID, category: str) -> None:
-        self.amount = amount
-        self.plan_id = plan_id
-        self.category = category
-        self._errors: Dict[str, List[str]] = {}
-
-    def get_amount_field(self) -> int:
-        return self.amount
-
-    def get_plan_id_field(self) -> UUID:
-        return self.plan_id
-
-    def get_category_field(self) -> str:
-        return self.category
 
 
 class AuthenticatedCompanyTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
+        self.translator = self.injector.get(FakeTranslator)
         self.session = self.injector.get(FakeSession)
-        self.request = self.injector.get(FakeRequest)
-        self.controller = self.injector.get(PayMeansOfProductionController)
         self.expected_user_id = uuid4()
         self.session.set_current_user_id(self.expected_user_id)
-        self.fake_form = FakePayMeansForm(amount=10, plan_id=uuid4(), category="Fixed")
+        self.controller = PayMeansOfProductionController(self.session, self.translator)
 
     def test_use_case_request_gets_returned_when_correct_input_data(self):
-        output = self.controller.process_input_data(self.fake_form)
+        output = self.controller.process_input_data(self.get_fake_form())
         self.assertIsInstance(output, PayMeansOfProductionRequest)
 
     def test_successfull_use_case_request_has_correct_buyer_id(self):
-        output = self.controller.process_input_data(self.fake_form)
-        assert isinstance(output, PayMeansOfProductionRequest)
+        output = self.controller.process_input_data(self.get_fake_form())
         self.assertEqual(output.buyer, self.expected_user_id)
 
     def test_successfull_use_case_request_has_correct_plan_id(self):
-        expected_plan_id = self.fake_form.plan_id
-        output = self.controller.process_input_data(self.fake_form)
-        assert isinstance(output, PayMeansOfProductionRequest)
+        expected_plan_id = uuid4()
+        output = self.controller.process_input_data(
+            self.get_fake_form(plan_id=str(expected_plan_id))
+        )
+        self.assertEqual(output.plan, expected_plan_id)
+
+    def test_successfull_use_case_request_has_plan_id_with_stripped_whitespaces(self):
+        expected_plan_id = uuid4()
+        form_input_plan_id = f"  {expected_plan_id}   "
+        output = self.controller.process_input_data(
+            self.get_fake_form(plan_id=form_input_plan_id)
+        )
         self.assertEqual(output.plan, expected_plan_id)
 
     def test_successfull_use_case_request_has_correct_amount(self):
-        expected_amount = self.fake_form.amount
-        output = self.controller.process_input_data(self.fake_form)
-        assert isinstance(output, PayMeansOfProductionRequest)
+        expected_amount = 10
+        output = self.controller.process_input_data(self.get_fake_form(amount="10"))
         self.assertEqual(output.amount, expected_amount)
 
     def test_successfull_use_case_request_has_correct_category_of_fixed_means_of_production(
         self,
     ):
         expected_category = PurposesOfPurchases.means_of_prod
-        assert self.fake_form.category == "Fixed"
-        output = self.controller.process_input_data(self.fake_form)
-        assert isinstance(output, PayMeansOfProductionRequest)
+        assert self.get_fake_form().category_field().get_value() == "Fixed"
+        output = self.controller.process_input_data(self.get_fake_form())
         self.assertEqual(output.purpose, expected_category)
 
     def test_successfull_use_case_request_has_correct_category_of_liquid_means(self):
         expected_category = PurposesOfPurchases.raw_materials
-        form = self.fake_form
-        form.category = "Liquid"
-        output = self.controller.process_input_data(self.fake_form)
-        assert isinstance(output, PayMeansOfProductionRequest)
+        output = self.controller.process_input_data(
+            self.get_fake_form(category="Liquid")
+        )
         self.assertEqual(output.purpose, expected_category)
+
+    def test_error_is_raised_if_amount_field_is_empty(self):
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(self.get_fake_form(amount=""))
+
+    def test_error_is_raised_if_plan_id_field_is_empty(self):
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(self.get_fake_form(plan_id=""))
+
+    def test_error_is_raised_if_category_field_is_empty(self):
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(self.get_fake_form(category=""))
+
+    def test_correct_error_message_when_amount_is_negative(self):
+        form = self.get_fake_form(amount="-1")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(
+            form.amount_errors,
+            [self.translator.gettext("Must be a number larger than zero.")],
+        )
+
+    def test_correct_error_message_when_amount_is_float_string(self):
+        form = self.get_fake_form(amount="1.1")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(
+            form.amount_errors,
+            [self.translator.gettext("This is not an integer.")],
+        )
+
+    def test_correct_error_message_returned_when_amount_string_contains_letters(
+        self,
+    ) -> None:
+        form = self.get_fake_form(amount="1a")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(
+            form.amount_errors,
+            [self.translator.gettext("This is not an integer.")],
+        )
+
+    def test_correct_error_message_returned_for_plan_id_when_form_data_is_empty_string(
+        self,
+    ) -> None:
+        form = self.get_fake_form(plan_id="")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(form.plan_id_errors, [self.translator.gettext("Invalid ID.")])
+
+    def test_correct_error_message_returned_when_plan_id_is_invalid_uuid(
+        self,
+    ) -> None:
+        form = self.get_fake_form(plan_id="aa18781hh")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(
+            form.plan_id_errors,
+            [self.translator.gettext("Invalid ID.")],
+        )
+
+    def test_correct_error_message_returned_when_category_is_empty(
+        self,
+    ) -> None:
+        form = self.get_fake_form(category="")
+        with self.assertRaises(self.controller.FormError):
+            self.controller.process_input_data(form)
+        self.assertEqual(
+            form.category_errors, [self.translator.gettext("This field is required.")]
+        )
+
+    def get_fake_form(
+        self, amount: str = "10", plan_id: str = str(uuid4()), category: str = "Fixed"
+    ) -> PayMeansFakeForm:
+        return PayMeansFakeForm(amount=amount, plan_id=plan_id, category=category)

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -12,6 +12,7 @@ from arbeitszeit.use_cases.send_accountant_registration_token.accountant_invitat
 )
 from arbeitszeit_web.colors import Colors
 from arbeitszeit_web.plotter import Plotter
+from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
 from tests.accountant_invitation_presenter import AccountantInvitationPresenterTestImpl
 from tests.company import CompanyManager
@@ -72,6 +73,11 @@ class TestingModule(Module):
     @singleton
     @provider
     def provide_fake_session(self) -> FakeSession:
+        return FakeSession()
+
+    @singleton
+    @provider
+    def provide_session(self) -> Session:
         return FakeSession()
 
     @provider

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -77,8 +77,8 @@ class TestingModule(Module):
 
     @singleton
     @provider
-    def provide_session(self) -> Session:
-        return FakeSession()
+    def provide_session(self, instance: FakeSession) -> Session:
+        return instance
 
     @provider
     def provide_fake_token_service(

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -22,14 +22,6 @@ class CompanyUrlIndexTests(ViewTestCase):
         self.cooperation_generator = self.injector.get(CooperationGenerator)
         self.company_generator = self.injector.get(CompanyGenerator)
 
-    def test_toggle_availability_url_for_existing_plan_leads_to_functional_url(
-        self,
-    ) -> None:
-        plan = self.plan_generator.create_plan()
-        url = self.url_index.get_toggle_availability_url(plan.id)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-
     def test_renew_plan_url_for_existing_plan_leads_to_functional_url(
         self,
     ) -> None:
@@ -43,24 +35,6 @@ class CompanyUrlIndexTests(ViewTestCase):
     ) -> None:
         plan = self.plan_generator.create_plan()
         url = self.url_index.get_hide_plan_url(plan.id)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-
-    def test_request_coop_url_leads_to_functional_url(
-        self,
-    ) -> None:
-        url = self.url_index.get_request_coop_url()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-    def test_end_coop_url_for_existing_plan_and_cooperation_leads_to_functional_url(
-        self,
-    ) -> None:
-        plan = self.plan_generator.create_plan()
-        coop = self.cooperation_generator.create_cooperation(
-            coordinator=self.company, plans=[plan]
-        )
-        url = self.url_index.get_end_coop_url(plan.id, coop.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
@@ -256,6 +230,46 @@ class GeneralUrlIndexTests(ViewTestCase):
         return response.invite_id
 
     def test_url_for_payment_of_consumer_product_leads_to_functional_url(self) -> None:
+        self.login_member()
         url = self.url_index.get_pay_consumer_product_url(amount=1, plan_id=uuid4())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_for_payment_of_means_of_production_with_plan_parameter_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        url = self.url_index.get_pay_means_of_production_with_plan_parameter_url(
+            uuid4()
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_toggle_availability_url_for_existing_plan_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        plan = self.plan_generator.create_plan()
+        url = self.url_index.get_toggle_availability_url(plan.id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_request_coop_url_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        url = self.url_index.get_request_coop_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_end_coop_url_for_existing_plan_and_cooperation_leads_to_functional_url(
+        self,
+    ) -> None:
+        company = self.login_company()
+        plan = self.plan_generator.create_plan()
+        coop = self.cooperation_generator.create_cooperation(
+            coordinator=company, plans=[plan]
+        )
+        url = self.url_index.get_end_coop_url(plan.id, coop.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -38,11 +38,6 @@ class CompanyUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
-    def test_pay_means_of_production_url_leads_to_a_view(self) -> None:
-        url = self.url_index.get_pay_means_of_production_url()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
 
 class PlotUrlIndexTests(ViewTestCase):
     def setUp(self) -> None:
@@ -235,13 +230,19 @@ class GeneralUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_url_for_payment_of_means_of_production_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        url = self.url_index.get_pay_means_of_production_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_url_for_payment_of_means_of_production_with_plan_parameter_leads_to_functional_url(
         self,
     ) -> None:
         self.login_company()
-        url = self.url_index.get_pay_means_of_production_with_plan_parameter_url(
-            uuid4()
-        )
+        url = self.url_index.get_pay_means_of_production_url(uuid4())
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -103,6 +103,25 @@ class PayConsumerProductFakeForm:
         self._plan_id = plan_id
 
 
+class PayMeansFakeForm:
+    def __init__(self, amount: str, plan_id: str, category: str) -> None:
+        self._amount = amount
+        self._plan_id = plan_id
+        self._category = category
+        self.amount_errors: List[str] = []
+        self.plan_id_errors: List[str] = []
+        self.category_errors: List[str] = []
+
+    def amount_field(self) -> FormFieldImpl[str]:
+        return FormFieldImpl(value=self._amount, errors=self.amount_errors)
+
+    def plan_id_field(self) -> FormFieldImpl[str]:
+        return FormFieldImpl(value=self._plan_id, errors=self.plan_id_errors)
+
+    def category_field(self) -> FormFieldImpl[str]:
+        return FormFieldImpl(value=self._category, errors=self.category_errors)
+
+
 class FormFieldImpl(Generic[T]):
     def __init__(self, value: T, errors: Optional[List[str]] = None) -> None:
         if errors is None:

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -105,21 +105,18 @@ class PayConsumerProductFakeForm:
 
 class PayMeansFakeForm:
     def __init__(self, amount: str, plan_id: str, category: str) -> None:
-        self._amount = amount
-        self._plan_id = plan_id
-        self._category = category
-        self.amount_errors: List[str] = []
-        self.plan_id_errors: List[str] = []
-        self.category_errors: List[str] = []
+        self._amount_field = FormFieldImpl(value=amount)
+        self._plan_id_field = FormFieldImpl(value=plan_id)
+        self._category_field = FormFieldImpl(value=category)
 
     def amount_field(self) -> FormFieldImpl[str]:
-        return FormFieldImpl(value=self._amount, errors=self.amount_errors)
+        return self._amount_field
 
     def plan_id_field(self) -> FormFieldImpl[str]:
-        return FormFieldImpl(value=self._plan_id, errors=self.plan_id_errors)
+        return self._plan_id_field
 
     def category_field(self) -> FormFieldImpl[str]:
-        return FormFieldImpl(value=self._category, errors=self.category_errors)
+        return self._category_field
 
 
 class FormFieldImpl(Generic[T]):

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.hide_plan import HidePlanPresenter
 from arbeitszeit_web.invite_worker_to_company import InviteWorkerToCompanyPresenter
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.pay_consumer_product import PayConsumerProductPresenter
-from arbeitszeit_web.pay_means_of_production import PayMeansOfProductionPresenter
 from arbeitszeit_web.presenters.accountant_invitation_presenter import (
     AccountantInvitationEmailPresenter,
 )
@@ -54,7 +53,6 @@ from .url_index import (
     ConfirmationUrlIndexImpl,
     HidePlanUrlIndexTestImpl,
     LanguageChangerUrlIndexImpl,
-    PayMeansOfProductionUrlIndexImpl,
     RenewPlanUrlIndexTestImpl,
     UrlIndexTestImpl,
 )
@@ -142,19 +140,6 @@ class PresenterTestsInjector(Module):
         return PayConsumerProductPresenter(
             user_notifier=notifier,
             translator=translator,
-        )
-
-    @provider
-    def provide_pay_means_of_production_presenter(
-        self,
-        notifier: Notifier,
-        translator: FakeTranslator,
-        pay_means_of_production_url_index: PayMeansOfProductionUrlIndexImpl,
-    ) -> PayMeansOfProductionPresenter:
-        return PayMeansOfProductionPresenter(
-            user_notifier=notifier,
-            trans=translator,
-            pay_means_of_production_url_index=pay_means_of_production_url_index,
         )
 
     @provider

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -1,11 +1,7 @@
 from injector import Injector, Module, inject, provider, singleton
 
 from arbeitszeit_web.create_cooperation import CreateCooperationPresenter
-from arbeitszeit_web.formatters.plan_summary_formatter import PlanSummaryFormatter
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsPresenter
-from arbeitszeit_web.get_plan_summary_company import (
-    GetPlanSummaryCompanySuccessPresenter,
-)
 from arbeitszeit_web.hide_plan import HidePlanPresenter
 from arbeitszeit_web.invite_worker_to_company import InviteWorkerToCompanyPresenter
 from arbeitszeit_web.notification import Notifier
@@ -35,12 +31,7 @@ from arbeitszeit_web.presenters.send_work_certificates_to_worker_presenter impor
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.request_cooperation import RequestCooperationPresenter
 from arbeitszeit_web.session import Session
-from arbeitszeit_web.url_index import (
-    EndCoopUrlIndex,
-    HidePlanUrlIndex,
-    RenewPlanUrlIndex,
-    UrlIndex,
-)
+from arbeitszeit_web.url_index import HidePlanUrlIndex, RenewPlanUrlIndex, UrlIndex
 from tests.datetime_service import FakeDatetimeService
 from tests.dependency_injection import TestingModule
 from tests.email import (
@@ -61,13 +52,10 @@ from .url_index import (
     AccountantDashboardUrlIndexImpl,
     AccountantInvitationUrlIndexImpl,
     ConfirmationUrlIndexImpl,
-    EndCoopUrlIndexTestImpl,
     HidePlanUrlIndexTestImpl,
     LanguageChangerUrlIndexImpl,
     PayMeansOfProductionUrlIndexImpl,
     RenewPlanUrlIndexTestImpl,
-    RequestCoopUrlIndexTestImpl,
-    TogglePlanAvailabilityUrlIndex,
     UrlIndexTestImpl,
 )
 
@@ -90,12 +78,6 @@ class PresenterTestsInjector(Module):
         return index
 
     @provider
-    def provide_end_coop_url_index(
-        self, index: EndCoopUrlIndexTestImpl
-    ) -> EndCoopUrlIndex:
-        return index
-
-    @provider
     def provide_session(self, session: FakeSession) -> Session:
         return session
 
@@ -112,13 +94,6 @@ class PresenterTestsInjector(Module):
     @provider
     def provide_notifier(self, notifier: NotifierTestImpl) -> Notifier:
         return notifier
-
-    @singleton
-    @provider
-    def provide_toggle_plan_availability_url_index(
-        self,
-    ) -> TogglePlanAvailabilityUrlIndex:
-        return TogglePlanAvailabilityUrlIndex()
 
     @singleton
     @provider
@@ -149,23 +124,6 @@ class PresenterTestsInjector(Module):
             translator=translator,
             mail_service=mail_service,
             email_configuration=email_configuration,
-        )
-
-    @provider
-    def provide_get_plan_summary_company_success_presenter(
-        self,
-        toggle_availability_url_index: TogglePlanAvailabilityUrlIndex,
-        end_coop_url_index: EndCoopUrlIndexTestImpl,
-        request_coop_url_index: RequestCoopUrlIndexTestImpl,
-        translator: FakeTranslator,
-        plan_summary_service: PlanSummaryFormatter,
-    ) -> GetPlanSummaryCompanySuccessPresenter:
-        return GetPlanSummaryCompanySuccessPresenter(
-            toggle_availability_url_index=toggle_availability_url_index,
-            end_coop_url_index=end_coop_url_index,
-            request_coop_url_index=request_coop_url_index,
-            trans=translator,
-            plan_summary_service=plan_summary_service,
         )
 
     @provider

--- a/tests/presenters/test_get_coop_summary_presenter.py
+++ b/tests/presenters/test_get_coop_summary_presenter.py
@@ -9,7 +9,7 @@ from arbeitszeit_web.session import UserRole
 from tests.session import FakeSession
 
 from .dependency_injection import get_dependency_injector
-from .url_index import EndCoopUrlIndexTestImpl, UrlIndexTestImpl
+from .url_index import UrlIndexTestImpl
 
 TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
     requester_is_coordinator=True,
@@ -33,7 +33,6 @@ class GetCoopSummarySuccessPresenterTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
         self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.end_coop_url_index = self.injector.get(EndCoopUrlIndexTestImpl)
         self.presenter = self.injector.get(GetCoopSummarySuccessPresenter)
         self.session = self.injector.get(FakeSession)
         self.session.login_company("test@test.test")
@@ -108,7 +107,7 @@ class GetCoopSummarySuccessPresenterTests(TestCase):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
             view_model.plans[0].end_coop_url,
-            self.end_coop_url_index.get_end_coop_url(
+            self.url_index.get_end_coop_url(
                 TESTING_RESPONSE_MODEL.plans[0].plan_id, TESTING_RESPONSE_MODEL.coop_id
             ),
         )

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -152,7 +152,7 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.payment_url,
-            self.url_index.get_pay_means_of_production_with_plan_parameter_url(
+            self.url_index.get_pay_means_of_production_url(
                 TESTING_PLAN_SUMMARY.plan_id
             ),
         )

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -55,24 +55,24 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
 
     def test_action_section_is_shown_when_current_user_is_planner(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
-        self.assertTrue(view_model.show_action_section)
+        self.assertTrue(view_model.show_own_plan_action_section)
 
     def test_action_section_is_not_shown_when_current_user_is_not_planner(self):
         response = replace(TESTING_RESPONSE_MODEL, current_user_is_planner=False)
         view_model = self.presenter.present(response)
-        self.assertFalse(view_model.show_action_section)
+        self.assertFalse(view_model.show_own_plan_action_section)
 
     def test_view_model_sows_availability_when_plan_is_available(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
-            view_model.action.is_available_bool,
+            view_model.own_plan_action.is_available_bool,
             TESTING_PLAN_SUMMARY.is_available,
         )
 
     def test_url_for_changing_availability_is_displayed_correctly(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
-            view_model.action.toggle_availability_url,
+            view_model.own_plan_action.toggle_availability_url,
             self.url_index.get_toggle_availability_url(TESTING_PLAN_SUMMARY.plan_id),
         )
 
@@ -81,9 +81,9 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
     ):
         assert TESTING_PLAN_SUMMARY.cooperation
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
-        self.assertTrue(view_model.action.is_cooperating)
+        self.assertTrue(view_model.own_plan_action.is_cooperating)
         self.assertEqual(
-            view_model.action.is_cooperating,
+            view_model.own_plan_action.is_cooperating,
             TESTING_PLAN_SUMMARY.is_cooperating,
         )
 
@@ -92,9 +92,9 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
     ):
         assert TESTING_PLAN_SUMMARY.cooperation
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
-        self.assertTrue(view_model.action.is_cooperating)
+        self.assertTrue(view_model.own_plan_action.is_cooperating)
         self.assertEqual(
-            view_model.action.end_coop_url,
+            view_model.own_plan_action.end_coop_url,
             self.url_index.get_end_coop_url(
                 TESTING_PLAN_SUMMARY.plan_id,
                 TESTING_PLAN_SUMMARY.cooperation,
@@ -106,8 +106,8 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
     ):
         assert TESTING_PLAN_SUMMARY.cooperation
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
-        self.assertTrue(view_model.action.is_cooperating)
-        self.assertIsNone(view_model.action.request_coop_url)
+        self.assertTrue(view_model.own_plan_action.is_cooperating)
+        self.assertIsNone(view_model.own_plan_action.request_coop_url)
 
     def test_no_url_for_ending_cooperation_is_displayed_when_plan_is_not_cooperating(
         self,
@@ -119,8 +119,8 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
             plan_summary=plan_summary, current_user_is_planner=True
         )
         view_model = self.presenter.present(response)
-        self.assertFalse(view_model.action.is_cooperating)
-        self.assertIsNone(view_model.action.end_coop_url)
+        self.assertFalse(view_model.own_plan_action.is_cooperating)
+        self.assertIsNone(view_model.own_plan_action.end_coop_url)
 
     def test_url_for_requesting_cooperation_is_displayed_correctly_when_plan_is_not_cooperating(
         self,
@@ -132,9 +132,9 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
             plan_summary=plan_summary, current_user_is_planner=True
         )
         view_model = self.presenter.present(response)
-        self.assertFalse(view_model.action.is_cooperating)
+        self.assertFalse(view_model.own_plan_action.is_cooperating)
         self.assertEqual(
-            view_model.action.request_coop_url,
+            view_model.own_plan_action.request_coop_url,
             self.url_index.get_request_coop_url(),
         )
 

--- a/tests/presenters/test_pay_means_of_production_presenter.py
+++ b/tests/presenters/test_pay_means_of_production_presenter.py
@@ -7,7 +7,7 @@ from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
 from .notifier import NotifierTestImpl
-from .url_index import PayMeansOfProductionUrlIndexImpl
+from .url_index import UrlIndexTestImpl
 
 reasons = PayMeansOfProductionResponse.RejectionReason
 
@@ -18,7 +18,7 @@ class PayMeansOfProductionTests(TestCase):
         self.notifier = self.injector.get(NotifierTestImpl)
         self.trans = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(PayMeansOfProductionPresenter)
-        self.url_index = self.injector.get(PayMeansOfProductionUrlIndexImpl)
+        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_show_confirmation_when_payment_was_successful(self) -> None:
         self.presenter.present(
@@ -102,7 +102,8 @@ class PayMeansOfProductionTests(TestCase):
         response = self.create_success_response()
         view_model = self.presenter.present(response)
         self.assertEqual(
-            view_model.redirect_url, self.url_index.get_pay_means_of_production_url()
+            view_model.redirect_url,
+            self.url_index.get_pay_means_of_production_url(),
         )
 
     def create_success_response(self) -> PayMeansOfProductionResponse:

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -67,20 +67,17 @@ class UrlIndexTestImpl:
     def get_pay_consumer_product_url(self, amount: int, plan_id: UUID) -> str:
         return f"pay consumer product url: {amount}, {plan_id}"
 
+    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+        return f"pay means of production url for plan {plan_id}"
 
-class RequestCoopUrlIndexTestImpl:
+    def get_toggle_availability_url(self, plan_id: UUID) -> str:
+        return f"fake_toggle_url:{plan_id}"
+
     def get_request_coop_url(self) -> str:
         return "fake_request_coop_url"
 
-
-class EndCoopUrlIndexTestImpl:
     def get_end_coop_url(self, plan_id: UUID, cooperation_id: UUID) -> str:
         return f"fake_end_coop_url:{plan_id}, {cooperation_id}"
-
-
-class TogglePlanAvailabilityUrlIndex:
-    def get_toggle_availability_url(self, plan_id: UUID) -> str:
-        return f"fake_toggle_url:{plan_id}"
 
 
 class RenewPlanUrlIndexTestImpl:

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -67,7 +67,7 @@ class UrlIndexTestImpl:
     def get_pay_consumer_product_url(self, amount: int, plan_id: UUID) -> str:
         return f"pay consumer product url: {amount}, {plan_id}"
 
-    def get_pay_means_of_production_with_plan_parameter_url(self, plan_id: UUID) -> str:
+    def get_pay_means_of_production_url(self, plan_id: Optional[UUID] = None) -> str:
         return f"pay means of production url for plan {plan_id}"
 
     def get_toggle_availability_url(self, plan_id: UUID) -> str:
@@ -103,11 +103,6 @@ class AccountantInvitationUrlIndexImpl:
 class AccountantDashboardUrlIndexImpl:
     def get_accountant_dashboard_url(self) -> str:
         return "accountant dashboard url"
-
-
-class PayMeansOfProductionUrlIndexImpl:
-    def get_pay_means_of_production_url(self) -> str:
-        return "pay means of production form url"
 
 
 class LanguageChangerUrlIndexImpl:


### PR DESCRIPTION
fixes #413

This PR adds a link to the plan summary pages, as seen by companies (if they are not the planner of the plan), to pay the product more easily. When they click the link, they get forwarded to the payment page, with the UUID of the plan already filled in.

The PR got quite big because I had to touch the plan summary page as well as the pay means of production page and implement the new url index, dependecy injection and form approach.

Plan-ID: ed6eb89f-0633-4544-9ddc-94466b7d5e82