### PR TITLE
Refactor MemberRepository

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -177,11 +177,21 @@ class MemberResult(QueryResult[Member], Protocol):
     def with_email_address(self, email: str) -> MemberResult:
         ...
 
-    def set_confirmation_timestamp(self, timestamp: datetime) -> int:
-        ...
+    def update(self) -> MemberUpdate:
+        """Prepare an update for all selected members."""
 
     def that_are_confirmed(self) -> MemberResult:
         ...
+
+
+class MemberUpdate(Protocol):
+    def set_confirmation_timestamp(self, timestamp: datetime) -> MemberUpdate:
+        ...
+
+    def perform(self) -> int:
+        """Perform the update action and return the number of columns
+        affected.
+        """
 
 
 class ConsumerPurchaseResult(QueryResult[ConsumerPurchase], Protocol):

--- a/arbeitszeit/use_cases/confirm_member.py
+++ b/arbeitszeit/use_cases/confirm_member.py
@@ -33,7 +33,7 @@ class ConfirmMemberUseCase:
             if members.that_are_confirmed():
                 pass
             else:
-                members.set_confirmation_timestamp(datetime.min)
+                members.update().set_confirmation_timestamp(datetime.min).perform()
                 member = members.first()
                 assert member
                 return self.Response(is_confirmed=True, member=member.id)

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -107,7 +107,9 @@ class MemberGenerator:
         assert (
             self.member_repository.get_members()
             .with_id(member.id)
+            .update()
             .set_confirmation_timestamp(registered_on)
+            .perform()
         )
         member = self.member_repository.get_members().with_id(member.id).first()
         assert member


### PR DESCRIPTION
The MemberResult.set_confirmation_timestamp method was moved to the newly introduced MemberUpdate interface. This was done to better follow the desired DB interface where update actions on selected rows can be aggregated before they are executed in one (or at least few) database operation.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418