### PR TITLE
Show name and user type in navbar

### DIFF
--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -70,10 +70,7 @@ class Company(UserMixin, db.Model):
     drafts = db.relationship("PlanDraft", lazy="dynamic")
 
     def __repr__(self):
-        return "<Company(email='%s', name='%s')>" % (
-            self.email,
-            self.name,
-        )
+        return "<Company(name='%s')>" % (self.name,)
 
 
 class Accountant(UserMixin, db.Model):

--- a/arbeitszeit_flask/static/main.css
+++ b/arbeitszeit_flask/static/main.css
@@ -1,13 +1,3 @@
-.not-active {
-  pointer-events: none;
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.unread-message {
-  font-weight: bold;
-}
-
-.unread-messages-indicator {
-  font-weight: bold;
+.navbar-end .navbar-item {
+  padding: 0.5rem 0.25rem;
 }

--- a/arbeitszeit_flask/templates/base_company.html
+++ b/arbeitszeit_flask/templates/base_company.html
@@ -33,28 +33,34 @@
       {% endif %}
     </div>
     <div class="navbar-end">
+      {% if not current_user.is_authenticated %}
       <div class="navbar-item">
-        <div class="buttons">
-          {% if not current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.login_company') }}">
-            {{ gettext("Sign in") }}
-          </a>
-          <a class="button" href="{{ url_for('auth.signup_company') }}">
-            {{ gettext("Sign up") }}
-          </a>
-          <a class="button" href="{{ url_for('auth.zurueck') }}">
-            {{ gettext("Back") }}
-          </a>
-          {% else %}
-          <a class="button" href="{{ url_for('auth.logout') }}">
-            {{ gettext("Sign out") }}
-          </a>
-          <a class="button" href="{{ url_for('main_company.hilfe') }}">
-            {{ gettext("?") }}
-          </a>
-          {% endif %}
-        </div>
+        <a class="button" href="{{ url_for('auth.login_company') }}">
+          {{ gettext("Sign in") }}
+        </a>
       </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.signup_company') }}">
+          {{ gettext("Sign up") }}
+        </a>
+      </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.zurueck') }}">
+          {{ gettext("Back") }}
+        </a>
+      </div>
+      {% else %}
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.logout') }}">
+          {{ gettext("Sign out") }}
+        </a>
+      </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('main_company.hilfe') }}">
+          {{ gettext("?") }}
+        </a>
+      </div>
+      {% endif %}
     </div>
   </div>
 </nav>

--- a/arbeitszeit_flask/templates/base_company.html
+++ b/arbeitszeit_flask/templates/base_company.html
@@ -5,7 +5,13 @@
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
+      {% if current_user.is_authenticated %}
+      <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
+      {{ current_user.name|truncate(20, True) }}
+      {% else %}
+      <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
       {{ gettext("Company view") }}
+      {% endif %}
     </div>
 
     <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
@@ -20,7 +26,7 @@
     <div class="navbar-start">
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_company.dashboard') }}" class="navbar-item">
-	{{ gettext("Dashboard") }}
+        {{ gettext("Dashboard") }}
       </a>
       {% block navbar_start %}
       {% endblock %}
@@ -28,26 +34,26 @@
     </div>
     <div class="navbar-end">
       <div class="navbar-item">
-	<div class="buttons">
-	  {% if not current_user.is_authenticated %}
-	  <a class="button" href="{{ url_for('auth.login_company') }}">
-	    {{ gettext("Sign in") }}
-	  </a>
-	  <a class="button" href="{{ url_for('auth.signup_company') }}">
-	    {{ gettext("Sign up") }}
-	  </a>
-	  <a class="button" href="{{ url_for('auth.zurueck') }}">
-	    {{ gettext("Back") }}
-	  </a>
-	  {% else %}
-	  <a class="button" href="{{ url_for('auth.logout') }}">
-	    {{ gettext("Sign out") }}
-	  </a>
-	  <a class="button" href="{{ url_for('main_company.hilfe') }}">
-	    {{ gettext("?") }}
-	  </a>
-	  {% endif %}
-	</div>
+        <div class="buttons">
+          {% if not current_user.is_authenticated %}
+          <a class="button" href="{{ url_for('auth.login_company') }}">
+            {{ gettext("Sign in") }}
+          </a>
+          <a class="button" href="{{ url_for('auth.signup_company') }}">
+            {{ gettext("Sign up") }}
+          </a>
+          <a class="button" href="{{ url_for('auth.zurueck') }}">
+            {{ gettext("Back") }}
+          </a>
+          {% else %}
+          <a class="button" href="{{ url_for('auth.logout') }}">
+            {{ gettext("Sign out") }}
+          </a>
+          <a class="button" href="{{ url_for('main_company.hilfe') }}">
+            {{ gettext("?") }}
+          </a>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -34,30 +34,35 @@
     </div>
 
     <div class="navbar-end">
+      {% if not current_user.is_authenticated %}
       <div class="navbar-item">
-        <div class="buttons">
-          {% if not current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.login_member') }}">
-            {{ gettext("Sign in")}}
-          </a>
-          <a class="button" href="{{ url_for('auth.signup_member') }}">
-            {{ gettext("Sign up")}}
-          </a>
-          <a class="button" href="{{ url_for('auth.zurueck') }}">
-            {{ gettext("Back")}}
-          </a>
-          {% endif %}
-          {% if current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.logout') }}">
-            {{ gettext("Sign out")}}
-          </a>
-          <a class="button" href="{{ url_for('main_member.hilfe') }}">
-            ?
-          </a>
-          {% endif %}
-
-        </div>
+        <a class="button" href="{{ url_for('auth.login_member') }}">
+          {{ gettext("Sign in")}}
+        </a>
       </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.signup_member') }}">
+          {{ gettext("Sign up")}}
+        </a>
+      </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.zurueck') }}">
+          {{ gettext("Back")}}
+        </a>
+      </div>
+      {% endif %}
+      {% if current_user.is_authenticated %}
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.logout') }}">
+          {{ gettext("Sign out")}}
+        </a>
+      </div>
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('main_member.hilfe') }}">
+          ?
+        </a>
+      </div>
+      {% endif %}
     </div>
   </div>
 </nav>

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -4,8 +4,14 @@
 {% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
-    <div class="navbar-item has-background-primary	has-text-white">
+    <div class="navbar-item has-background-primary has-text-white">
+      {% if current_user.is_authenticated %}
+      <span class="icon"><i class="fas fa-user"></i></span>&nbsp;
+      {{ current_user.name|truncate(20, True) }}
+      {% else %}
+      <span class="icon"><i class="fas fa-user"></i></span>&nbsp;
       {{ gettext("Member view") }}
+      {% endif %}
     </div>
 
     <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -50,8 +50,7 @@
           {{ gettext("Back")}}
         </a>
       </div>
-      {% endif %}
-      {% if current_user.is_authenticated %}
+      {% else %}
       <div class="navbar-item">
         <a class="button" href="{{ url_for('auth.logout') }}">
           {{ gettext("Sign out")}}


### PR DESCRIPTION
This PR proposes to add to the navbar an icon ("user" or "industry") depending on if the currently logged-in user role is member or company. It also adds the name of the user to the navbar.

![image](https://user-images.githubusercontent.com/61537351/190902104-918a731e-a7aa-433c-8ece-a82e10b6b28f.png)

The intention of this change is to make it clearer to users, which account they are logged in with. 

It also fixes a small bug in the burger menu on small screens (buttons were arranged horizontally instead of vertically).

Plan ID: ecdb2bb1-6690-4a6e-a8a5-d08e26ac1afd