### PR TITLE
Bug fix in UpdatePlansAndPayout

### DIFF
--- a/arbeitszeit/use_cases/update_plans_and_payout.py
+++ b/arbeitszeit/use_cases/update_plans_and_payout.py
@@ -7,6 +7,7 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Plan, SocialAccounting
 from arbeitszeit.payout_factor import PayoutFactorService
 from arbeitszeit.repositories import (
+    PayoutFactorRepository,
     PlanCooperationRepository,
     PlanRepository,
     TransactionRepository,
@@ -22,19 +23,20 @@ class UpdatePlansAndPayout:
     social_accounting: SocialAccounting
     plan_cooperation_repository: PlanCooperationRepository
     payout_factor_service: PayoutFactorService
+    payout_factor_repository: PayoutFactorRepository
 
     def __call__(self) -> None:
         """
         This function should be called at least once per day,
         preferably more often (e.g. every hour).
         """
+        self._calculate_plan_expiration()
         payout_factor = self.payout_factor_service.calculate_payout_factor()
         self.payout_factor_service.store_payout_factor(payout_factor)
-        self._calculate_plan_expiration(payout_factor)
         for plan in self.plan_repository.all_plans_approved_active_and_not_expired():
             self._payout_work_certificates(plan, payout_factor)
 
-    def _calculate_plan_expiration(self, payout_factor: Decimal) -> None:
+    def _calculate_plan_expiration(self) -> None:
         for plan in self.plan_repository.get_active_plans():
             assert plan.is_active, "Plan is not active!"
             assert plan.activation_date, "Plan has no activation date!"
@@ -45,7 +47,7 @@ class UpdatePlansAndPayout:
 
             assert plan.active_days is not None
             if self._plan_is_expired(plan):
-                self._handle_expired_plan(plan, payout_factor)
+                self._handle_expired_plan(plan)
 
     def _payout_work_certificates(self, plan: Plan, payout_factor: Decimal) -> None:
         """
@@ -85,15 +87,22 @@ class UpdatePlansAndPayout:
         assert plan.expiration_date
         return self.datetime_service.now() > plan.expiration_date
 
-    def _handle_expired_plan(self, plan: Plan, payout_factor: Decimal) -> None:
+    def _handle_expired_plan(self, plan: Plan) -> None:
         """
-        payout overdue wages, if there are any
+        payout overdue wages, if there are any, applying the latest payout factor stored in repo
         delete plan's cooperation and coop request, if there is any
         set plan as expired
         """
         assert plan.active_days
         while plan.payout_count < plan.active_days:
-            self._payout(plan, payout_factor)
+            payout_factor = self.payout_factor_repository.get_latest_payout_factor()
+            if payout_factor is None:
+                # overdue wages and no pf in repo should hardly ever happen
+                # in this case best approximation is probably 1
+                payout_factor_value = Decimal(1)
+            else:
+                payout_factor_value = payout_factor.value
+            self._payout(plan, payout_factor_value)
         self._delete_cooperation_and_coop_request_from_plan(plan)
         self.plan_repository.set_plan_as_expired(plan)
 

--- a/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
+++ b/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
@@ -1,9 +1,12 @@
 {% extends "base_accountant.html" %}
 
 {% block content %}
-<div class="section">
+<div class="content has-text-centered">
+  <h1>{{ gettext("Unreviewed plans") }}</h1>
+</div>
+<section class="section">
   {% if view_model.show_plan_list %}
-  <div class="columns is-centered has-text-left">
+  <div class="column is-4 is-offset-4 is-centered has-text-left">
     {% for plan in view_model.plans %}
     <article class="media">
       <div class="media-content">
@@ -29,5 +32,5 @@
   {% else %}
   {{ gettext("There are currently no plans waiting for review") }}
   {% endif %}
-</div>
+</section>
 {% endblock %}

--- a/tests/services/test_payout_factor_service.py
+++ b/tests/services/test_payout_factor_service.py
@@ -1,0 +1,97 @@
+from decimal import Decimal
+
+from arbeitszeit.entities import ProductionCosts
+from arbeitszeit.payout_factor import PayoutFactorService
+from tests.use_cases.base_test_case import BaseTestCase
+from tests.use_cases.repositories import FakePayoutFactorRepository
+
+
+class CalculationTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.service = self.injector.get(PayoutFactorService)
+        self.payout_factor_repository = self.injector.get(FakePayoutFactorRepository)
+
+    def test_that_payout_factor_is_zero_if_no_plans_exist(self):
+        pf = self.service.calculate_payout_factor()
+        self.assertEqual(pf, 0)
+
+    def test_that_payout_factor_is_negative_with_one_public_plan_that_includes_p_or_r(
+        self,
+    ):
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(10), Decimal(10), Decimal(10)),
+        )
+        pf = self.service.calculate_payout_factor()
+        self.assertTrue(pf < 0)
+
+    def test_that_payout_factor_is_zero_with_one_public_plan_that_does_not_includes_p_or_r(
+        self,
+    ):
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(10), Decimal(0), Decimal(0)),
+        )
+        pf = self.service.calculate_payout_factor()
+        self.assertEqual(pf, 0)
+
+    def test_that_payout_factor_is_zero_when_productive_labour_equals_sum_of_public_p_and_r(
+        self,
+    ):
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(10), Decimal(10), Decimal(10)),
+        )
+        self.plan_generator.create_plan(
+            is_public_service=False,
+            costs=ProductionCosts(Decimal(20), Decimal(0), Decimal(0)),
+        )
+        pf = self.service.calculate_payout_factor()
+        self.assertEqual(pf, 0)
+
+    def test_that_payout_factor_is_positive_when_productive_labour_surpasses_sum_of_public_p_and_r(
+        self,
+    ):
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(10), Decimal(10), Decimal(10)),
+        )
+        self.plan_generator.create_plan(
+            is_public_service=False,
+            costs=ProductionCosts(Decimal(21), Decimal(0), Decimal(0)),
+        )
+        pf = self.service.calculate_payout_factor()
+        self.assertTrue(pf > 0)
+
+    def test_that_payout_factor_is_negative_when_sum_of_public_p_and_r_surpasses_productive_labour(
+        self,
+    ):
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(0), Decimal(10), Decimal(10)),
+        )
+        self.plan_generator.create_plan(
+            is_public_service=False,
+            costs=ProductionCosts(Decimal(19), Decimal(0), Decimal(0)),
+        )
+        pf = self.service.calculate_payout_factor()
+        self.assertTrue(pf < 0)
+
+    def test_that_correct_payout_factor_gets_calculated(self):
+        A = 10
+        Po = 10
+        Ro = 10
+        Ao = 10
+
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(Ao), Decimal(Ro), Decimal(Po)),
+        )
+        self.plan_generator.create_plan(
+            is_public_service=False,
+            costs=ProductionCosts(Decimal(A), Decimal(10), Decimal(10)),
+        )
+        pf = self.service.calculate_payout_factor()
+        expected_payout_factor = Decimal((A - (Po + Ro)) / (A + Ao))
+        self.assertAlmostEqual(pf, expected_payout_factor)


### PR DESCRIPTION
I noticed the following problem: 1) change activation date in the database. 2) run `flask payout`. 3) the FIK does not take the new activation_date into account (only when you run it a second time)

The same problem occurs when a plan has recently expired.

The reason for this behaviour is that calculate_plan_expiration depends on payout_factor (in order to pay out overdue wages of expired plans) and is therefore run AFTER the calculation of the payout factor. We would have to run the use case twice to get the desired result.

Instead I propose to use the latest available payout factor from the repo to pay out overdue wages. In consequence we can run calculate_plan_expiration BEFORE calculate_payout_factor.

A problem arises when there has never been calculated a payout factor and overdue wages have to be paid out. In this rare situation (that only can happen at the start of the economy, I propose to set payout factor to 1)

P.S.: I use the `BaseTestCase` designed for use cases to test the payout factor service. I guess that's ok, because it's both business logic.

Plan-ID: b33932e9-567a-4712-a48c-3ef347ec561e