### PR TITLE
Refactor planning stats

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -105,6 +105,10 @@ class ProductionCosts:
             means_cost=self.means_cost + other.means_cost,
         )
 
+    @classmethod
+    def zero(cls) -> ProductionCosts:
+        return cls(Decimal(0), Decimal(0), Decimal(0))
+
 
 @dataclass
 class PlanDraft:
@@ -251,3 +255,9 @@ class PayoutFactor:
 class LabourCertificatesPayout:
     plan_id: UUID
     transaction_id: UUID
+
+
+@dataclass
+class PlanningStatistics:
+    average_plan_duration_in_days: Decimal
+    total_planned_costs: ProductionCosts

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -19,6 +19,7 @@ from arbeitszeit.entities import (
     PayoutFactor,
     Plan,
     PlanDraft,
+    PlanningStatistics,
     ProductionCosts,
     Purchase,
     PurposesOfPurchases,
@@ -104,6 +105,11 @@ class PlanResult(QueryResult[Plan], Protocol):
         """If no companies are specified then the repository should
         return all plans that request cooperation with any
         coordinator.
+        """
+
+    def get_statistics(self) -> PlanningStatistics:
+        """Return aggregate planning information for all plans
+        included in a result set.
         """
 
     def update(self) -> PlanUpdate:
@@ -255,26 +261,6 @@ class PurchaseRepository(ABC):
 class PlanRepository(ABC):
     @abstractmethod
     def create_plan_from_draft(self, draft_id: UUID) -> Optional[UUID]:
-        pass
-
-    @abstractmethod
-    def avg_timeframe_of_active_plans(self) -> Decimal:
-        pass
-
-    @abstractmethod
-    def sum_of_active_planned_work(self) -> Decimal:
-        pass
-
-    @abstractmethod
-    def sum_of_active_planned_resources(self) -> Decimal:
-        pass
-
-    @abstractmethod
-    def sum_of_active_planned_means(self) -> Decimal:
-        pass
-
-    @abstractmethod
-    def all_plans_approved_and_not_expired(self) -> Iterator[Plan]:
         pass
 
     @abstractmethod

--- a/arbeitszeit/use_cases/get_statistics.py
+++ b/arbeitszeit/use_cases/get_statistics.py
@@ -43,20 +43,20 @@ class GetStatistics:
             certs_total,
             available_product,
         ) = self._count_certificates_and_available_product()
+        active_plans = self.plan_repository.get_plans().that_are_active()
+        planning_statistics = active_plans.get_statistics()
         return StatisticsResponse(
             registered_companies_count=len(self.company_repository.get_companies()),
             registered_members_count=len(self.member_repository.get_members()),
             cooperations_count=self.cooperation_respository.count_cooperations(),
             certificates_count=certs_total,
             available_product=available_product,
-            active_plans_count=len(self.plan_repository.get_plans().that_are_active()),
-            active_plans_public_count=len(
-                self.plan_repository.get_plans().that_are_active().that_are_public()
-            ),
-            avg_timeframe=self.plan_repository.avg_timeframe_of_active_plans(),
-            planned_work=self.plan_repository.sum_of_active_planned_work(),
-            planned_resources=self.plan_repository.sum_of_active_planned_resources(),
-            planned_means=self.plan_repository.sum_of_active_planned_means(),
+            active_plans_count=len(active_plans),
+            active_plans_public_count=len(active_plans.that_are_public()),
+            avg_timeframe=planning_statistics.average_plan_duration_in_days,
+            planned_work=planning_statistics.total_planned_costs.labour_cost,
+            planned_resources=planning_statistics.total_planned_costs.resource_cost,
+            planned_means=planning_statistics.total_planned_costs.means_cost,
             payout_factor=self.payout_factor_repository.get_latest_payout_factor(),
         )
 


### PR DESCRIPTION
This PR refactors the DB logic for retrieving global planning stats. The refactoring allows the collection of planning stats from any `PlanResult`. This makes it much easier to calculate planning statistics for any arbitrary set of plans, e.g. all public plans or all plans that are inside a cooperation and so on. Also less DB calls are made in the use case `GetStatistics`.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418