### PR TITLE
change transaction appearance for accounts p, r, a

### DIFF
--- a/arbeitszeit_flask/templates/company/account_a.html
+++ b/arbeitszeit_flask/templates/company/account_a.html
@@ -6,55 +6,42 @@
 {% endblock %}
 
 {% block content %}
+{% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="section is-medium has-text-centered">
+<div class="mt-3 has-text-centered">
     <h1 class="title">
         {{ gettext("Account a") }}
     </h1>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("Your account for work certificates") }}</p>
+</div>
+<div class="mt-5 has-text-centered">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            <div class="box has-background-info-light has-text-info-dark">
+                <div class="icon"><i class="fas fa-info-circle"></i></div>
+                <p>{{ gettext("Your account for work certificates") }}</p>
+            </div>
+            <p>{{ gettext("Balance:") }}</p>
+            <p
+                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+                {{ view_model.account_balance }}
+            </p>
+        </div>
     </div>
-
-    <p>{{ gettext("Balance:") }}</p>
-    <p
-        class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
-        {{ view_model.account_balance }}
-    </p>
-
+</div>
+<div class="has-text-centered">
     <div>
         <img src="{{ view_model.plot_url }}" alt="plot of a account">
     </div>
-
-    <div class="table-container">
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>{{ gettext("Type") }}</th>
-                    <th>{{ gettext("Details") }}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-
-                {% if view_model.transactions is defined and view_model.transactions|length %}
-                {% for trans_info in view_model.transactions %}
-                <tr>
-                    <td>{{ trans_info.date }}</td>
-                    <td>
-                        {{ trans_info.transaction_type }}
-                    </td>
-                    <td>{{ trans_info.purpose }}</td>
-                    <td
-                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
-                        {{ trans_info.transaction_volume }}
-                    </td>
-                </tr>
-                {% endfor %}
-                {% endif %}
-            </tbody>
-        </table>
+</div>
+<div class="section">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            {% if view_model.transactions is defined and view_model.transactions|length %}
+            {% for trans_info in view_model.transactions %}
+            {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
+            {% endfor %}
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/account_p.html
+++ b/arbeitszeit_flask/templates/company/account_p.html
@@ -6,54 +6,42 @@
 {% endblock %}
 
 {% block content %}
+{% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="section is-medium has-text-centered">
+<div class="mt-3 has-text-centered">
     <h1 class="title">
         {{ gettext("Account p") }}
     </h1>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("Your account for fixed means of production.") }}</p>
+</div>
+<div class="mt-5 has-text-centered">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            <div class="box has-background-info-light has-text-info-dark">
+                <div class="icon"><i class="fas fa-info-circle"></i></div>
+                <p>{{ gettext("Your account for fixed means of production.") }}</p>
+            </div>
+            <p>{{ gettext("Balance:") }}</p>
+            <p
+                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+                {{ view_model.account_balance }}
+            </p>
+        </div>
     </div>
-    <p>{{ gettext("Balance:") }}</p>
-    <p
-        class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
-        {{ view_model.account_balance }}
-    </p>
-
+</div>
+<div class="has-text-centered">
     <div>
         <img src="{{ view_model.plot_url }}" alt="plot of p account">
     </div>
-
-    <div class="table-container">
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>{{ gettext("Type") }}</th>
-                    <th>{{ gettext("Details") }}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% if view_model.transactions is defined and view_model.transactions|length %}
-                {% for trans_info in view_model.transactions %}
-                <tr>
-                    <td>{{ trans_info.date }}</td>
-                    <td>
-                        {{ trans_info.transaction_type }}
-                    </td>
-                    <td>{{ trans_info.purpose }}</td>
-                    <td
-                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
-                        {{
-                        trans_info.transaction_volume }}
-                    </td>
-                </tr>
-                {% endfor %}
-                {% endif %}
-            </tbody>
-        </table>
+</div>
+<div class="section">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            {% if view_model.transactions is defined and view_model.transactions|length %}
+            {% for trans_info in view_model.transactions %}
+            {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
+            {% endfor %}
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/account_r.html
+++ b/arbeitszeit_flask/templates/company/account_r.html
@@ -6,52 +6,42 @@
 {% endblock %}
 
 {% block content %}
+{% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="section is-medium has-text-centered">
+<div class="mt-3 has-text-centered">
     <h1 class="title">
-        {{ gettext("Account r")}}
+        {{ gettext("Account r") }}
     </h1>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("Your account for liquid means of production") }}</p>
+</div>
+<div class="mt-5 has-text-centered">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            <div class="box has-background-info-light has-text-info-dark">
+                <div class="icon"><i class="fas fa-info-circle"></i></div>
+                <p>{{ gettext("Your account for liquid means of production") }}</p>
+            </div>
+            <p>{{ gettext("Balance:") }}</p>
+            <p
+                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+                {{ view_model.account_balance }}
+            </p>
+        </div>
     </div>
-    <p>{{ gettext("Balance:") }}</p>
-    <p
-        class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
-        {{ view_model.account_balance }}
-    </p>
-
+</div>
+<div class="has-text-centered">
     <div>
         <img src="{{ view_model.plot_url }}" alt="plot of r account">
     </div>
-
-    <div class="table-container">
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>{{ gettext("Type") }}</th>
-                    <th>{{ gettext("Details") }}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% if view_model.transactions is defined and view_model.transactions|length %}
-                {% for trans_info in view_model.transactions %}
-                <tr>
-                    <td>{{ trans_info.date }}</td>
-                    <td>{{ trans_info.transaction_type }}</td>
-                    <td>{{ trans_info.purpose }}</td>
-                    <td
-                        class="has-text-right has-text-weight-bold {{ 'has-text-success' if trans_info.transaction_volume|float >= 0 else 'has-text-danger' }}">
-                        {{
-                        trans_info.transaction_volume }}
-                    </td>
-                </tr>
-                {% endfor %}
-                {% endif %}
-            </tbody>
-        </table>
+</div>
+<div class="section">
+    <div class="columns is-centered">
+        <div class="column is-two-thirds">
+            {% if view_model.transactions is defined and view_model.transactions|length %}
+            {% for trans_info in view_model.transactions %}
+            {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
+            {% endfor %}
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/macros/transactions.html
+++ b/arbeitszeit_flask/templates/macros/transactions.html
@@ -1,0 +1,27 @@
+{% macro basic_transaction(date, type, purpose, volume) %}
+
+<article class="media">
+    <div class="media-left">
+        <p class="pt-1">
+            <small class="has-text-weight-semibold">{{ date }}</small><br>
+        </p>
+    </div>
+    <div class="media-content">
+        <div class="content">
+            <p>
+                <strong class="is-size-5">
+                    {{ type }}
+                </strong>
+                <br>
+                <small>{{ purpose }}</small>
+            </p>
+        </div>
+    </div>
+    <div class="media-right">
+        <p class="is-size-5 pt-1 {{ 'has-text-success' if volume|float >= 0 else 'has-text-danger' }}">
+            {{ volume }}
+        </p>
+    </div>
+</article>
+
+{% endmacro %}

--- a/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
+++ b/arbeitszeit_flask/translations/de/LC_MESSAGES/messages.po
@@ -1673,7 +1673,7 @@ msgstr "Bezahlung"
 #: tests/presenters/test_show_p_account_details.py:53
 #: tests/presenters/test_show_r_account_details.py:53
 msgid "Credit"
-msgstr "Guthaben"
+msgstr "Gutschrift"
 
 #: arbeitszeit_web/presenters/show_company_work_invite_details_presenter.py:27
 #, python-format


### PR DESCRIPTION
This PR makes the list of transactions of accounts p, r and a mobile responsive. Account prd will follow after merge of PR #505.

Because the transactions items do all look the same in these 3 acccounts, I created a jinja macro `basic_transaction(date, type, purpose, volume)`.

Plan-ID: ecdb2bb1-6690-4a6e-a8a5-d08e26ac1afd

![image](https://user-images.githubusercontent.com/61537351/190856945-d5e3a440-6e42-4f18-bf16-47f8c20037bd.png)
