### PR TITLE
Translation setup: adapt README, fix bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ the command::
 Translation
 -----------
 
-We use `Flask-Babel <https://flask-babel.tkte.ch/>`_ for translation.
+We use `Flask-Babel <https://python-babel.github.io/flask-babel/>`_ for translation.
 
 1) Add a new language:
 

--- a/README.rst
+++ b/README.rst
@@ -201,13 +201,17 @@ In jinja templates use:
 - ``ngettext(singular: str, plural: str, n)``
 
 
-3) Parse code and update language specific .po-files::
+3) Parse code for translatable strings (create .pot file): 
+
+    $ python setup.py extract_messages
+
+4) Update language specific .po-files::
 
     $ python setup.py update_catalog
 
-4) Translate language specific .po-files.
+5) Translate language specific .po-files.
 	
-5) Compile translation files::
+6) Compile translation files to .mo-files::
 
     $ python setup.py compile_catalog
 

--- a/tests/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/presenters/test_get_member_dashboard_presenter.py
@@ -151,8 +151,8 @@ class GetMemberDashboardPresenterTests(TestCase):
     def test_correct_invite_message_is_shown(self):
         expected_company_name = "company name"
         expected_message = self.translator.gettext(
-            f"Company {expected_company_name} has invited you!"
-        )
+            "Company %(expected_company_name)s has invited you!"
+        ) % dict(expected_company_name=expected_company_name)
         response = self.get_response(
             invites=[self.get_invite(company_name=expected_company_name)]
         )


### PR DESCRIPTION
For the translation setup there was a step in the README missing (the part with `extract_messages`)

Moreover there was a wrong string interpolation (using translator + f-string) in a test function which prevented the extract_messages command to succeed.

(I'll get a merge commit with #538, but that's ok)

No certs needed.