### PR TITLE
Delete expiration_date from `Plan` db model

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
 from typing import List, Optional, Union
@@ -150,7 +150,6 @@ class Plan:
     is_active: bool
     expired: bool
     activation_date: Optional[datetime]
-    expiration_date: Optional[datetime]
     active_days: Optional[int]
     payout_count: int
     requested_cooperation: Optional[UUID]
@@ -174,6 +173,13 @@ class Plan:
     @property
     def is_approved(self) -> bool:
         return self.approval_date is not None
+
+    @property
+    def expiration_date(self) -> Optional[datetime]:
+        if not self.activation_date:
+            return None
+        exp_date = self.activation_date + timedelta(days=int(self.timeframe))
+        return exp_date
 
 
 class PurposesOfPurchases(Enum):

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -103,10 +103,6 @@ class PlanRepository(ABC):
         pass
 
     @abstractmethod
-    def set_expiration_date(self, plan: Plan, expiration_date: datetime) -> None:
-        pass
-
-    @abstractmethod
     def set_active_days(self, plan: Plan, full_active_days: int) -> None:
         pass
 

--- a/arbeitszeit/use_cases/update_plans_and_payout.py
+++ b/arbeitszeit/use_cases/update_plans_and_payout.py
@@ -1,4 +1,3 @@
-import datetime
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -40,16 +39,10 @@ class UpdatePlansAndPayout:
             assert plan.is_active, "Plan is not active!"
             assert plan.activation_date, "Plan has no activation date!"
 
-            expiration_time = plan.activation_date + datetime.timedelta(
-                days=int(plan.timeframe)
-            )
-
             self.plan_repository.set_active_days(
                 plan, self._calculate_active_days(plan)
             )
-            self.plan_repository.set_expiration_date(plan, expiration_time)
 
-            assert plan.expiration_date
             assert plan.active_days is not None
             if self._plan_is_expired(plan):
                 self._handle_expired_plan(plan, payout_factor)

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -685,7 +685,6 @@ class PlanRepository(repositories.PlanRepository):
             approval_reason=plan.review.approval_reason,
             is_active=plan.is_active,
             expired=plan.expired,
-            expiration_date=plan.expiration_date,
             activation_date=plan.activation_date,
             active_days=plan.active_days,
             payout_count=plan.payout_count,
@@ -727,7 +726,6 @@ class PlanRepository(repositories.PlanRepository):
             is_public_service=plan.is_public_service,
             is_active=False,
             activation_date=None,
-            expiration_date=None,
             active_days=None,
             payout_count=0,
             is_available=True,
@@ -762,14 +760,6 @@ class PlanRepository(repositories.PlanRepository):
         plan_orm = self.object_to_orm(plan)
         plan_orm.expired = True
         plan_orm.is_active = False
-
-    def set_expiration_date(
-        self, plan: entities.Plan, expiration_date: datetime
-    ) -> None:
-        plan.expiration_date = expiration_date
-
-        plan_orm = self.object_to_orm(plan)
-        plan_orm.expiration_date = expiration_date
 
     def set_active_days(self, plan: entities.Plan, full_active_days: int) -> None:
         plan.active_days = full_active_days

--- a/arbeitszeit_flask/migrations/versions/5517f6309552_delete_plan_expiration_date.py
+++ b/arbeitszeit_flask/migrations/versions/5517f6309552_delete_plan_expiration_date.py
@@ -1,0 +1,25 @@
+"""delete Plan.expiration_date
+
+Revision ID: 5517f6309552
+Revises: f8d8f7d8904e
+Create Date: 2022-11-13 16:04:16.564694
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '5517f6309552'
+down_revision = 'f8d8f7d8904e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('plan') as batch_op:
+        batch_op.drop_column('expiration_date')
+
+
+def downgrade():
+    with op.batch_alter_table('plan') as batch_op:
+        batch_op.add_column(sa.Column('expiration_date', sa.DateTime(), autoincrement=False, nullable=True))

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -112,7 +112,6 @@ class Plan(UserMixin, db.Model):
     is_active = db.Column(db.Boolean, nullable=False, default=False)
     activation_date = db.Column(db.DateTime, nullable=True)
     expired = db.Column(db.Boolean, nullable=False, default=False)
-    expiration_date = db.Column(db.DateTime, nullable=True)
     active_days = db.Column(db.Integer, nullable=True)
     payout_count = db.Column(db.Integer, nullable=False, default=0)
     is_available = db.Column(db.Boolean, nullable=False, default=True)

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -494,9 +494,6 @@ class PlanRepository(interfaces.PlanRepository):
         plan.expired = True
         plan.is_active = False
 
-    def set_expiration_date(self, plan: Plan, expiration_date: datetime) -> None:
-        plan.expiration_date = expiration_date
-
     def set_active_days(self, plan: Plan, full_active_days: int) -> None:
         plan.active_days = full_active_days
 
@@ -644,7 +641,6 @@ class PlanRepository(interfaces.PlanRepository):
             approval_date=None,
             approval_reason=None,
             expired=False,
-            expiration_date=None,
             active_days=None,
             payout_count=0,
             requested_cooperation=None,

--- a/tests/use_cases/test_update_plans_and_payout.py
+++ b/tests/use_cases/test_update_plans_and_payout.py
@@ -34,14 +34,6 @@ class UseCaseTests(TestCase):
         self.payout()
         self.assertFalse(plan.expired)
 
-    def test_that_expiration_time_is_set_if_plan_is_active(self) -> None:
-        plan = self.plan_generator.create_plan(
-            timeframe=2, activation_date=self.datetime_service.now()
-        )
-        self.assertIsNone(plan.expiration_date)
-        self.payout()
-        self.assertIsNotNone(plan.expiration_date)
-
     def test_that_active_days_is_set_if_plan_is_active(self) -> None:
         plan = self.plan_generator.create_plan(
             timeframe=2, activation_date=self.datetime_service.now()
@@ -87,28 +79,6 @@ class UseCaseTests(TestCase):
         self.payout()
         assert not plan.expired
         assert plan.is_active
-
-    def test_that_expiration_date_is_correctly_calculated_if_plan_expires_now(
-        self,
-    ) -> None:
-        self.datetime_service.freeze_time(datetime.datetime.now())
-        plan = self.plan_generator.create_plan(
-            timeframe=1, activation_date=self.datetime_service.now_minus_one_day()
-        )
-        self.payout()
-        expected_expiration_time = self.datetime_service.now()
-        assert plan.expiration_date == expected_expiration_time
-
-    def test_that_expiration_date_is_correctly_calculated_if_plan_expires_in_the_future(
-        self,
-    ) -> None:
-        self.datetime_service.freeze_time(datetime.datetime.now())
-        plan = self.plan_generator.create_plan(
-            timeframe=2, activation_date=self.datetime_service.now_minus_one_day()
-        )
-        self.payout()
-        expected_expiration_time = self.datetime_service.now_plus_one_day()
-        assert plan.expiration_date == expected_expiration_time
 
     def test_that_plan_with_requested_cooperation_has_no_requested_cooperation_after_expiration(
         self,


### PR DESCRIPTION
Until now, a plan's expiration date has been calculated in `update_plans_and_payout` Use Case and stored in the database afterwards.

I think expiration date can simply be calculated when needed in the business logic. I made it a property of `Plan` entity. 

Let me know what you think about this change.

Plan ID (please add me to the cooperation before paying): b33932e9-567a-4712-a48c-3ef347ec561e
