### PR TITLE
Update versions of actions if CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v11
+    - uses: cachix/install-nix-action@v18
+    - uses: cachix/cachix-action@v12
       with:
         name: arbeitszeit
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
   build-nix:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v17
     - uses: cachix/cachix-action@v11
       with:
@@ -28,9 +28,9 @@ jobs:
   build-pip:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10.5
         cache: 'pip'


### PR DESCRIPTION
I updated the versions of `actions/checkout`, `actions/setup-python`  and `cachix` in the CI workflow to suffice the deprecation warnings.