### PR TITLE
show buyer in company's prd account (use case)

### DIFF
--- a/arbeitszeit/transactions.py
+++ b/arbeitszeit/transactions.py
@@ -5,8 +5,8 @@ from typing import List, Union
 
 from injector import inject
 
-from .entities import AccountTypes, Company, Member, Transaction
-from .repositories import TransactionRepository
+from .entities import AccountTypes, Company, Member, SocialAccounting, Transaction
+from .repositories import AccountOwnerRepository, TransactionRepository
 
 
 class TransactionTypes(Enum):
@@ -32,6 +32,7 @@ class TransactionTypes(Enum):
 @dataclass
 class UserAccountingService:
     transaction_repository: TransactionRepository
+    account_owner_repository: AccountOwnerRepository
 
     def get_all_transactions_sorted(
         self, user: Union[Member, Company]
@@ -131,3 +132,21 @@ class UserAccountingService:
         if user_is_sender:
             return -1 * transaction.amount_sent
         return transaction.amount_received
+
+    def get_buyer(
+        self,
+        transaction_type: TransactionTypes,
+        transaction: Transaction,
+    ) -> Union[Member, Company, None]:
+        if transaction_type not in (
+            TransactionTypes.sale_of_consumer_product,
+            TransactionTypes.sale_of_fixed_means,
+            TransactionTypes.sale_of_liquid_means,
+        ):
+            return None
+        buyer_account = transaction.sending_account
+        buyer = self.account_owner_repository.get_account_owner(buyer_account)
+        assert not isinstance(
+            buyer, SocialAccounting
+        )  # from the transactiontype we know: buyer can't be social accounting
+        return buyer

--- a/arbeitszeit/use_cases/show_prd_account_details.py
+++ b/arbeitszeit/use_cases/show_prd_account_details.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from itertools import accumulate
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Union
 from uuid import UUID
 
 from injector import inject
@@ -19,7 +19,7 @@ from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 class ShowPRDAccountDetailsUseCase:
     @dataclass
     class Buyer:
-        buyer_type: Union[Type[Company], Type[Member]]
+        buyer_is_member: bool
         buyer_id: UUID
         buyer_name: str
 
@@ -109,7 +109,7 @@ class ShowPRDAccountDetailsUseCase:
         if not buyer:
             return None
         return self.Buyer(
-            buyer_type=Member if isinstance(buyer, Member) else Company,
+            buyer_is_member=True if isinstance(buyer, Member) else False,
             buyer_id=buyer.id,
             buyer_name=buyer.get_name(),
         )

--- a/arbeitszeit/use_cases/show_prd_account_details.py
+++ b/arbeitszeit/use_cases/show_prd_account_details.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from itertools import accumulate
-from typing import List, Optional, Union
+from typing import List, Optional, Type, Union
 from uuid import UUID
 
 from injector import inject
@@ -19,6 +19,7 @@ from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 class ShowPRDAccountDetailsUseCase:
     @dataclass
     class Buyer:
+        buyer_type: Union[Type[Company], Type[Member]]
         buyer_id: UUID
         buyer_name: str
 
@@ -107,4 +108,8 @@ class ShowPRDAccountDetailsUseCase:
     ) -> Optional[ShowPRDAccountDetailsUseCase.Buyer]:
         if not buyer:
             return None
-        return self.Buyer(buyer_id=buyer.id, buyer_name=buyer.get_name())
+        return self.Buyer(
+            buyer_type=Member if isinstance(buyer, Member) else Company,
+            buyer_id=buyer.id,
+            buyer_name=buyer.get_name(),
+        )

--- a/arbeitszeit/use_cases/show_prd_account_details.py
+++ b/arbeitszeit/use_cases/show_prd_account_details.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from itertools import accumulate
-from typing import List
+from typing import List, Optional, Union
 from uuid import UUID
 
 from injector import inject
 
-from arbeitszeit.entities import AccountTypes, Company, Transaction
+from arbeitszeit.entities import AccountTypes, Company, Member, Transaction
 from arbeitszeit.repositories import AccountRepository, CompanyRepository
 from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 
@@ -18,11 +18,17 @@ from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 @dataclass
 class ShowPRDAccountDetailsUseCase:
     @dataclass
+    class Buyer:
+        buyer_id: UUID
+        buyer_name: str
+
+    @dataclass
     class TransactionInfo:
         transaction_type: TransactionTypes
         date: datetime
         transaction_volume: Decimal
         purpose: str
+        buyer: Optional[ShowPRDAccountDetailsUseCase.Buyer]
 
     @dataclass
     class PlotDetails:
@@ -76,11 +82,13 @@ class ShowPRDAccountDetailsUseCase:
             transaction,
             user_is_sender,
         )
+        buyer = self.accounting_service.get_buyer(transaction_type, transaction)
         return self.TransactionInfo(
-            transaction_type,
-            transaction.date,
-            transaction_volume,
-            transaction.purpose,
+            transaction_type=transaction_type,
+            date=transaction.date,
+            transaction_volume=transaction_volume,
+            purpose=transaction.purpose,
+            buyer=self._create_buyer_info(buyer),
         )
 
     def _get_plot_dates(self, transactions: List[TransactionInfo]) -> List[datetime]:
@@ -93,3 +101,10 @@ class ShowPRDAccountDetailsUseCase:
         volumes.reverse()
         volumes_cumsum = list(accumulate(volumes))
         return volumes_cumsum
+
+    def _create_buyer_info(
+        self, buyer: Union[Company, Member, None]
+    ) -> Optional[ShowPRDAccountDetailsUseCase.Buyer]:
+        if not buyer:
+            return None
+        return self.Buyer(buyer_id=buyer.id, buyer_name=buyer.get_name())

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,7 @@
                     composeExtensions (import nix/developmentOverrides.nix)
                     (import nix/pythonPackages.nix);
                 };
-            in {
-              python310 = overridePython prev.python310;
-            };
+            in { python310 = overridePython prev.python310; };
         };
       };
     in systemDependent // systemIndependent;

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -19,6 +19,7 @@ DEFAULT_INFO1 = ShowPRDAccountDetailsUseCase.TransactionInfo(
     date=datetime.now(),
     transaction_volume=Decimal(10.007),
     purpose="Test purpose",
+    buyer=None,
 )
 
 DEFAULT_INFO2 = ShowPRDAccountDetailsUseCase.TransactionInfo(
@@ -26,6 +27,9 @@ DEFAULT_INFO2 = ShowPRDAccountDetailsUseCase.TransactionInfo(
     date=datetime.now(),
     transaction_volume=Decimal(20),
     purpose="Test purpose",
+    buyer=ShowPRDAccountDetailsUseCase.Buyer(
+        buyer_id=uuid4(), buyer_name="member name"
+    ),
 )
 
 

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -4,6 +4,7 @@ from typing import List
 from unittest import TestCase
 from uuid import UUID, uuid4
 
+from arbeitszeit.entities import Member
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.show_prd_account_details import ShowPRDAccountDetailsUseCase
 from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
@@ -28,7 +29,7 @@ DEFAULT_INFO2 = ShowPRDAccountDetailsUseCase.TransactionInfo(
     transaction_volume=Decimal(20),
     purpose="Test purpose",
     buyer=ShowPRDAccountDetailsUseCase.Buyer(
-        buyer_id=uuid4(), buyer_name="member name"
+        buyer_type=Member, buyer_id=uuid4(), buyer_name="member name"
     ),
 )
 

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -4,7 +4,6 @@ from typing import List
 from unittest import TestCase
 from uuid import UUID, uuid4
 
-from arbeitszeit.entities import Member
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.show_prd_account_details import ShowPRDAccountDetailsUseCase
 from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
@@ -29,7 +28,7 @@ DEFAULT_INFO2 = ShowPRDAccountDetailsUseCase.TransactionInfo(
     transaction_volume=Decimal(20),
     purpose="Test purpose",
     buyer=ShowPRDAccountDetailsUseCase.Buyer(
-        buyer_type=Member, buyer_id=uuid4(), buyer_name="member name"
+        buyer_is_member=True, buyer_id=uuid4(), buyer_name="member name"
     ),
 )
 

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 
-from arbeitszeit.entities import SocialAccounting
+from arbeitszeit.entities import Company, Member, SocialAccounting
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import ShowPRDAccountDetailsUseCase
 from tests.data_generators import (
@@ -387,6 +387,7 @@ def test_that_correct_buyer_info_is_shown_when_company_sold_to_member(
 
     response = show_prd_account_details(company.id)
     assert response.transactions[0].buyer
+    assert response.transactions[0].buyer.buyer_type == Member
     assert response.transactions[0].buyer.buyer_id == member.id
     assert response.transactions[0].buyer.buyer_name == member.name
 
@@ -409,5 +410,6 @@ def test_that_correct_buyer_info_is_shown_when_company_sold_to_company(
 
     response = show_prd_account_details(company2.id)
     assert response.transactions[0].buyer
+    assert response.transactions[0].buyer.buyer_type == Company
     assert response.transactions[0].buyer.buyer_id == company1.id
     assert response.transactions[0].buyer.buyer_name == company1.name

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 
-from arbeitszeit.entities import Company, Member, SocialAccounting
+from arbeitszeit.entities import SocialAccounting
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import ShowPRDAccountDetailsUseCase
 from tests.data_generators import (
@@ -387,7 +387,7 @@ def test_that_correct_buyer_info_is_shown_when_company_sold_to_member(
 
     response = show_prd_account_details(company.id)
     assert response.transactions[0].buyer
-    assert response.transactions[0].buyer.buyer_type == Member
+    assert response.transactions[0].buyer.buyer_is_member == True
     assert response.transactions[0].buyer.buyer_id == member.id
     assert response.transactions[0].buyer.buyer_name == member.name
 
@@ -410,6 +410,6 @@ def test_that_correct_buyer_info_is_shown_when_company_sold_to_company(
 
     response = show_prd_account_details(company2.id)
     assert response.transactions[0].buyer
-    assert response.transactions[0].buyer.buyer_type == Company
+    assert response.transactions[0].buyer.buyer_is_member == False
     assert response.transactions[0].buyer.buyer_id == company1.id
     assert response.transactions[0].buyer.buyer_name == company1.name

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -346,3 +346,68 @@ def test_that_plotting_info_is_generated_in_the_correct_order_after_selling_of_t
     assert response.plot.accumulated_volumes[2] == (
         trans1.amount_received + trans2.amount_received + trans3.amount_received
     )
+
+
+@injection_test
+def test_that_no_buyer_is_shown_in_transaction_detail_when_transaction_is_debit_for_expected_sales(
+    show_prd_account_details: ShowPRDAccountDetailsUseCase,
+    company_generator: CompanyGenerator,
+    social_accounting: SocialAccounting,
+    transaction_generator: TransactionGenerator,
+):
+    company = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=social_accounting.account,
+        receiving_account=company.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(5),
+    )
+
+    response = show_prd_account_details(company.id)
+    assert response.transactions[0].buyer is None
+
+
+@injection_test
+def test_that_correct_buyer_info_is_shown_when_company_sold_to_member(
+    show_prd_account_details: ShowPRDAccountDetailsUseCase,
+    company_generator: CompanyGenerator,
+    member_generator: MemberGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company = company_generator.create_company()
+    member = member_generator.create_member()
+
+    transaction_generator.create_transaction(
+        sending_account=member.account,
+        receiving_account=company.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(5),
+    )
+
+    response = show_prd_account_details(company.id)
+    assert response.transactions[0].buyer
+    assert response.transactions[0].buyer.buyer_id == member.id
+    assert response.transactions[0].buyer.buyer_name == member.name
+
+
+@injection_test
+def test_that_correct_buyer_info_is_shown_when_company_sold_to_company(
+    show_prd_account_details: ShowPRDAccountDetailsUseCase,
+    company_generator: CompanyGenerator,
+    transaction_generator: TransactionGenerator,
+):
+    company1 = company_generator.create_company()
+    company2 = company_generator.create_company()
+
+    transaction_generator.create_transaction(
+        sending_account=company1.means_account,
+        receiving_account=company2.product_account,
+        amount_sent=Decimal(10),
+        amount_received=Decimal(5),
+    )
+
+    response = show_prd_account_details(company2.id)
+    assert response.transactions[0].buyer
+    assert response.transactions[0].buyer.buyer_id == company1.id
+    assert response.transactions[0].buyer.buyer_name == company1.name


### PR DESCRIPTION
This PR is a first step to solve that companies cannot see who paid products in their PRD-account (see issue #435). 

To make it possibe, a `buyer` field is added to the Response object of the `ShowPRDAccountDetailsUseCase`.

This is so far only the Use Case implementation. If approved, a second PR will deal with the presenter level. 

Plan ID: ecdb2bb1-6690-4a6e-a8a5-d08e26ac1afd