### PR TITLE
Feature for list of unreviewed plans

### DIFF
--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -51,8 +51,8 @@ from .get_draft_summary import (
 )
 from .get_member_account import GetMemberAccount, GetMemberAccountResponse
 from .get_member_dashboard import GetMemberDashboard
-from .get_plan_summary_company import GetPlanSummaryCompany
 from .get_plan_summary_accountant import GetPlanSummaryAccountant
+from .get_plan_summary_company import GetPlanSummaryCompany
 from .get_plan_summary_member import GetPlanSummaryMember
 from .get_statistics import GetStatistics, StatisticsResponse
 from .hide_plan import HidePlan, HidePlanResponse

--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -52,6 +52,7 @@ from .get_draft_summary import (
 from .get_member_account import GetMemberAccount, GetMemberAccountResponse
 from .get_member_dashboard import GetMemberDashboard
 from .get_plan_summary_company import GetPlanSummaryCompany
+from .get_plan_summary_accountant import GetPlanSummaryAccountant
 from .get_plan_summary_member import GetPlanSummaryMember
 from .get_statistics import GetStatistics, StatisticsResponse
 from .hide_plan import HidePlan, HidePlanResponse
@@ -164,6 +165,7 @@ __all__ = [
     "GetMemberAccount",
     "GetMemberAccountResponse",
     "GetMemberDashboard",
+    "GetPlanSummaryAccountant",
     "GetPlanSummaryMember",
     "GetPlanSummaryCompany",
     "GetStatistics",

--- a/arbeitszeit/use_cases/get_plan_summary_accountant.py
+++ b/arbeitszeit/use_cases/get_plan_summary_accountant.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union
+from uuid import UUID
+
+from injector import inject
+
+from arbeitszeit.plan_summary import PlanSummary, PlanSummaryService
+from arbeitszeit.repositories import PlanRepository
+
+
+@inject
+@dataclass
+class GetPlanSummaryAccountant:
+    @dataclass
+    class Success:
+        plan_summary: PlanSummary
+
+    @dataclass
+    class Failure:
+        pass
+
+    plan_repository: PlanRepository
+    plan_summary_service: PlanSummaryService
+
+    def __call__(self, plan_id: UUID) -> Union[Success, Failure]:
+        plan = self.plan_repository.get_plans().with_id(plan_id).first()
+        if plan is None:
+            return self.Failure()
+        return self.Success(
+            plan_summary=self.plan_summary_service.get_summary_from_plan(plan)
+        )

--- a/arbeitszeit/use_cases/get_plan_summary_accountant.py
+++ b/arbeitszeit/use_cases/get_plan_summary_accountant.py
@@ -24,7 +24,7 @@ class GetPlanSummaryAccountant:
     plan_repository: PlanRepository
     plan_summary_service: PlanSummaryService
 
-    def __call__(self, plan_id: UUID) -> Union[Success, Failure]:
+    def get_plan_summary(self, plan_id: UUID) -> Union[Success, Failure]:
         plan = self.plan_repository.get_plans().with_id(plan_id).first()
         if plan is None:
             return self.Failure()

--- a/arbeitszeit/use_cases/list_plans_with_pending_review.py
+++ b/arbeitszeit/use_cases/list_plans_with_pending_review.py
@@ -21,6 +21,7 @@ class ListPlansWithPendingReviewUseCase:
         id: UUID
         product_name: str
         planner_name: str
+        planner_id: UUID
 
     @dataclass
     class Response:
@@ -41,4 +42,5 @@ class ListPlansWithPendingReviewUseCase:
             id=plan_model.id,
             product_name=plan_model.prd_name,
             planner_name=plan_model.planner.name,
+            planner_id=plan_model.planner.id,
         )

--- a/arbeitszeit_flask/accountant/blueprint.py
+++ b/arbeitszeit_flask/accountant/blueprint.py
@@ -5,7 +5,7 @@ from flask import Blueprint, redirect, session, url_for
 from flask_login import login_required
 
 from arbeitszeit_flask import types
-from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_flask.dependency_injection import AccountantModule, with_injection
 
 main_accountant = Blueprint(
     "main_accountant",
@@ -34,7 +34,7 @@ class AccountantRoute:
 
     def _apply_decorators(self, function):
         return main_accountant.route(self.route_string, methods=self.methods)(
-            with_injection()(login_required(function))
+            with_injection([AccountantModule()])(login_required(function))
         )
 
 

--- a/arbeitszeit_flask/accountant/routes.py
+++ b/arbeitszeit_flask/accountant/routes.py
@@ -80,12 +80,12 @@ def approve_plan(
 @AccountantRoute("/accountant/plan_summary/<uuid:plan_id>")
 def plan_summary(
     plan_id: UUID,
-    get_plan_summary_accountant: GetPlanSummaryAccountant,
+    use_case: GetPlanSummaryAccountant,
     template_renderer: UserTemplateRenderer,
     presenter: GetPlanSummaryAccountantSuccessPresenter,
     http_404_view: Http404View,
 ) -> Response:
-    use_case_response = get_plan_summary_accountant(plan_id)
+    use_case_response = use_case.get_plan_summary(plan_id)
     if isinstance(use_case_response, GetPlanSummaryAccountant.Success):
         view_model = presenter.present(use_case_response)
         return FlaskResponse(

--- a/arbeitszeit_flask/accountant/routes.py
+++ b/arbeitszeit_flask/accountant/routes.py
@@ -3,8 +3,10 @@ from uuid import UUID
 from flask import Response as FlaskResponse
 from flask import redirect
 
+from arbeitszeit import use_cases
 from arbeitszeit.use_cases.approve_plan import ApprovePlanUseCase
 from arbeitszeit.use_cases.get_accountant_dashboard import GetAccountantDashboardUseCase
+from arbeitszeit.use_cases.get_company_summary import GetCompanySummary
 from arbeitszeit.use_cases.get_plan_summary_accountant import GetPlanSummaryAccountant
 from arbeitszeit.use_cases.list_plans_with_pending_review import (
     ListPlansWithPendingReviewUseCase,
@@ -15,6 +17,7 @@ from arbeitszeit_flask.template import UserTemplateRenderer
 from arbeitszeit_flask.types import Response
 from arbeitszeit_flask.views.http_404_view import Http404View
 from arbeitszeit_web.controllers.approve_plan_controller import ApprovePlanController
+from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_plan_summary_accountant import (
     GetPlanSummaryAccountantSuccessPresenter,
 )
@@ -90,6 +93,25 @@ def plan_summary(
                 "accountant/plan_summary.html",
                 context=dict(view_model=view_model.to_dict()),
             )
+        )
+    else:
+        return http_404_view.get_response()
+
+
+@AccountantRoute("/accountant/company_summary/<uuid:company_id>")
+def company_summary(
+    company_id: UUID,
+    get_company_summary: GetCompanySummary,
+    template_renderer: UserTemplateRenderer,
+    presenter: GetCompanySummarySuccessPresenter,
+    http_404_view: Http404View,
+):
+    use_case_response = get_company_summary(company_id)
+    if isinstance(use_case_response, use_cases.GetCompanySummarySuccess):
+        view_model = presenter.present(use_case_response)
+        return template_renderer.render_template(
+            "accountant/company_summary.html",
+            context=dict(view_model=view_model.to_dict()),
         )
     else:
         return http_404_view.get_response()

--- a/arbeitszeit_flask/accountant/routes.py
+++ b/arbeitszeit_flask/accountant/routes.py
@@ -1,9 +1,11 @@
 from uuid import UUID
 
+from flask import Response as FlaskResponse
 from flask import redirect
 
 from arbeitszeit.use_cases.approve_plan import ApprovePlanUseCase
 from arbeitszeit.use_cases.get_accountant_dashboard import GetAccountantDashboardUseCase
+from arbeitszeit.use_cases.get_plan_summary_accountant import GetPlanSummaryAccountant
 from arbeitszeit.use_cases.list_plans_with_pending_review import (
     ListPlansWithPendingReviewUseCase,
 )
@@ -11,7 +13,11 @@ from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.flask_session import FlaskSession
 from arbeitszeit_flask.template import UserTemplateRenderer
 from arbeitszeit_flask.types import Response
+from arbeitszeit_flask.views.http_404_view import Http404View
 from arbeitszeit_web.controllers.approve_plan_controller import ApprovePlanController
+from arbeitszeit_web.get_plan_summary_accountant import (
+    GetPlanSummaryAccountantSuccessPresenter,
+)
 from arbeitszeit_web.presenters.approve_plan_presenter import ApprovePlanPresenter
 from arbeitszeit_web.presenters.get_accountant_dashboard_presenter import (
     GetAccountantDashboardPresenter,
@@ -66,3 +72,24 @@ def approve_plan(
     response = use_case.approve_plan(request)
     view_model = presenter.approve_plan(response)
     return redirect(view_model.redirect_url)
+
+
+@AccountantRoute("/accountant/plan_summary/<uuid:plan_id>")
+def plan_summary(
+    plan_id: UUID,
+    get_plan_summary_accountant: GetPlanSummaryAccountant,
+    template_renderer: UserTemplateRenderer,
+    presenter: GetPlanSummaryAccountantSuccessPresenter,
+    http_404_view: Http404View,
+) -> Response:
+    use_case_response = get_plan_summary_accountant(plan_id)
+    if isinstance(use_case_response, GetPlanSummaryAccountant.Success):
+        view_model = presenter.present(use_case_response)
+        return FlaskResponse(
+            template_renderer.render_template(
+                "accountant/plan_summary.html",
+                context=dict(view_model=view_model.to_dict()),
+            )
+        )
+    else:
+        return http_404_view.get_response()

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -57,6 +57,7 @@ from arbeitszeit_flask.mail_service import (
 )
 from arbeitszeit_flask.notifications import FlaskFlashNotifier
 from arbeitszeit_flask.template import (
+    AccountantTemplateIndex,
     AnonymousUserTemplateRenderer,
     CompanyTemplateIndex,
     FlaskTemplateRenderer,
@@ -111,6 +112,12 @@ from .views import ViewsModule
 __all__ = [
     "ViewsModule",
 ]
+
+
+class AccountantModule(Module):
+    @provider
+    def provide_template_index(self) -> TemplateIndex:
+        return AccountantTemplateIndex()
 
 
 class MemberModule(Module):

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -26,7 +26,7 @@ from arbeitszeit_flask.views import (
 )
 from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresenter
 from arbeitszeit_web.get_coop_summary import GetCoopSummarySuccessPresenter
-from arbeitszeit_web.get_plan_summary_member import GetPlanSummarySuccessPresenter
+from arbeitszeit_web.get_plan_summary_member import GetPlanSummaryMemberSuccessPresenter
 from arbeitszeit_web.get_statistics import GetStatisticsPresenter
 from arbeitszeit_web.presenters.get_member_account_presenter import (
     GetMemberAccountPresenter,
@@ -171,7 +171,7 @@ def plan_summary(
     plan_id: UUID,
     get_plan_summary_member: use_cases.GetPlanSummaryMember,
     template_renderer: UserTemplateRenderer,
-    presenter: GetPlanSummarySuccessPresenter,
+    presenter: GetPlanSummaryMemberSuccessPresenter,
     http_404_view: Http404View,
 ) -> Response:
     use_case_response = get_plan_summary_member(plan_id)

--- a/arbeitszeit_flask/template.py
+++ b/arbeitszeit_flask/template.py
@@ -32,6 +32,11 @@ class CompanyTemplateIndex:
         return f"company/{name}.html"
 
 
+class AccountantTemplateIndex:
+    def get_template_by_name(self, name: str) -> str:
+        return f"accountant/{name}.html"
+
+
 class FlaskTemplateRenderer:
     _EMPTY_CONTEXT: Dict[str, Any] = dict()
 

--- a/arbeitszeit_flask/templates/accountant/404.html
+++ b/arbeitszeit_flask/templates/accountant/404.html
@@ -1,0 +1,9 @@
+{% extends "base_accountant.html" %}
+
+{% block content %}
+
+<div class="section has-text-centered">
+    HTTP 404 NOT FOUND
+</div>
+
+{% endblock %}

--- a/arbeitszeit_flask/templates/accountant/company_summary.html
+++ b/arbeitszeit_flask/templates/accountant/company_summary.html
@@ -1,0 +1,10 @@
+{% extends "base_accountant.html" %}
+
+{% block navbar_start %}
+<div class="navbar-item">{{ gettext("Company overview") }}</div>
+{% endblock %}
+
+{% block content %}
+{% from 'macros/company_summary.html' import company_summary %}
+{{ company_summary(view_model) }}
+{% endblock %}

--- a/arbeitszeit_flask/templates/accountant/plan_summary.html
+++ b/arbeitszeit_flask/templates/accountant/plan_summary.html
@@ -1,0 +1,11 @@
+{% extends "base_accountant.html" %}
+
+{% block navbar_start %}
+<div class="navbar-item">{{ gettext("Plan information") }}</div>
+{% endblock %}
+
+{% block content %}
+{% from 'macros/plan_summary.html' import plan_summary %}
+{{ plan_summary(view_model) }}
+
+{% endblock %}

--- a/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
+++ b/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
@@ -1,9 +1,11 @@
 {% extends "base_accountant.html" %}
 
 {% block content %}
-<div class="content has-text-centered">
-  <h1>{{ gettext("Unreviewed plans") }}</h1>
-</div>
+<section class="section"> 
+  <div class="content has-text-centered">
+    <h1>{{ gettext("Unreviewed plans") }}</h1>
+  </div>
+</section>
 <section class="section">
   {% if view_model.show_plan_list %}
   <div class="column is-4 is-offset-4 is-centered has-text-left">
@@ -11,9 +13,9 @@
     <article class="media">
       <div class="media-content">
         <div class="content">
-          <strong>{{ plan.product_name }}</strong>
+          <strong><a href="{{ plan.plan_summary_url }}">{{ plan.product_name }}</a></strong>
           <br>
-          <small>@{{ plan.planner_name }}</small>
+          <small>@<a href="{{ plan.company_summary_url }}">{{ plan.planner_name }}</a></small>
         </div>
       </div>
       <div class="media-right">

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -13,6 +13,8 @@ class GeneralUrlIndex:
             return url_for("main_company.plan_summary", plan_id=plan_id)
         elif user_role == UserRole.member:
             return url_for("main_member.plan_summary", plan_id=plan_id)
+        elif user_role == UserRole.accountant:
+            return url_for("main_accountant.plan_summary", plan_id=plan_id)
         else:
             raise ValueError(f"Plan summary url is unsupported for {user_role}")
 
@@ -53,8 +55,10 @@ class GeneralUrlIndex:
     ) -> str:
         if user_role == UserRole.company:
             return url_for("main_company.company_summary", company_id=company_id)
-        if user_role == UserRole.member:
+        elif user_role == UserRole.member:
             return url_for("main_member.company_summary", company_id=company_id)
+        elif user_role == UserRole.accountant:
+            return url_for("main_accountant.company_summary", company_id=company_id)
         else:
             raise ValueError(f"company summary not available for {user_role}")
 

--- a/arbeitszeit_web/get_plan_summary_accountant.py
+++ b/arbeitszeit_web/get_plan_summary_accountant.py
@@ -1,0 +1,38 @@
+from dataclasses import asdict, dataclass
+from typing import Any, Dict
+
+from injector import inject
+
+from arbeitszeit.use_cases.get_plan_summary_accountant import GetPlanSummaryAccountant
+from arbeitszeit_web.formatters.plan_summary_formatter import (
+    PlanSummaryFormatter,
+    PlanSummaryWeb,
+)
+from arbeitszeit_web.url_index import UrlIndex
+
+from .translator import Translator
+
+
+@dataclass
+class GetPlanSummaryAccountantViewModel:
+    summary: PlanSummaryWeb
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@inject
+@dataclass
+class GetPlanSummaryAccountantSuccessPresenter:
+    trans: Translator
+    plan_summary_service: PlanSummaryFormatter
+    url_index: UrlIndex
+
+    def present(
+        self, response: GetPlanSummaryAccountant.Success
+    ) -> GetPlanSummaryAccountantViewModel:
+        return GetPlanSummaryAccountantViewModel(
+            summary=self.plan_summary_service.format_plan_summary(
+                response.plan_summary
+            ),
+        )

--- a/arbeitszeit_web/get_plan_summary_member.py
+++ b/arbeitszeit_web/get_plan_summary_member.py
@@ -14,7 +14,7 @@ from .translator import Translator
 
 
 @dataclass
-class GetPlanSummaryViewModel:
+class GetPlanSummaryMemberViewModel:
     summary: PlanSummaryWeb
     pay_product_url: str
 
@@ -24,15 +24,15 @@ class GetPlanSummaryViewModel:
 
 @inject
 @dataclass
-class GetPlanSummarySuccessPresenter:
+class GetPlanSummaryMemberSuccessPresenter:
     trans: Translator
     plan_summary_service: PlanSummaryFormatter
     url_index: UrlIndex
 
     def present(
         self, response: GetPlanSummaryMember.Success
-    ) -> GetPlanSummaryViewModel:
-        return GetPlanSummaryViewModel(
+    ) -> GetPlanSummaryMemberViewModel:
+        return GetPlanSummaryMemberViewModel(
             summary=self.plan_summary_service.format_plan_summary(
                 response.plan_summary
             ),

--- a/arbeitszeit_web/presenters/list_plans_with_pending_review_presenter.py
+++ b/arbeitszeit_web/presenters/list_plans_with_pending_review_presenter.py
@@ -8,6 +8,7 @@ from injector import inject
 from arbeitszeit.use_cases.list_plans_with_pending_review import (
     ListPlansWithPendingReviewUseCase as UseCase,
 )
+from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.url_index import UrlIndex
 
 
@@ -19,6 +20,8 @@ class ListPlansWithPendingReviewPresenter:
         product_name: str
         planner_name: str
         approve_plan_url: str
+        plan_summary_url: str
+        company_summary_url: str
 
     @dataclass
     class ViewModel:
@@ -35,6 +38,12 @@ class ListPlansWithPendingReviewPresenter:
                     product_name=plan.product_name,
                     planner_name=plan.planner_name,
                     approve_plan_url=self.url_index.get_approve_plan_url(plan.id),
+                    plan_summary_url=self.url_index.get_plan_summary_url(
+                        user_role=UserRole.accountant, plan_id=plan.id
+                    ),
+                    company_summary_url=self.url_index.get_company_summary_url(
+                        user_role=UserRole.accountant, company_id=plan.planner_id
+                    ),
                 )
                 for plan in response.plans
             ],

--- a/tests/flask_integration/test_get_company_summary.py
+++ b/tests/flask_integration/test_get_company_summary.py
@@ -1,0 +1,54 @@
+from uuid import uuid4
+
+from .flask import ViewTestCase
+
+
+class AuthenticatedMemberTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.member = self.login_member()
+
+    def test_get_404_when_company_does_not_exist(self) -> None:
+        url = f"/member/company_summary/{uuid4()}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_200_when_company_exists(self) -> None:
+        company = self.company_generator.create_company()
+        url = f"/member/company_summary/{company}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class AuthenticatedCompanyTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company = self.login_company()
+
+    def test_get_404_when_company_does_not_exist(self) -> None:
+        url = f"/company/company_summary/{uuid4()}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_200_when_company_exists(self) -> None:
+        company = self.company_generator.create_company()
+        url = f"/company/company_summary/{company}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class AuthenticatedAccountantTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.accountant = self.login_accountant()
+
+    def test_get_404_when_company_does_not_exist(self) -> None:
+        url = f"/accountant/company_summary/{uuid4()}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_200_when_company_exists(self) -> None:
+        company = self.company_generator.create_company()
+        url = f"/accountant/company_summary/{company}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_get_plan_summary.py
+++ b/tests/flask_integration/test_get_plan_summary.py
@@ -39,3 +39,21 @@ class AuthenticatedCompanyTests(ViewTestCase):
         url = f"/company/plan_summary/{plan.id}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+
+class AuthenticatedAccountantTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.accountant = self.login_accountant()
+
+    def test_get_404_when_plan_does_not_exist(self) -> None:
+        url = f"/accountant/plan_summary/{uuid4()}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_200_when_plan_exists(self) -> None:
+        plan = self.plan_generator.create_plan()
+        url = f"/accountant/plan_summary/{plan.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/tests/presenters/test_get_plan_summary_company_presenter.py
+++ b/tests/presenters/test_get_plan_summary_company_presenter.py
@@ -45,7 +45,7 @@ TESTING_RESPONSE_MODEL = GetPlanSummaryCompany.Response(
 
 class GetPlanSummaryCompanySuccessPresenterTests(TestCase):
     """
-    some functionality are tested in tests/presenters/test_plan_summary_service.py
+    some functionality are tested in tests/presenters/test_plan_summary_formatter.py
     """
 
     def setUp(self) -> None:

--- a/tests/presenters/test_get_plan_summary_member_presenter.py
+++ b/tests/presenters/test_get_plan_summary_member_presenter.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from arbeitszeit.plan_summary import PlanSummary
 from arbeitszeit.use_cases.get_plan_summary_member import GetPlanSummaryMember
-from arbeitszeit_web.get_plan_summary_member import GetPlanSummarySuccessPresenter
+from arbeitszeit_web.get_plan_summary_member import GetPlanSummaryMemberSuccessPresenter
 from tests.presenters.dependency_injection import injection_test
 from tests.presenters.url_index import UrlIndexTestImpl
 
@@ -19,7 +19,7 @@ class PresenterTests(TestCase):
     def setUp(
         self,
         url_index: UrlIndexTestImpl,
-        presenter: GetPlanSummarySuccessPresenter,
+        presenter: GetPlanSummaryMemberSuccessPresenter,
     ) -> None:
         self.url_index = url_index
         self.presenter = presenter

--- a/tests/presenters/test_get_plan_summary_member_presenter.py
+++ b/tests/presenters/test_get_plan_summary_member_presenter.py
@@ -12,7 +12,7 @@ from tests.presenters.url_index import UrlIndexTestImpl
 
 class PresenterTests(TestCase):
     """
-    some functionality tested in tests/presenters/test_plan_summary_service.py
+    some functionality tested in tests/presenters/test_plan_summary_formatter.py
     """
 
     @injection_test

--- a/tests/presenters/test_list_plans_with_pending_review_presenter.py
+++ b/tests/presenters/test_list_plans_with_pending_review_presenter.py
@@ -7,6 +7,7 @@ from arbeitszeit.use_cases.list_plans_with_pending_review import (
 from arbeitszeit_web.presenters.list_plans_with_pending_review_presenter import (
     ListPlansWithPendingReviewPresenter,
 )
+from arbeitszeit_web.session import UserRole
 
 from .base_test_case import BaseTestCase
 from .url_index import UrlIndexTestImpl
@@ -57,6 +58,28 @@ class PresenterTests(BaseTestCase):
             0
         ].approve_plan_url == self.url_index.get_approve_plan_url(plan_id)
 
+    def test_that_plan_summary_url_is_set_correctly(self) -> None:
+        plan_id = uuid4()
+        view_model = self.presenter.list_plans_with_pending_review(
+            self._get_response_with_one_plan(plan_id=plan_id)
+        )
+        assert view_model.plans[
+            0
+        ].plan_summary_url == self.url_index.get_plan_summary_url(
+            user_role=UserRole.accountant, plan_id=plan_id
+        )
+
+    def test_that_company_summary_url_is_set_correctly(self) -> None:
+        planner_id = uuid4()
+        view_model = self.presenter.list_plans_with_pending_review(
+            self._get_response_with_one_plan(planner_id=planner_id)
+        )
+        assert view_model.plans[
+            0
+        ].company_summary_url == self.url_index.get_company_summary_url(
+            user_role=UserRole.accountant, company_id=planner_id
+        )
+
     def _get_empty_response(self) -> UseCase.Response:
         return UseCase.Response(plans=[])
 
@@ -66,13 +89,19 @@ class PresenterTests(BaseTestCase):
         product_name: str = "test product",
         planner_name: str = "example company",
         plan_id: Optional[UUID] = None,
+        planner_id: Optional[UUID] = None,
     ) -> UseCase.Response:
         if plan_id is None:
             plan_id = uuid4()
+        if planner_id is None:
+            planner_id = uuid4()
         return UseCase.Response(
             plans=[
                 UseCase.Plan(
-                    id=plan_id, product_name=product_name, planner_name=planner_name
+                    id=plan_id,
+                    product_name=product_name,
+                    planner_name=planner_name,
+                    planner_id=planner_id,
                 )
             ]
         )

--- a/tests/use_cases/test_get_plan_summary_accountant.py
+++ b/tests/use_cases/test_get_plan_summary_accountant.py
@@ -1,0 +1,24 @@
+from uuid import uuid4
+
+from arbeitszeit.use_cases.get_plan_summary_accountant import GetPlanSummaryAccountant
+from tests.use_cases.base_test_case import BaseTestCase
+
+
+class UseCaseTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(GetPlanSummaryAccountant)
+        self.company = self.company_generator.create_company_entity()
+
+    def test_that_failure_is_returned_when_plan_does_not_exist(self) -> None:
+        self.assertIsInstance(self.use_case(uuid4()), GetPlanSummaryAccountant.Failure)
+
+    def test_plan_summary_success_is_returned_when_plan_exists(self):
+        plan = self.plan_generator.create_plan()
+        self.assertIsInstance(self.use_case(plan.id), GetPlanSummaryAccountant.Success)
+
+    def test_plan_summary_is_returned_when_plan_exists(self):
+        plan = self.plan_generator.create_plan()
+        plan_summary_success = self.use_case(plan.id)
+        assert isinstance(plan_summary_success, GetPlanSummaryAccountant.Success)
+        self.assertTrue(plan_summary_success.plan_summary)

--- a/tests/use_cases/test_get_plan_summary_accountant.py
+++ b/tests/use_cases/test_get_plan_summary_accountant.py
@@ -11,14 +11,18 @@ class UseCaseTests(BaseTestCase):
         self.company = self.company_generator.create_company_entity()
 
     def test_that_failure_is_returned_when_plan_does_not_exist(self) -> None:
-        self.assertIsInstance(self.use_case(uuid4()), GetPlanSummaryAccountant.Failure)
+        self.assertIsInstance(
+            self.use_case.get_plan_summary(uuid4()), GetPlanSummaryAccountant.Failure
+        )
 
     def test_plan_summary_success_is_returned_when_plan_exists(self):
         plan = self.plan_generator.create_plan()
-        self.assertIsInstance(self.use_case(plan.id), GetPlanSummaryAccountant.Success)
+        self.assertIsInstance(
+            self.use_case.get_plan_summary(plan.id), GetPlanSummaryAccountant.Success
+        )
 
     def test_plan_summary_is_returned_when_plan_exists(self):
         plan = self.plan_generator.create_plan()
-        plan_summary_success = self.use_case(plan.id)
+        plan_summary_success = self.use_case.get_plan_summary(plan.id)
         assert isinstance(plan_summary_success, GetPlanSummaryAccountant.Success)
         self.assertTrue(plan_summary_success.plan_summary)

--- a/tests/use_cases/test_list_plans_with_pending_review.py
+++ b/tests/use_cases/test_list_plans_with_pending_review.py
@@ -64,6 +64,14 @@ class UseCaseTests(BaseTestCase):
             expected_company_name, [plan.planner_name for plan in response.plans]
         )
 
+    def test_id_of_planning_company_is_in_response(self) -> None:
+        planner = self.company_generator.create_company_entity()
+        self.file_plan_draft(planner=planner)
+        response = self.use_case.list_plans_with_pending_review(
+            request=ListPlansWithPendingReviewUseCase.Request()
+        )
+        self.assertIn(planner.id, [plan.planner_id for plan in response.plans])
+
     def file_plan_draft(
         self, product_name: Optional[str] = None, planner: Optional[Company] = None
     ) -> UUID:


### PR DESCRIPTION
fixes #566 

Among other things I created two routes for accountants, `plan_summary` and `company_summary`.

I noticed there were no integration tests for the company_summary page.

I did not implement the links in the accountants list of unreviewed plans yet, to make this PR not too large.

Plan-ID: b33932e9-567a-4712-a48c-3ef347ec561e