### PR TITLE
Don't show "actions" in plan summary of inactive plans

### DIFF
--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -10,12 +10,12 @@
 {{ plan_summary(view_model) }}
 
 <div class="section has-text-centered">
+    {% if view_model.show_payment_url %}
     <div class="content">
         <h1 class="title">
             {{ gettext("Actions") }}
         </h1>
     </div>
-    {% if view_model.show_payment_url %}
     <div class="column is-offset-2 is-8">
         <div class="box">
             <div class="tile is-ancestor">
@@ -34,6 +34,11 @@
     </div>
     {% endif %}
     {% if view_model.show_own_plan_action_section %}
+    <div class="content">
+        <h1 class="title">
+            {{ gettext("Actions") }}
+        </h1>
+    </div>
     <div class="column is-offset-2 is-8">
         <div class="box">
             <div class="tile is-ancestor">

--- a/arbeitszeit_web/get_plan_summary_company.py
+++ b/arbeitszeit_web/get_plan_summary_company.py
@@ -49,9 +49,12 @@ class GetPlanSummaryCompanySuccessPresenter:
         plan_id = plan_summary.plan_id
         coop_id = plan_summary.cooperation
         is_cooperating = plan_summary.is_cooperating
+        show_own_plan_action_section = (
+            response.current_user_is_planner and plan_summary.is_active
+        )
         return GetPlanSummaryCompanyViewModel(
             summary=self.plan_summary_service.format_plan_summary(plan_summary),
-            show_own_plan_action_section=response.current_user_is_planner,
+            show_own_plan_action_section=show_own_plan_action_section,
             own_plan_action=OwnPlanAction(
                 is_available_bool=plan_summary.is_available,
                 toggle_availability_url=self.url_index.get_toggle_availability_url(

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -62,7 +62,17 @@ class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
         view_model = self.presenter.present(response)
         self.assertFalse(view_model.show_own_plan_action_section)
 
-    def test_view_model_sows_availability_when_plan_is_available(self):
+    def test_action_section_is_not_shown_when_current_user_is_planner_but_plan_is_expired(
+        self,
+    ):
+        summary_of_inactive_plan = replace(TESTING_PLAN_SUMMARY, is_active=False)
+        use_case_response = GetPlanSummaryCompany.Response(
+            plan_summary=summary_of_inactive_plan, current_user_is_planner=True
+        )
+        view_model = self.presenter.present(use_case_response)
+        self.assertFalse(view_model.show_own_plan_action_section)
+
+    def test_view_model_shows_availability_when_plan_is_available(self):
         view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
         self.assertEqual(
             view_model.own_plan_action.is_available_bool,


### PR DESCRIPTION
fixes #504

This PR hides the "action" section of company's own plan, if the plan is inactive. 

The idea is that neither changing availability nor joining a cooperation makes sense for an expired plan.

(Currently, "inactive" means "expired". In the future, this assumption may not hold and we may have to change the bahaviour accordingly.)

No certs needed.