### PR TITLE
Use FLASK_DEBUG instead of FLASK_ENV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ environment variables:
 
      export ARBEITSZEITAPP_CONFIGURATION_PATH="$PWD/arbeitszeit_flask/development_settings.py"
      export FLASK_APP=arbeitszeit_flask
-     export FLASK_ENV=development
+     export FLASK_DEBUG=1
      export DEV_DATABASE_URI="postgresql://postgres@localhost:5432/<name of database>"
      export DEV_SECRET_KEY=my_secret_key
      export ARBEITSZEIT_APP_SERVER_NAME=localhost:5000

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -56,7 +56,7 @@ def create_app(config=None, db=None, template_folder=None):
     login_manager.login_view = "auth.start"
 
     # Init Flask-Talisman
-    if app.config["ENV"] == "production":
+    if not app.config["DEBUG"]:
         csp = {"default-src": ["'self'", "'unsafe-inline'", "*.fontawesome.com"]}
         Talisman(
             app, content_security_policy=csp, force_https=app.config["FORCE_HTTPS"]
@@ -108,11 +108,10 @@ def create_app(config=None, db=None, template_folder=None):
         app.register_blueprint(member.blueprint.main_member)
         app.register_blueprint(accountant.blueprint.main_accountant)
 
-        if app.config["ENV"] == "development":
-            if app.config["DEBUG_DETAILS"] == True:
-                # print profiling info to sys.stout
-                show_profile_info(app)
-                show_sql_queries(app)
+        if app.config["DEBUG_DETAILS"] == True:
+            # print profiling info to sys.stout
+            show_profile_info(app)
+            show_sql_queries(app)
 
         return app
 

--- a/arbeitszeit_flask/configuration_base.py
+++ b/arbeitszeit_flask/configuration_base.py
@@ -1,6 +1,6 @@
 from os import environ
 
-DEBUG = False
+FLASK_DEBUG = 0
 DEBUG_DETAILS = False
 TESTING = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/arbeitszeit_flask/development_settings.py
+++ b/arbeitszeit_flask/development_settings.py
@@ -1,6 +1,5 @@
 from os import environ, path
 
-DEBUG = True
 DEBUG_DETAILS = environ.get("DEBUG_DETAILS") in ("true", "True", "1", "t")
 TESTING = True
 SQLALCHEMY_DATABASE_URI = environ.get("DEV_DATABASE_URI")

--- a/arbeitszeit_flask/production_settings.py
+++ b/arbeitszeit_flask/production_settings.py
@@ -1,6 +1,5 @@
 from os import environ
 
-FLASK_DEBUG = 0
 TESTING = False
 # using heroku's existing env variable
 # (SQLAlchemy 1.4.x has removed support for the postgres:// URI scheme, which is used by Heroku Postgres)

--- a/arbeitszeit_flask/production_settings.py
+++ b/arbeitszeit_flask/production_settings.py
@@ -1,7 +1,6 @@
 from os import environ
 
-FLASK_ENV = "production"
-DEBUG = False
+FLASK_DEBUG = 0
 TESTING = False
 # using heroku's existing env variable
 # (SQLAlchemy 1.4.x has removed support for the postgres:// URI scheme, which is used by Heroku Postgres)

--- a/tests/flask_integration/dependency_injection.py
+++ b/tests/flask_integration/dependency_injection.py
@@ -30,7 +30,7 @@ class FlaskConfiguration(dict):
                 "SECRET_KEY": "dev secret key",
                 "WTF_CSRF_ENABLED": False,
                 "SERVER_NAME": "test.name",
-                "ENV": "development",
+                "DEBUG": True,
                 "DEBUG_DETAILS": False,
                 "SECURITY_PASSWORD_SALT": "dev password salt",
                 "TESTING": True,


### PR DESCRIPTION
FLASK_ENV and the ENV attribute are deprecated since flask 2.2 and won't be used from flask 2.3. I adapted our code to use FLASK_DEBUG.

https://flask.palletsprojects.com/en/2.2.x/config/#ENV

No certs needed.