### PR TITLE
Show buyer in prd account presenter

### DIFF
--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -30,7 +30,6 @@
                     <th></th>
                     <th>{{ gettext("Type") }}</th>
                     <th>{{ gettext("Buyer") }} </th>
-                    <th>{{ gettext("Buyer type") }} </th>
                     <th>{{ gettext("Details") }}</th>
                     <th></th>
                 </tr>
@@ -43,8 +42,9 @@
                     <td>
                         {{ trans_info.transaction_type }}
                     </td>
-                    <td>{{ trans_info.buyer_name }}</td>
-                    <td>{{ trans_info.buyer_type }}</td>
+                    <td><span class="icon"><i
+                                class='{{ trans_info.buyer_type_icon }}'></i></span>&ensp;<span>{{ trans_info.buyer_name }}</span>
+                    </td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
                         class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -29,6 +29,7 @@
                 <tr>
                     <th></th>
                     <th>{{ gettext("Type") }}</th>
+                    <th>{{ gettext("Buyer") }} </th>
                     <th>{{ gettext("Details") }}</th>
                     <th></th>
                 </tr>
@@ -41,6 +42,7 @@
                     <td>
                         {{ trans_info.transaction_type }}
                     </td>
+                    <td>{{ trans_info.buyer_name }}</td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
                         class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -30,6 +30,7 @@
                     <th></th>
                     <th>{{ gettext("Type") }}</th>
                     <th>{{ gettext("Buyer") }} </th>
+                    <th>{{ gettext("Buyer type") }} </th>
                     <th>{{ gettext("Details") }}</th>
                     <th></th>
                 </tr>
@@ -43,6 +44,7 @@
                         {{ trans_info.transaction_type }}
                     </td>
                     <td>{{ trans_info.buyer_name }}</td>
+                    <td>{{ trans_info.buyer_type }}</td>
                     <td>{{ trans_info.purpose }}</td>
                     <td
                         class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from injector import inject
 
@@ -22,6 +22,7 @@ class ShowPRDAccountDetailsPresenter:
         transaction_volume: str
         purpose: str
         buyer_name: str
+        buyer_type: str
 
     @dataclass
     class ViewModel:
@@ -72,4 +73,15 @@ class ShowPRDAccountDetailsPresenter:
             transaction_volume=str(round(transaction.transaction_volume, 2)),
             purpose=transaction.purpose,
             buyer_name=transaction.buyer.buyer_name if transaction.buyer else "",
+            buyer_type=self._get_buyer_type(transaction.buyer),
         )
+
+    def _get_buyer_type(
+        self, buyer: Optional[ShowPRDAccountDetailsUseCase.Buyer]
+    ) -> str:
+        if not buyer:
+            return ""
+        elif buyer.buyer_is_member:
+            return self.translator.gettext("Worker")
+        else:
+            return self.translator.gettext("Company")

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -21,6 +21,7 @@ class ShowPRDAccountDetailsPresenter:
         date: str
         transaction_volume: str
         purpose: str
+        buyer_name: str
 
     @dataclass
     class ViewModel:
@@ -64,10 +65,11 @@ class ShowPRDAccountDetailsPresenter:
             else self.translator.gettext("Sale")
         )
         return self.TransactionInfo(
-            transaction_type,
-            self.datetime_service.format_datetime(
+            transaction_type=transaction_type,
+            date=self.datetime_service.format_datetime(
                 date=transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
-            str(round(transaction.transaction_volume, 2)),
-            transaction.purpose,
+            transaction_volume=str(round(transaction.transaction_volume, 2)),
+            purpose=transaction.purpose,
+            buyer_name=transaction.buyer.buyer_name if transaction.buyer else "",
         )

--- a/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/show_prd_account_details_presenter.py
@@ -22,7 +22,7 @@ class ShowPRDAccountDetailsPresenter:
         transaction_volume: str
         purpose: str
         buyer_name: str
-        buyer_type: str
+        buyer_type_icon: Optional[str]
 
     @dataclass
     class ViewModel:
@@ -73,15 +73,15 @@ class ShowPRDAccountDetailsPresenter:
             transaction_volume=str(round(transaction.transaction_volume, 2)),
             purpose=transaction.purpose,
             buyer_name=transaction.buyer.buyer_name if transaction.buyer else "",
-            buyer_type=self._get_buyer_type(transaction.buyer),
+            buyer_type_icon=self._get_buyer_type_icon(transaction.buyer),
         )
 
-    def _get_buyer_type(
+    def _get_buyer_type_icon(
         self, buyer: Optional[ShowPRDAccountDetailsUseCase.Buyer]
-    ) -> str:
+    ) -> Optional[str]:
         if not buyer:
-            return ""
+            return None
         elif buyer.buyer_is_member:
-            return self.translator.gettext("Worker")
+            return "fas fa-user"
         else:
-            return self.translator.gettext("Company")
+            return "fas fa-industry"

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -10,6 +10,7 @@ from arbeitszeit_web.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
+from tests.presenters.url_index import UrlIndexTestImpl
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
@@ -39,6 +40,7 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.translator = self.injector.get(FakeTranslator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowPRDAccountDetailsPresenter)
+        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_return_empty_list_when_no_transactions_took_place(self):
         response = self._use_case_response()
@@ -103,6 +105,18 @@ class CompanyTransactionsPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertTrue(view_model.plot_url)
         self.assertIn(str(response.company_id), view_model.plot_url)
+
+    def test_name_of_buyer_is_shown_if_transaction_is_of_type_sale(self):
+        response = self._use_case_response(transactions=[DEFAULT_INFO2])
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.transactions[0].buyer_name, "member name")
+
+    def test_name_of_buyer_is_empty_string_if_transaction_is_of_type_expected_sales(
+        self,
+    ):
+        response = self._use_case_response(transactions=[DEFAULT_INFO1])
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.transactions[0].buyer_name, "")
 
     def _use_case_response(
         self,

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -113,7 +113,7 @@ class CompanyTransactionsPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.transactions[0].buyer_name, "member name")
 
-    def test_correct_type_of_buyer_is_shown_if_transaction_is_sale_of_consumer_product(
+    def test_correct_icon_for_type_of_buyer_is_shown_if_transaction_is_sale_of_consumer_product(
         self,
     ):
         response = self._use_case_response(
@@ -127,11 +127,9 @@ class CompanyTransactionsPresenterTests(TestCase):
             ]
         )
         view_model = self.presenter.present(response)
-        self.assertEqual(
-            view_model.transactions[0].buyer_type, self.translator.gettext("Worker")
-        )
+        self.assertEqual(view_model.transactions[0].buyer_type_icon, "fas fa-user")
 
-    def test_correct_type_of_buyer_is_shown_if_transaction_is_sale_of_liquid_means(
+    def test_correct_icon_for_type_of_buyer_is_shown_if_transaction_is_sale_of_liquid_means(
         self,
     ):
         response = self._use_case_response(
@@ -147,16 +145,14 @@ class CompanyTransactionsPresenterTests(TestCase):
             ]
         )
         view_model = self.presenter.present(response)
-        self.assertEqual(
-            view_model.transactions[0].buyer_type, self.translator.gettext("Company")
-        )
+        self.assertEqual(view_model.transactions[0].buyer_type_icon, "fas fa-industry")
 
-    def test_type_of_buyer_is_empty_string_if_transaction_is_of_type_expected_sales(
+    def test_type_of_buyer_is_none_if_transaction_is_of_type_expected_sales(
         self,
     ):
         response = self._use_case_response(transactions=[self._get_transaction_info()])
         view_model = self.presenter.present(response)
-        self.assertEqual(view_model.transactions[0].buyer_type, "")
+        self.assertIsNone(view_model.transactions[0].buyer_type_icon)
 
     def test_name_of_buyer_is_empty_string_if_transaction_is_of_type_expected_sales(
         self,

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import List
+from typing import List, Optional
 from unittest import TestCase
 from uuid import UUID, uuid4
 
@@ -14,24 +14,6 @@ from tests.presenters.url_index import UrlIndexTestImpl
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
-
-DEFAULT_INFO1 = ShowPRDAccountDetailsUseCase.TransactionInfo(
-    transaction_type=TransactionTypes.expected_sales,
-    date=datetime.now(),
-    transaction_volume=Decimal(10.007),
-    purpose="Test purpose",
-    buyer=None,
-)
-
-DEFAULT_INFO2 = ShowPRDAccountDetailsUseCase.TransactionInfo(
-    transaction_type=TransactionTypes.sale_of_consumer_product,
-    date=datetime.now(),
-    transaction_volume=Decimal(20),
-    purpose="Test purpose",
-    buyer=ShowPRDAccountDetailsUseCase.Buyer(
-        buyer_is_member=True, buyer_id=uuid4(), buyer_name="member name"
-    ),
-)
 
 
 class CompanyTransactionsPresenterTests(TestCase):
@@ -57,7 +39,7 @@ class CompanyTransactionsPresenterTests(TestCase):
     ):
         ACCOUNT_BALANCE = Decimal(100.007)
         response = self._use_case_response(
-            transactions=[DEFAULT_INFO1], account_balance=ACCOUNT_BALANCE
+            transactions=[self._get_transaction_info()], account_balance=ACCOUNT_BALANCE
         )
         view_model = self.presenter.present(response)
         self.assertTrue(len(view_model.transactions), 1)
@@ -69,7 +51,9 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertEqual(
             trans.date,
             self.datetime_service.format_datetime(
-                date=DEFAULT_INFO1.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
+                date=self._get_transaction_info().date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
             ),
         )
         self.assertEqual(trans.transaction_volume, "10.01")
@@ -79,7 +63,12 @@ class CompanyTransactionsPresenterTests(TestCase):
         self,
     ):
         response = self._use_case_response(
-            transactions=[DEFAULT_INFO2], account_balance=Decimal(100.007)
+            transactions=[
+                self._get_transaction_info(
+                    transaction_type=TransactionTypes.sale_of_consumer_product
+                )
+            ],
+            account_balance=Decimal(100.007),
         )
         view_model = self.presenter.present(response)
         self.assertTrue(len(view_model.transactions), 1)
@@ -89,14 +78,18 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertEqual(
             trans.date,
             self.datetime_service.format_datetime(
-                date=DEFAULT_INFO1.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
+                date=self._get_transaction_info().date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
             ),
         )
-        self.assertEqual(trans.transaction_volume, "20.00")
+        self.assertEqual(trans.transaction_volume, "10.01")
         self.assertIsInstance(trans.purpose, str)
 
     def test_return_two_transactions_when_two_transactions_took_place(self):
-        response = self._use_case_response(transactions=[DEFAULT_INFO1, DEFAULT_INFO2])
+        response = self._use_case_response(
+            transactions=[self._get_transaction_info(), self._get_transaction_info()]
+        )
         view_model = self.presenter.present(response)
         self.assertTrue(len(view_model.transactions), 2)
 
@@ -107,14 +100,68 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertIn(str(response.company_id), view_model.plot_url)
 
     def test_name_of_buyer_is_shown_if_transaction_is_of_type_sale(self):
-        response = self._use_case_response(transactions=[DEFAULT_INFO2])
+        response = self._use_case_response(
+            transactions=[
+                self._get_transaction_info(
+                    transaction_type=TransactionTypes.sale_of_consumer_product,
+                    buyer=ShowPRDAccountDetailsUseCase.Buyer(
+                        buyer_is_member=True, buyer_id=uuid4(), buyer_name="member name"
+                    ),
+                )
+            ]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.transactions[0].buyer_name, "member name")
+
+    def test_correct_type_of_buyer_is_shown_if_transaction_is_sale_of_consumer_product(
+        self,
+    ):
+        response = self._use_case_response(
+            transactions=[
+                self._get_transaction_info(
+                    transaction_type=TransactionTypes.sale_of_consumer_product,
+                    buyer=ShowPRDAccountDetailsUseCase.Buyer(
+                        buyer_is_member=True, buyer_id=uuid4(), buyer_name="member name"
+                    ),
+                )
+            ]
+        )
+        view_model = self.presenter.present(response)
+        self.assertEqual(
+            view_model.transactions[0].buyer_type, self.translator.gettext("Worker")
+        )
+
+    def test_correct_type_of_buyer_is_shown_if_transaction_is_sale_of_liquid_means(
+        self,
+    ):
+        response = self._use_case_response(
+            transactions=[
+                self._get_transaction_info(
+                    transaction_type=TransactionTypes.sale_of_liquid_means,
+                    buyer=ShowPRDAccountDetailsUseCase.Buyer(
+                        buyer_is_member=False,
+                        buyer_id=uuid4(),
+                        buyer_name="company name",
+                    ),
+                )
+            ]
+        )
+        view_model = self.presenter.present(response)
+        self.assertEqual(
+            view_model.transactions[0].buyer_type, self.translator.gettext("Company")
+        )
+
+    def test_type_of_buyer_is_empty_string_if_transaction_is_of_type_expected_sales(
+        self,
+    ):
+        response = self._use_case_response(transactions=[self._get_transaction_info()])
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.transactions[0].buyer_type, "")
 
     def test_name_of_buyer_is_empty_string_if_transaction_is_of_type_expected_sales(
         self,
     ):
-        response = self._use_case_response(transactions=[DEFAULT_INFO1])
+        response = self._use_case_response(transactions=[self._get_transaction_info()])
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.transactions[0].buyer_name, "")
 
@@ -129,4 +176,19 @@ class CompanyTransactionsPresenterTests(TestCase):
     ):
         return ShowPRDAccountDetailsUseCase.Response(
             company_id, transactions, account_balance, plot
+        )
+
+    def _get_transaction_info(
+        self,
+        transaction_type: TransactionTypes = None,
+        buyer: Optional[ShowPRDAccountDetailsUseCase.Buyer] = None,
+    ):
+        if transaction_type is None:
+            transaction_type = TransactionTypes.expected_sales
+        return ShowPRDAccountDetailsUseCase.TransactionInfo(
+            transaction_type=transaction_type,
+            date=datetime.now(),
+            transaction_volume=Decimal(10.007),
+            purpose="Test purpose",
+            buyer=buyer,
         )

--- a/tests/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/presenters/test_show_prd_account_details_presenter.py
@@ -100,18 +100,21 @@ class CompanyTransactionsPresenterTests(TestCase):
         self.assertIn(str(response.company_id), view_model.plot_url)
 
     def test_name_of_buyer_is_shown_if_transaction_is_of_type_sale(self):
+        expected_member_name = "member name"
         response = self._use_case_response(
             transactions=[
                 self._get_transaction_info(
                     transaction_type=TransactionTypes.sale_of_consumer_product,
                     buyer=ShowPRDAccountDetailsUseCase.Buyer(
-                        buyer_is_member=True, buyer_id=uuid4(), buyer_name="member name"
+                        buyer_is_member=True,
+                        buyer_id=uuid4(),
+                        buyer_name=expected_member_name,
                     ),
                 )
             ]
         )
         view_model = self.presenter.present(response)
-        self.assertEqual(view_model.transactions[0].buyer_name, "member name")
+        self.assertEqual(view_model.transactions[0].buyer_name, expected_member_name)
 
     def test_correct_icon_for_type_of_buyer_is_shown_if_transaction_is_sale_of_consumer_product(
         self,


### PR DESCRIPTION
fixes #435

This PR adds a new column in the company's prd account overview, where the buyer of the product is shown. The buyer of a product is currently only represented by its name and an icon that shows if the buyer is a worker or a company. 

Later we can add more information, when needed, e.g. an ID or a link to the company summary page. 

In case the transaction in a given row is not a sale but a expected sales debit, the field stays empty.  

Plan-ID: ecdb2bb1-6690-4a6e-a8a5-d08e26ac1afd