### PR TITLE
Notifications: Fixed position + disappearing

### DIFF
--- a/arbeitszeit_flask/static/main.css
+++ b/arbeitszeit_flask/static/main.css
@@ -10,3 +10,19 @@
     padding: 0 0 0 0;
     vertical-align: -.125em;
 }
+
+
+/* notification box */
+.notification_box {
+  position: fixed;
+  left: 25%;
+  right: 25%;
+  width: 50%;
+  animation: hide_notification 5s linear 2s 1 forwards;
+}
+
+@keyframes hide_notification {
+  to {
+      opacity: 0;
+  }
+}

--- a/arbeitszeit_flask/templates/base_accountant.html
+++ b/arbeitszeit_flask/templates/base_accountant.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from 'macros/show_notifications.html' import show_notifications %}
 
 {% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">

--- a/arbeitszeit_flask/templates/base_company.html
+++ b/arbeitszeit_flask/templates/base_company.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from 'macros/show_notifications.html' import show_notifications %}
 
 {% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from 'macros/show_notifications.html' import show_notifications %}
 
 {% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">

--- a/arbeitszeit_flask/templates/macros/show_notifications.html
+++ b/arbeitszeit_flask/templates/macros/show_notifications.html
@@ -3,9 +3,12 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
 {% for category, message in messages %}
-<div class="column is-4 is-offset-4">
+<div class="notification_box">
   <div class="block has-text-centered">
-    <div class="notification {{ category }}"><button class="delete"></button>{{ message }}</div>
+    <div class="notification {{ category }}">
+      <button class="delete is-medium"></button>
+      {{ message }}
+    </div>
   </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
This PR gives notifications a fixed position on top of the screen and makes them disappear after 5 seconds. 

This change has been made so that users can see notifications even when they get directed to the middle of a page. 

Plan-ID: b33932e9-567a-4712-a48c-3ef347ec561e
