### PR TITLE
Redesign "my cooperations" page

### DIFF
--- a/arbeitszeit/use_cases/list_inbound_coop_requests.py
+++ b/arbeitszeit/use_cases/list_inbound_coop_requests.py
@@ -24,6 +24,7 @@ class ListedInboundCoopRequest:
     plan_id: UUID
     plan_name: str
     planner_name: str
+    planner_id: UUID
 
 
 @dataclass
@@ -69,4 +70,5 @@ class ListInboundCoopRequests:
             plan_id=plan.id,
             plan_name=plan.prd_name,
             planner_name=plan.planner.name,
+            planner_id=plan.planner.id,
         )

--- a/arbeitszeit_flask/static/main.css
+++ b/arbeitszeit_flask/static/main.css
@@ -11,6 +11,10 @@
     vertical-align: -.125em;
 }
 
+.media-right form button.large-button {
+  padding: 12px 12px 12px 12px;
+  vertical-align: -.125em;
+}
 
 /* notification box */
 .notification_box {

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -82,9 +82,15 @@
             <div class="media-content">
                 <div class="content">
                     <p>
-                    <small><span>{{ gettext("Company") }}:</span>&nbsp;<a href="{{ req.planner_url }}">{{ req.planner_name }}</a></small>
+                    <small>
+                        <span>{{ gettext("Company") }}:</span>&nbsp;
+                        <strong><a href="{{ req.planner_url }}">{{ req.planner_name }}</a></strong>
+                    </small>
                     <br>
-                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;<a href="{{ req.plan_url }}">{{ req.plan_name }}</a></small>
+                    <small>
+                        <span>{{ gettext("Plan") }}:</span>&nbsp;
+                        <strong><a href="{{ req.plan_url }}">{{ req.plan_name }}</a></strong>
+                    </small>
                     <br>
                     <small><span>{{ gettext("My cooperation") }}:</span>&nbsp;{{ req.coop_name }}</small
                     </p>
@@ -130,7 +136,10 @@
             <div class="media-content">
                 <div class="content">
                     <p>
-                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;{{ req.plan_name }}</small>
+                    <small>
+                        <span>{{ gettext("Plan") }}:</span>&nbsp;
+                        <strong><a href="{{ req.plan_url }}">{{ req.plan_name }}</a></strong>
+                    </small>
                     <br>
                     <small><span>{{ gettext("Cooperation") }}:</span>&nbsp;{{ req.coop_name }}</small>
                     </p>

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -6,10 +6,12 @@
 
 {% block content %}
 <div class="section has-text-centered">
-    <h1 class="title">
-        {{ gettext("My cooperations") }}
-    </h1>
+  <h1 class="title">
+      {{ gettext("My cooperations") }}
+   </h1>  
+</div>
 
+<div class="section has-text-centered">
     <div class="tile is-ancestor">
         <div class="tile is-parent"></div>
         <a class="tile is-parent" href="{{ url_for('main_company.create_cooperation') }}">
@@ -21,7 +23,8 @@
         </a>
         <div class="tile is-parent"></div>
     </div>
-
+</div>
+<div class="section has-text-centered">
     <h1 class="title is-4">
         {{ gettext("Cooperations that I coordinate") }}
     </h1>
@@ -42,130 +45,112 @@
     {% endfor %}
     {% endif %}
 
-    <div class="table-container">
-        {% if list_of_coordinations.rows %}
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th>{{ gettext("Cooperation") }}</th>
-                    <th>{{ gettext("Name") }}</th>
-                    <th>{{ gettext("Definition") }}</th>
-                    <th>{{ gettext("Number of plans") }} </th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for coop in list_of_coordinations.rows %}
-                <tr>
-                    <td><a href="{{ coop.coop_summary_url }}">{{ coop.coop_id }}</a></td>
-                    <td>{{ coop.coop_name }}</td>
-                    <td>{% for paragraph in coop.coop_definition %}{{ paragraph }}<br>{% endfor %}</td>
-                    <td>{{ coop.count_plans_in_coop }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        {% else %}
-        <p>{{ gettext("You do not coordinate any cooperation") }}</p>
-        {% endif %}
+    <div class="column is-offset-4 is-4 has-text-left">
+    {% if list_of_coordinations.rows %}
+    {% for coop in list_of_coordinations.rows %}
+      <article class="media">
+        <div class="media-content">
+          <div class="content">
+            <p>
+              <strong class="is-size-5">
+                <a href="{{ coop.coop_summary_url }}">{{ coop.coop_name }}</a>
+              </strong>
+              <br>
+              <small><span>{{ gettext("Number of plans") }}</span>&nbsp;{{ coop.count_plans_in_coop }}</small>
+            </p>
+          </div>
+        </div>
+      </article>  
+    {% endfor %}
+    {% else %}
+    <p class="has-text-centered">{{ gettext("You do not coordinate any cooperation") }}</p>
+    {% endif %}
     </div>
+</div>
+
+<div class="section has-text-centered">
     <div class="content">
         <h1 class="title is-4">
             {{ gettext("Incoming cooperation request (by others)") }}
         </h1>
     </div>
-    <div class="table-container">
-        {% if list_of_inbound_coop_requests.rows %}
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th>{{ gettext("My cooperation") }}</th>
-                    <th>{{ gettext("Requesting company") }}</th>
-                    <th>{{ gettext("Requesting plan") }}</th>
-                    <th>{{ gettext("Accept request") }}</th>
-                    <th>{{ gettext("Decline") }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for req in list_of_inbound_coop_requests.rows %}
-                <tr>
-                    <td>{{ req.coop_name }}</td>
-                    <td>{{ req.planner_name }}</td>
-                    <td>{{ req.plan_name }}</td>
-                    <form action="" method="post">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <td>
-                            <div class="control">
-                                <button class="button is-small is-success" name="accept"
-                                    value="{{ req.coop_id }},{{ req.plan_id }}" type="submit">
-                                    <span class="icon">
-                                        <i class="fas fa-check"></i>
-                                    </span>
-                                    <span>{{ gettext("Accept") }}</span>
-                                </button>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="control">
-                                <button class="button is-small is-danger" name="deny"
-                                    value="{{ req.coop_id }},{{ req.plan_id }}" type="submit">
-                                    <span class="icon">
-                                        <i class="fas fa-times"></i>
-                                    </span>
-                                    <span>{{ gettext("Decline") }}</span>
-                                </button>
-                            </div>
-                        </td>
-                    </form>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        {% else %}
-        <p>{{ gettext("You don't have open requests") }}</p>
-        {% endif %}
-    </div>
 
+    <div class="column is-offset-4 is-4 has-text-left">
+    {% if list_of_inbound_coop_requests.rows %}
+    {% for req in list_of_inbound_coop_requests.rows %}
+        <article class="media">
+            <div class="media-content">
+                <div class="content">
+                    <p>
+                    <small><span>{{ gettext("Company") }}:</span>&nbsp;{{ req.coop_name }}</small>
+                    <br>
+                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;{{ req.plan_name }}</small>
+                    <br>
+                    <small><span>{{ gettext("My cooperation") }}:</span>&nbsp;{{ req.coop_name }}</small
+                    </p>
+                </div>
+            </div>
+            <div class="media-right">
+                <form action="" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="content pt-1">
+                    <button class="button large-button is-primary" name="accept" 
+                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Accept') }}">
+                        <i class="fas fa-check"></i>
+                    </button>
+                    &nbsp;
+                    <button class="button large-button is-danger" name="deny" 
+                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Deny') }}">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+                </form>                
+            </div>
+        </article>  
+    
+    {% endfor %}
+    </div>
+    
+    {% else %}
+    <p class="has-text-centered">{{ gettext("You don't have open requests") }}</p>
+    {% endif %}
+
+</div>
+<div class="section has-text-centered">
     <div class="content">
         <h1 class="title is-4">
             {{ gettext("Outgoing cooperation requests (own requests)") }}
         </h1>
     </div>
 
-    <div class="table-container">
+    <div class="column is-offset-4 is-4 has-text-left">
         {% if list_of_outbound_coop_requests.rows %}
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th>{{ gettext("My requesting plan")}}</th>
-                    <th>{{ gettext("Requested cooperation") }}</th>
-                    <th>{{ gettext("Cancel request") }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for req in list_of_outbound_coop_requests.rows %}
-                <tr>
-                    <td>{{ req.plan_name }}</td>
-                    <td>{{ req.coop_name }}</td>
-                    <form action="" method="post">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <td>
-                            <div class="control">
-                                <button class="button is-small is-danger" name="cancel" value="{{ req.plan_id }}"
-                                    type="submit">
-                                    <span class="icon">
-                                        <i class="fas fa-times"></i>
-                                    </span>
-                                    <span>{{ gettext("Cancel")}}</span>
-                                </button>
-                            </div>
-                        </td>
+        {% for req in list_of_outbound_coop_requests.rows %}
+        <article class="media">
+            <div class="media-content">
+                <div class="content">
+                    <p>
+                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;{{ req.plan_name }}</small>
+                    <br>
+                    <small><span>{{ gettext("Cooperation") }}:</span>&nbsp;{{ req.coop_name }}</small>
+                    </p>
+                </div>
+            </div>
+            <div class="media-right">
+                <form action="" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="content pt-1">
+                        <button class="button large-button is-danger" name="cancel" 
+                            value="{{ req.plan_id }}" type="submit" title="{{ gettext('Cancel') }}">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
                     </form>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+            </div>
+        </article>
+        {% endfor %}
         {% else %}
-        <p>{{ gettext("You haven't requested any cooperation")}}</p>
+        <p class="has-text-centered">{{ gettext("You haven't requested any cooperation")}}</p>
         {% endif %}
     </div>
 </div>

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -82,9 +82,9 @@
             <div class="media-content">
                 <div class="content">
                     <p>
-                    <small><span>{{ gettext("Company") }}:</span>&nbsp;{{ req.coop_name }}</small>
+                    <small><span>{{ gettext("Company") }}:</span>&nbsp;<a href="{{ req.planner_url }}">{{ req.planner_name }}</a></small>
                     <br>
-                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;{{ req.plan_name }}</small>
+                    <small><span>{{ gettext("Plan") }}:</span>&nbsp;<a href="{{ req.plan_url }}">{{ req.plan_name }}</a></small>
                     <br>
                     <small><span>{{ gettext("My cooperation") }}:</span>&nbsp;{{ req.coop_name }}</small
                     </p>
@@ -100,7 +100,7 @@
                     </button>
                     &nbsp;
                     <button class="button large-button is-danger" name="deny" 
-                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Deny') }}">
+                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Decline') }}">
                         <i class="fas fa-times"></i>
                     </button>
                 </div>

--- a/arbeitszeit_web/show_my_cooperations.py
+++ b/arbeitszeit_web/show_my_cooperations.py
@@ -43,6 +43,7 @@ class ListOfInboundCooperationRequestsRow:
 class ListOfOutboundCooperationRequestsRow:
     plan_id: str
     plan_name: str
+    plan_url: str
     coop_id: str
     coop_name: str
 
@@ -174,6 +175,9 @@ class ShowMyCooperationsPresenter:
         return ListOfOutboundCooperationRequestsRow(
             plan_id=str(plan.plan_id),
             plan_name=plan.plan_name,
+            plan_url=self.url_index.get_plan_summary_url(
+                user_role=UserRole.company, plan_id=plan.plan_id
+            ),
             coop_id=str(plan.coop_id),
             coop_name=plan.coop_name,
         )

--- a/arbeitszeit_web/show_my_cooperations.py
+++ b/arbeitszeit_web/show_my_cooperations.py
@@ -34,7 +34,9 @@ class ListOfInboundCooperationRequestsRow:
     coop_name: str
     plan_id: str
     plan_name: str
+    plan_url: str
     planner_name: str
+    planner_url: str
 
 
 @dataclass
@@ -157,7 +159,13 @@ class ShowMyCooperationsPresenter:
             coop_name=plan.coop_name,
             plan_id=str(plan.plan_id),
             plan_name=plan.plan_name,
+            plan_url=self.url_index.get_plan_summary_url(
+                user_role=UserRole.company, plan_id=plan.plan_id
+            ),
             planner_name=plan.planner_name,
+            planner_url=self.url_index.get_company_summary_url(
+                user_role=UserRole.company, company_id=plan.planner_id
+            ),
         )
 
     def _display_outbound_coop_requests(

--- a/tests/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/presenters/test_show_my_cooperations_presenter.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from unittest import TestCase
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases import (
     AcceptCooperationResponse,
@@ -14,9 +13,9 @@ from arbeitszeit.use_cases import (
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.show_my_cooperations import ShowMyCooperationsPresenter
+from tests.presenters.base_test_case import BaseTestCase
 from tests.translator import FakeTranslator
 
-from .dependency_injection import get_dependency_injector
 from .url_index import UrlIndexTestImpl
 
 LIST_COORDINATIONS_RESPONSE_LEN_1 = ListCoordinationsResponse(
@@ -31,17 +30,29 @@ LIST_COORDINATIONS_RESPONSE_LEN_1 = ListCoordinationsResponse(
     ]
 )
 
-LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1 = ListInboundCoopRequestsResponse(
-    cooperation_requests=[
-        ListedInboundCoopRequest(
-            coop_id=uuid4(),
-            coop_name="coop name",
-            plan_id=uuid4(),
-            plan_name="plan name",
-            planner_name="planner name",
-        )
-    ]
-)
+
+def get_inbound_response_length_1(
+    coop_id: UUID = None, plan_id: UUID = None, planner_id: UUID = None
+) -> ListInboundCoopRequestsResponse:
+    if coop_id is None:
+        coop_id = uuid4()
+    if plan_id is None:
+        plan_id = uuid4()
+    if planner_id is None:
+        planner_id = uuid4()
+    return ListInboundCoopRequestsResponse(
+        cooperation_requests=[
+            ListedInboundCoopRequest(
+                coop_id=coop_id,
+                coop_name="coop name",
+                plan_id=plan_id,
+                plan_name="plan name",
+                planner_name="planner name",
+                planner_id=planner_id,
+            )
+        ]
+    )
+
 
 LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1 = ListOutboundCoopRequestsResponse(
     cooperation_requests=[
@@ -55,9 +66,9 @@ LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1 = ListOutboundCoopRequestsResponse(
 )
 
 
-class ShowMyCooperationsPresenterTests(TestCase):
+class ShowMyCooperationsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
-        self.injector = get_dependency_injector()
+        super().setUp()
         self.url_index = self.injector.get(UrlIndexTestImpl)
         self.translator = FakeTranslator()
         self.presenter = self.injector.get(ShowMyCooperationsPresenter)
@@ -65,7 +76,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_coordinations_are_presented_correctly(self):
         presentation = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             AcceptCooperationResponse(rejection_reason=None),
             DenyCooperationResponse(rejection_reason=None),
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -100,41 +111,10 @@ class ShowMyCooperationsPresenterTests(TestCase):
             str(LIST_COORDINATIONS_RESPONSE_LEN_1.coordinations[0].count_plans_in_coop),
         )
 
-    def test_inbound_cooperation_requests_are_presented_correctly(self):
-        presentation = self.presenter.present(
-            LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
-            AcceptCooperationResponse(rejection_reason=None),
-            DenyCooperationResponse(rejection_reason=None),
-            LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
-            None,
-        )
-        self.assertEqual(len(presentation.list_of_inbound_coop_requests.rows), 1)
-        self.assertEqual(
-            presentation.list_of_inbound_coop_requests.rows[0].coop_name,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1.cooperation_requests[0].coop_name,
-        )
-        self.assertEqual(
-            presentation.list_of_inbound_coop_requests.rows[0].coop_id,
-            str(LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1.cooperation_requests[0].coop_id),
-        )
-        self.assertEqual(
-            presentation.list_of_inbound_coop_requests.rows[0].plan_id,
-            str(LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1.cooperation_requests[0].plan_id),
-        )
-        self.assertEqual(
-            presentation.list_of_inbound_coop_requests.rows[0].plan_name,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1.cooperation_requests[0].plan_name,
-        )
-        self.assertEqual(
-            presentation.list_of_inbound_coop_requests.rows[0].planner_name,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1.cooperation_requests[0].planner_name,
-        )
-
     def test_successfull_accept_request_response_is_presented_correctly(self):
         presentation_success = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             AcceptCooperationResponse(rejection_reason=None),
             None,
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -154,7 +134,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_successfull_deny_request_response_is_presented_correctly(self):
         presentation_success = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             None,
             DenyCooperationResponse(rejection_reason=None),
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -174,7 +154,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_failed_accept_request_response_is_presented_correctly(self):
         presentation_failure = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             AcceptCooperationResponse(
                 rejection_reason=AcceptCooperationResponse.RejectionReason.plan_not_found
             ),
@@ -196,7 +176,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_failed_deny_request_response_is_presented_correctly(self):
         presentation_failure = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             None,
             DenyCooperationResponse(
                 rejection_reason=DenyCooperationResponse.RejectionReason.plan_not_found
@@ -218,7 +198,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_outbound_cooperation_requests_are_presented_correctly(self):
         presentation = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             AcceptCooperationResponse(rejection_reason=None),
             DenyCooperationResponse(rejection_reason=None),
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -249,7 +229,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_successfull_cancel_request_response_is_presented_correctly(self):
         presentation = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             None,
             None,
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -268,7 +248,7 @@ class ShowMyCooperationsPresenterTests(TestCase):
     def test_failed_cancel_request_response_is_presented_correctly(self):
         presentation = self.presenter.present(
             LIST_COORDINATIONS_RESPONSE_LEN_1,
-            LIST_INBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(),
             None,
             None,
             LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
@@ -282,4 +262,67 @@ class ShowMyCooperationsPresenterTests(TestCase):
         self.assertEqual(
             presentation.cancel_message[0],
             self.translator.gettext("Error: Not possible to cancel request."),
+        )
+
+
+class InboundTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(ShowMyCooperationsPresenter)
+        self.url_index = self.injector.get(UrlIndexTestImpl)
+        self.COOP_ID = uuid4()
+        self.PLAN_ID = uuid4()
+        self.PLANNER_ID = uuid4()
+        self.view_model = self.presenter.present(
+            LIST_COORDINATIONS_RESPONSE_LEN_1,
+            get_inbound_response_length_1(
+                coop_id=self.COOP_ID, plan_id=self.PLAN_ID, planner_id=self.PLANNER_ID
+            ),
+            AcceptCooperationResponse(rejection_reason=None),
+            DenyCooperationResponse(rejection_reason=None),
+            LIST_OUTBD_COOP_REQUESTS_RESPONSE_LEN_1,
+            None,
+        )
+
+    def test_inbound_coop_name_is_presented(self):
+        self.assertTrue(
+            self.view_model.list_of_inbound_coop_requests.rows[0].coop_name,
+        )
+
+    def test_inbound_plan_name_is_presented(self):
+        self.assertTrue(
+            self.view_model.list_of_inbound_coop_requests.rows[0].plan_name,
+        )
+
+    def test_inbound_planner_name_is_presented(self):
+        self.assertTrue(
+            self.view_model.list_of_inbound_coop_requests.rows[0].planner_name,
+        )
+
+    def test_inbound_coop_id_is_presented_correctly(self):
+        self.assertEqual(
+            self.view_model.list_of_inbound_coop_requests.rows[0].coop_id,
+            str(self.COOP_ID),
+        )
+
+    def test_inbound_plan_id_is_presented_correctly(self):
+        self.assertEqual(
+            self.view_model.list_of_inbound_coop_requests.rows[0].plan_id,
+            str(self.PLAN_ID),
+        )
+
+    def test_inbound_plan_url_is_presented_correctly(self):
+        self.assertEqual(
+            self.view_model.list_of_inbound_coop_requests.rows[0].plan_url,
+            self.url_index.get_plan_summary_url(
+                user_role=UserRole.company, plan_id=self.PLAN_ID
+            ),
+        )
+
+    def test_inbound_planner_url_is_presented_correctly(self):
+        self.assertEqual(
+            self.view_model.list_of_inbound_coop_requests.rows[0].planner_url,
+            self.url_index.get_company_summary_url(
+                user_role=UserRole.company, company_id=self.PLANNER_ID
+            ),
         )

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from tests.data_generators import (
     AccountantGenerator,
     CompanyGenerator,
+    CooperationGenerator,
     MemberGenerator,
     PlanGenerator,
 )
@@ -56,4 +57,5 @@ class BaseTestCase(TestCase):
     company_generator = _lazy_property(CompanyGenerator)
     plan_generator = _lazy_property(PlanGenerator)
     accountant_generator = _lazy_property(AccountantGenerator)
+    coop_generator = _lazy_property(CooperationGenerator)
     datetime_service = _lazy_property(FakeDatetimeService)

--- a/tests/use_cases/test_list_inbound_coop_requests.py
+++ b/tests/use_cases/test_list_inbound_coop_requests.py
@@ -7,56 +7,49 @@ from arbeitszeit.use_cases import (
     ListInboundCoopRequestsRequest,
     ListInboundCoopRequestsResponse,
 )
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-
-from .dependency_injection import injection_test
+from tests.use_cases.base_test_case import BaseTestCase
 
 
-def plan_in_list(plan: Plan, response: ListInboundCoopRequestsResponse) -> bool:
-    for listed_request in response.cooperation_requests:
-        if plan.id == listed_request.plan_id:
-            return True
-    return False
+class UseCaseTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(ListInboundCoopRequests)
 
+    def test_emtpy_list_is_returned_when_cooperation_is_not_found(self):
+        response = self.use_case(ListInboundCoopRequestsRequest(uuid4()))
+        assert len(response.cooperation_requests) == 0
 
-@injection_test
-def test_emtpy_list_is_returned_when_cooperation_is_not_found(
-    list_requests: ListInboundCoopRequests,
-):
-    response = list_requests(ListInboundCoopRequestsRequest(uuid4()))
-    assert len(response.cooperation_requests) == 0
+    def test_empty_list_is_returned_when_there_are_no_requests_for_coordinator(
+        self,
+    ):
+        coordinator = self.company_generator.create_company_entity()
+        coop = self.coop_generator.create_cooperation()
+        self.plan_generator.create_plan(
+            requested_cooperation=coop, activation_date=datetime.min
+        )
+        response = self.use_case(ListInboundCoopRequestsRequest(coordinator.id))
+        assert len(response.cooperation_requests) == 0
 
+    def test_correct_plans_are_returned_when_plans_request_cooperation(
+        self,
+    ):
+        coordinator = self.company_generator.create_company_entity()
+        coop = self.coop_generator.create_cooperation(coordinator=coordinator)
+        requesting_plan1 = self.plan_generator.create_plan(
+            requested_cooperation=coop, activation_date=datetime.min
+        )
+        requesting_plan2 = self.plan_generator.create_plan(
+            requested_cooperation=coop, activation_date=datetime.min
+        )
+        response = self.use_case(ListInboundCoopRequestsRequest(coordinator.id))
+        assert len(response.cooperation_requests) == 2
+        assert self.plan_in_list(requesting_plan1, response)
+        assert self.plan_in_list(requesting_plan2, response)
 
-@injection_test
-def test_empty_list_is_returned_when_there_are_no_requests_for_coordinator(
-    list_requests: ListInboundCoopRequests,
-    coop_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    coordinator = company_generator.create_company_entity()
-    coop = coop_generator.create_cooperation()
-    plan_generator.create_plan(requested_cooperation=coop, activation_date=datetime.min)
-    response = list_requests(ListInboundCoopRequestsRequest(coordinator.id))
-    assert len(response.cooperation_requests) == 0
-
-
-@injection_test
-def test_correct_plans_are_returned_when_plans_request_cooperation(
-    list_requests: ListInboundCoopRequests,
-    coop_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    coordinator = company_generator.create_company_entity()
-    coop = coop_generator.create_cooperation(coordinator=coordinator)
-    requesting_plan1 = plan_generator.create_plan(
-        requested_cooperation=coop, activation_date=datetime.min
-    )
-    requesting_plan2 = plan_generator.create_plan(
-        requested_cooperation=coop, activation_date=datetime.min
-    )
-    response = list_requests(ListInboundCoopRequestsRequest(coordinator.id))
-    assert len(response.cooperation_requests) == 2
-    assert plan_in_list(requesting_plan1, response)
-    assert plan_in_list(requesting_plan2, response)
+    def plan_in_list(
+        self, plan: Plan, response: ListInboundCoopRequestsResponse
+    ) -> bool:
+        for listed_request in response.cooperation_requests:
+            if plan.id == listed_request.plan_id:
+                return True
+        return False


### PR DESCRIPTION
A step towards #415

Before adding a new section to `/company/my_cooperations` with a company's own cooperating plans in an upcoming PR, I firstly redesign the page here:

- make it mobile friendly (replace tables with bulma media object)
- add links to plan summaries and company summaries  
 
Plan-ID: b33932e9-567a-4712-a48c-3ef347ec561e
