### PR TITLE
Implement dedicated database record for tracking payout of labour certificates

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -149,7 +149,6 @@ class Plan:
     is_active: bool
     expired: bool
     activation_date: Optional[datetime]
-    payout_count: int
     requested_cooperation: Optional[UUID]
     cooperation: Optional[UUID]
     is_available: bool
@@ -246,3 +245,9 @@ class Accountant:
 class PayoutFactor:
     calculation_date: datetime
     value: Decimal
+
+
+@dataclass
+class LabourCertificatesPayout:
+    plan_id: UUID
+    transaction_id: UUID

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -14,6 +14,7 @@ from arbeitszeit.entities import (
     Company,
     CompanyWorkInvite,
     Cooperation,
+    LabourCertificatesPayout,
     Member,
     PayoutFactor,
     Plan,
@@ -217,6 +218,11 @@ class AccountResult(QueryResult[Account], Protocol):
         ...
 
 
+class LabourCertificatesPayoutResult(QueryResult[LabourCertificatesPayout], Protocol):
+    def for_plan(self, plan: UUID) -> LabourCertificatesPayoutResult:
+        ...
+
+
 class PurchaseRepository(ABC):
     @abstractmethod
     def create_purchase_by_company(
@@ -249,10 +255,6 @@ class PurchaseRepository(ABC):
 class PlanRepository(ABC):
     @abstractmethod
     def create_plan_from_draft(self, draft_id: UUID) -> Optional[UUID]:
-        pass
-
-    @abstractmethod
-    def increase_payout_count_by_one(self, plan: Plan) -> None:
         pass
 
     @abstractmethod
@@ -531,4 +533,14 @@ class PayoutFactorRepository(Protocol):
         ...
 
     def get_latest_payout_factor(self) -> Optional[PayoutFactor]:
+        ...
+
+
+class DatabaseGateway(Protocol):
+    def get_labour_certificates_payouts(self) -> LabourCertificatesPayoutResult:
+        ...
+
+    def create_labour_certificates_payout(
+        self, transaction: UUID, plan: UUID
+    ) -> LabourCertificatesPayout:
         ...

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -32,6 +32,7 @@ from arbeitszeit_flask.database.repositories import (
     AccountRepository,
     CompanyRepository,
     CooperationRepository,
+    DatabaseGatewayImpl,
     MemberRepository,
     PayoutFactorRepository,
     PlanDraftRepository,
@@ -191,6 +192,10 @@ class FlaskModule(Module):
         binder[EmailConfiguration] = AliasProvider(FlaskEmailConfiguration)  # type: ignore
         binder[interfaces.TransactionRepository] = AliasProvider(TransactionRepository)  # type: ignore
         binder[interfaces.AccountantRepository] = AliasProvider(AccountantRepository)  # type: ignore
+        binder.bind(
+            interfaces.DatabaseGateway,  # type: ignore
+            to=AliasProvider(DatabaseGatewayImpl),
+        )
         binder[TemplateRenderer] = AliasProvider(FlaskTemplateRenderer)  # type: ignore
         binder[Session] = AliasProvider(FlaskSession)  # type: ignore
         binder[Notifier] = AliasProvider(FlaskFlashNotifier)  # type: ignore

--- a/arbeitszeit_flask/migrations/versions/15d33dfe8ec7_.py
+++ b/arbeitszeit_flask/migrations/versions/15d33dfe8ec7_.py
@@ -1,0 +1,120 @@
+# type: ignore
+"""empty message
+
+Revision ID: 15d33dfe8ec7
+Revises: 2185d9d4448f
+Create Date: 2023-02-15 13:04:28.046515
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import orm
+from uuid import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = '15d33dfe8ec7'
+down_revision = '2185d9d4448f'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'labour_certificates_payout',
+        sa.Column('transaction_id', sa.String(), nullable=False),
+        sa.Column('plan_id', sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(['plan_id'], ['plan.id'], ),
+        sa.ForeignKeyConstraint(['transaction_id'], ['transaction.id'], ),
+        sa.PrimaryKeyConstraint('transaction_id')
+    )
+    bind = op.get_bind()
+    with orm.Session(bind=bind) as session:
+        certificate_payout_transactions = session.query(Transaction).filter(
+            sa.and_(
+                Transaction.sending_account.in_(
+                    session.query(SocialAccounting).with_entities(SocialAccounting.account)
+                ),
+                Transaction.receiving_account.in_(
+                    session.query(Company).with_entities(Company.a_account)
+                )
+            )
+        )
+        for transaction in certificate_payout_transactions:
+            plan_id = transaction.purpose.removeprefix("Plan-Id: ")
+            UUID(plan_id)
+            payout = LabourCertificatesPayout(
+                transaction_id=transaction.id,
+                plan_id=plan_id,
+            )
+            session.add(payout)
+        session.commit()
+    with op.batch_alter_table('plan', schema=None) as batch_op:
+        batch_op.drop_column('payout_count')
+
+
+def downgrade():
+    with op.batch_alter_table('plan', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('payout_count', sa.INTEGER(), autoincrement=False, nullable=True))
+    bind = op.get_bind()
+    with orm.Session(bind=bind) as session:
+        for plan in session.query(Plan):
+            payout_count = session.query(LabourCertificatesPayout).filter(LabourCertificatesPayout.plan_id == plan.id).count()
+            plan.payout_count = payout_count
+        session.commit()
+    with op.batch_alter_table('plan') as batch_op:
+        batch_op.alter_column(sa.Column('payout_count', sa.INTEGER(), autoincrement=False, nullable=False))
+    op.drop_table('labour_certificates_payout')
+
+
+Base = declarative_base()
+
+
+class Company(Base):
+    __tablename__ = "company"
+
+    id = sa.Column(sa.String, primary_key=True)
+    a_account = sa.Column(sa.ForeignKey("account.id"), nullable=False)
+
+
+class SocialAccounting(Base):
+    __tablename__ = "social_accounting"
+    id = sa.Column(sa.String, primary_key=True)
+    account = sa.Column(sa.ForeignKey("account.id"), nullable=False)
+
+
+class Transaction(Base):
+    __tablename__ = "transaction"
+    id = sa.Column(
+        sa.String,
+        primary_key=True,
+    )
+    date = sa.Column(sa.DateTime, nullable=False)
+    sending_account = sa.Column(
+        sa.String,
+        sa.ForeignKey("account.id"),
+        nullable=False
+    )
+    receiving_account = sa.Column(
+        sa.String,
+        sa.ForeignKey("account.id"),
+        nullable=False,
+    )
+    purpose = sa.Column(sa.String(1000), nullable=True)
+
+
+class LabourCertificatesPayout(Base):
+    __tablename__ = "labour_certificates_payout"
+    transaction_id = sa.Column(
+        sa.String,
+        sa.ForeignKey("transaction.id"),
+        nullable=False,
+        primary_key=True,
+    )
+    plan_id = sa.Column(sa.String, sa.ForeignKey("plan.id"), nullable=False)
+
+
+class Plan(Base):
+    __tablename__ = "plan"
+    id = sa.Column(sa.String, primary_key=True)
+    payout_count = sa.Column(sa.Integer, nullable=False, default=0)

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -113,7 +113,6 @@ class Plan(db.Model):
     is_active = db.Column(db.Boolean, nullable=False, default=False)
     activation_date = db.Column(db.DateTime, nullable=True)
     expired = db.Column(db.Boolean, nullable=False, default=False)
-    payout_count = db.Column(db.Integer, nullable=False, default=0)
     is_available = db.Column(db.Boolean, nullable=False, default=True)
     requested_cooperation = db.Column(
         db.String, db.ForeignKey("cooperation.id"), nullable=True
@@ -184,6 +183,16 @@ class Purchase(db.Model):
     price_per_unit = db.Column(db.Numeric(), nullable=False)
     amount = db.Column(db.Integer, nullable=False)
     purpose = db.Column(db.Enum(entities.PurposesOfPurchases), nullable=False)
+
+
+class LabourCertificatesPayout(db.Model):
+    transaction_id = db.Column(
+        db.String,
+        db.ForeignKey("transaction.id"),
+        nullable=False,
+        primary_key=True,
+    )
+    plan_id = db.Column(db.String, db.ForeignKey("plan.id"), nullable=False)
 
 
 class CompanyWorkInvite(db.Model):

--- a/tests/flask_integration/test_database_gateway_impl.py
+++ b/tests/flask_integration/test_database_gateway_impl.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from arbeitszeit import entities
+from arbeitszeit_flask.database.repositories import (
+    AccountRepository,
+    DatabaseGatewayImpl,
+    TransactionRepository,
+)
+from tests.data_generators import PlanGenerator
+
+from .flask import FlaskTestCase
+
+
+class LabourCertificatesPayoutTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.database_gateway = self.injector.get(DatabaseGatewayImpl)
+        self.transaction_repository = self.injector.get(TransactionRepository)
+        self.account_repository = self.injector.get(AccountRepository)
+        self.plan_generator = self.injector.get(PlanGenerator)
+
+    def test_that_by_default_no_payouts_are_found_in_db(self) -> None:
+        assert not self.database_gateway.get_labour_certificates_payouts()
+
+    def test_that_some_payouts_are_found_if_one_was_created_previously(self) -> None:
+        plan = self.plan_generator.create_plan()
+        self.database_gateway.create_labour_certificates_payout(
+            transaction=self.create_transaction(),
+            plan=plan.id,
+        )
+        assert self.database_gateway.get_labour_certificates_payouts()
+
+    def test_that_3_payouts_were_registered_if_3_were_created(self) -> None:
+        plan = self.plan_generator.create_plan()
+        for _ in range(3):
+            self.database_gateway.create_labour_certificates_payout(
+                transaction=self.create_transaction(),
+                plan=plan.id,
+            )
+        assert len(self.database_gateway.get_labour_certificates_payouts()) == 3
+
+    def test_that_retrieved_payout_containts_plan_id_that_it_was_created_with(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        self.database_gateway.create_labour_certificates_payout(
+            transaction=self.create_transaction(),
+            plan=plan.id,
+        )
+        for payout in self.database_gateway.get_labour_certificates_payouts():
+            assert payout.plan_id == plan.id
+
+    def test_that_retrieved_payout_contains_the_transaction_id_that_it_was_created_with(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        transaction = self.create_transaction()
+        self.database_gateway.create_labour_certificates_payout(
+            transaction=transaction,
+            plan=plan.id,
+        )
+        for payout in self.database_gateway.get_labour_certificates_payouts():
+            assert payout.transaction_id == transaction
+
+    def test_that_returned_payout_contains_plan_id_that_it_was_created_with(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        transaction = self.create_transaction()
+        payout = self.database_gateway.create_labour_certificates_payout(
+            transaction=transaction,
+            plan=plan.id,
+        )
+        assert payout.plan_id == plan.id
+
+    def test_that_no_payouts_are_returned_when_filtering_for_non_existing_plan(
+        self,
+    ) -> None:
+        self.database_gateway.create_labour_certificates_payout(
+            transaction=self.create_transaction(),
+            plan=self.plan_generator.create_plan().id,
+        )
+        assert not self.database_gateway.get_labour_certificates_payouts().for_plan(
+            uuid4()
+        )
+
+    def test_that_a_payout_is_returned_when_filtering_for_existing_plan(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan().id
+        self.database_gateway.create_labour_certificates_payout(
+            transaction=self.create_transaction(),
+            plan=plan,
+        )
+        assert self.database_gateway.get_labour_certificates_payouts().for_plan(plan)
+
+    def create_transaction(self) -> UUID:
+        sending_account = self.account_repository.create_account(
+            entities.AccountTypes.accounting
+        )
+        receiving_account = self.account_repository.create_account(
+            entities.AccountTypes.a
+        )
+        transaction = self.transaction_repository.create_transaction(
+            date=datetime(2000, 1, 1),
+            sending_account=sending_account.id,
+            receiving_account=receiving_account.id,
+            purpose="",
+            amount_sent=Decimal(1),
+            amount_received=Decimal(1),
+        )
+        return transaction.id

--- a/tests/flask_integration/test_plan_repository.py
+++ b/tests/flask_integration/test_plan_repository.py
@@ -83,14 +83,6 @@ class PlanRepositoryTests(FlaskTestCase):
         assert plan_from_repo
         assert plan_from_repo.hidden_by_user
 
-    def test_that_payout_count_is_increased_by_one(self) -> None:
-        plan = self.plan_generator.create_plan()
-        assert plan.payout_count == 0
-        self.plan_repository.increase_payout_count_by_one(plan)
-        plan_from_repo = self.plan_repository.get_plans().with_id(plan.id).first()
-        assert plan_from_repo
-        assert plan_from_repo.payout_count == 1
-
     def test_that_availability_is_toggled_to_false(self) -> None:
         plan = self.plan_generator.create_plan()
         assert plan.is_available == True

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -81,6 +81,10 @@ class InMemoryModule(Module):
             repositories.FakePayoutFactorRepository
         )
         binder[TokenService] = AliasProvider(FakeTokenService)  # type: ignore
+        binder.bind(
+            interfaces.DatabaseGateway,  # type: ignore
+            to=AliasProvider(repositories.EntityStorage),
+        )
 
 
 def get_dependency_injector() -> Injector:


### PR DESCRIPTION
Before this change we tracked the payout process of labour certificates by increasing a counter on the `Plan` model. This approach has several drawback:

1) It limits the amount of information we can track about the payout process of labour certificates. It would be hard to add additional information about the payout process since we would need to introduce additional fields to the `Plan` model. Let's say we wanted to track the FIK used when transferring labour certificates for each payout transaction. There would be no obvious way to do that currently.

2) It attaches information to a plan that are not related to the planning process itself but rather related to the payout process. The `Plan` model is unnecessarily rich in information that could be tracked separately.

For those reasons I implemented a separate model `LabourCertificatePayout` that for now has two fields.

`plan_id` is a reference to the plan that the labour certificates are meant for.
`transaction_id` points the the transaction that facilitates the payment process.

Since I worked for several hours on this PR, I would appreciate if the collective would expend the certificates for 2 PRs instead of one.
Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418 (2x)