### PR TITLE
Pin nix version in github pipeline to 2.13.3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: arbeitszeit
@@ -81,6 +83,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: arbeitszeit


### PR DESCRIPTION
This should fix the current build errors. There is a regression in the installation script for nix 2.14. See https://github.com/NixOS/nixpkgs/pull/218858#issuecomment-1448758169 for further info.

No certs required.