### PR TITLE
Stop using deprecated sqlalchemy features

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -409,7 +409,8 @@ class CompanyQueryResult(FlaskQueryResult[entities.Company]):
 
     def add_worker(self, member: UUID) -> int:
         companies_changed = 0
-        member = models.Member.query.get(str(member))
+        member = models.Member.query.filter(models.Member.id == str(member)).first()
+        assert member
         for company in self.query:
             companies_changed += 1
             company.workers.append(member)
@@ -683,8 +684,8 @@ class MemberRepository(repositories.MemberRepository):
             confirmed_on=orm_object.confirmed_on,
         )
 
-    def object_to_orm(self, member: entities.Member) -> Member:
-        return Member.query.get(str(member.id))
+    def object_to_orm(self, member: entities.Member) -> models.Member:
+        return models.Member.query.filter(models.Member.id == str(member.id)).first()
 
     def create_member(
         self,
@@ -731,7 +732,9 @@ class CompanyRepository(repositories.CompanyRepository):
     db: SQLAlchemy
 
     def object_to_orm(self, company: entities.Company) -> Company:
-        return Company.query.get(str(company.id))
+        orm = models.Company.query.filter(models.Company.id == str(company.id)).first()
+        assert orm
+        return orm
 
     def object_from_orm(self, company_orm: Company) -> entities.Company:
         return entities.Company(
@@ -896,7 +899,10 @@ class AccountRepository(repositories.AccountRepository):
         return self.object_from_orm(account)
 
     def get_account_balance(self, account: UUID) -> Decimal:
-        account_orm = models.Account.query.get(str(account))
+        account_orm = models.Account.query.filter(
+            models.Account.id == str(account)
+        ).first()
+        assert account_orm
         received = set(account_orm.transactions_received)
         sent = set(account_orm.transactions_sent)
         intersection = received & sent
@@ -907,7 +913,9 @@ class AccountRepository(repositories.AccountRepository):
         )
 
     def get_by_id(self, id: UUID) -> entities.Account:
-        return self.object_from_orm(Account.query.get(str(id)))
+        orm = Account.query.filter(models.Account.id == str(id)).first()
+        assert orm
+        return self.object_from_orm(orm)
 
     def get_accounts(self) -> AccountQueryResult:
         return AccountQueryResult(
@@ -1056,7 +1064,9 @@ class PlanRepository(repositories.PlanRepository):
         )
 
     def object_to_orm(self, plan: entities.Plan) -> models.Plan:
-        return models.Plan.query.get(str(plan.id))
+        orm = models.Plan.query.filter(models.Plan.id == str(plan.id)).first()
+        assert orm
+        return orm
 
     def _create_plan_from_draft(
         self,
@@ -1240,7 +1250,7 @@ class PlanDraftRepository(repositories.PlanDraftRepository):
             ).update(update_instructions)
 
     def get_by_id(self, id: UUID) -> Optional[entities.PlanDraft]:
-        orm = PlanDraft.query.get(str(id))
+        orm = models.PlanDraft.query.filter(models.PlanDraft.id == str(id)).first()
         if orm is None:
             return None
         else:

--- a/arbeitszeit_flask/flask_session.py
+++ b/arbeitszeit_flask/flask_session.py
@@ -47,17 +47,22 @@ class FlaskSession:
             return None
 
     def login_member(self, member: UUID, remember: bool = False) -> None:
-        member = models.Member.query.get(str(member))
+        member = models.Member.query.filter(models.Member.id == (str(member))).first()
+        assert member
         login_user(member, remember=remember)
         session["user_type"] = "member"
 
     def login_company(self, company: UUID, remember: bool = False) -> None:
-        company = models.Company.query.get(str(company))
+        company = models.Company.query.filter(models.Company.id == str(company)).first()
+        assert company
         login_user(company, remember=remember)
         session["user_type"] = "company"
 
     def login_accountant(self, accountant: UUID, remember: bool = False) -> None:
-        accountant = models.Accountant.query.get(str(accountant))
+        accountant = models.Accountant.query.filter(
+            models.Accountant.id == str(accountant)
+        ).first()
+        assert accountant
         login_user(accountant, remember=remember)
         session["user_type"] = "accountant"
 

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -44,12 +44,17 @@ class Member(UserMixin, db.Model):
     confirmed_on = db.Column(db.DateTime, nullable=True)
     account = db.Column(db.ForeignKey("account.id"), nullable=False)
 
-    user = db.relationship("User", lazy=True, uselist=False, backref="member")
+    user = db.relationship(
+        "User",
+        lazy=True,
+        uselist=False,
+        backref=db.backref("member", cascade_backrefs=False),
+    )
     workplaces = db.relationship(
         "Company",
         secondary=jobs,
         lazy="dynamic",
-        backref=db.backref("workers", lazy="dynamic"),
+        backref=db.backref("workers", lazy="dynamic", cascade_backrefs=False),
     )
 
 
@@ -65,8 +70,17 @@ class Company(UserMixin, db.Model):
     prd_account = db.Column(db.ForeignKey("account.id"), nullable=False)
 
     drafts = db.relationship("PlanDraft", lazy="dynamic")
-    user = db.relationship("User", lazy=True, uselist=False, backref="company")
-    plans = db.relationship("Plan", lazy="dynamic", backref="company")
+    user = db.relationship(
+        "User",
+        lazy=True,
+        uselist=False,
+        backref=db.backref("company", cascade_backrefs=False),
+    )
+    plans = db.relationship(
+        "Plan",
+        lazy="dynamic",
+        backref=db.backref("company", cascade_backrefs=False),
+    )
 
     def __repr__(self):
         return "<Company(name='%s')>" % (self.name,)
@@ -77,7 +91,12 @@ class Accountant(UserMixin, db.Model):
     user_id = db.Column(db.ForeignKey("user.id"), nullable=False)
     name = db.Column(db.String(1000), nullable=False)
 
-    user = db.relationship("User", lazy=True, uselist=False, backref="accountant")
+    user = db.relationship(
+        "User",
+        lazy=True,
+        uselist=False,
+        backref=db.backref("accountant", cascade_backrefs=False),
+    )
 
 
 class PlanDraft(db.Model):
@@ -118,7 +137,9 @@ class Plan(db.Model):
     cooperation = db.Column(db.String, db.ForeignKey("cooperation.id"), nullable=True)
     hidden_by_user = db.Column(db.Boolean, nullable=False, default=False)
 
-    review = db.relationship("PlanReview", uselist=False, back_populates="plan")
+    review = db.relationship(
+        "PlanReview", uselist=False, back_populates="plan", cascade_backrefs=False
+    )
 
 
 class PlanReview(db.Model):
@@ -126,7 +147,7 @@ class PlanReview(db.Model):
     approval_date = db.Column(db.DateTime, nullable=True, default=None)
     plan_id = db.Column(db.String, db.ForeignKey("plan.id"), nullable=False)
 
-    plan = db.relationship("Plan", back_populates="review")
+    plan = db.relationship("Plan", back_populates="review", cascade_backrefs=False)
 
     def __repr__(self) -> str:
         return f"PlanReview(id={self.id!r}, plan_id={self.plan_id!r}, approval_date={self.approval_date!r})"
@@ -149,13 +170,13 @@ class Account(db.Model):
         "Transaction",
         foreign_keys="Transaction.sending_account",
         lazy="dynamic",
-        backref="account_from",
+        backref=db.backref("account_from", cascade_backrefs=False),
     )
     transactions_received = db.relationship(
         "Transaction",
         foreign_keys="Transaction.receiving_account",
         lazy="dynamic",
-        backref="account_to",
+        backref=db.backref("account_to", cascade_backrefs=False),
     )
 
 
@@ -213,7 +234,10 @@ class Cooperation(db.Model):
     coordinator = db.Column(db.String, db.ForeignKey("company.id"), nullable=False)
 
     plans = db.relationship(
-        "Plan", foreign_keys="Plan.cooperation", lazy="dynamic", backref="coop"
+        "Plan",
+        foreign_keys="Plan.cooperation",
+        lazy="dynamic",
+        backref=db.backref("coop", cascade_backrefs=False),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,3 @@ module = [
     "wtforms"
 ]
 ignore_missing_imports = true
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    '''ignore:'_app_ctx_stack' is deprecated:DeprecationWarning''',
-    'ignore:Dialect sqlite\+pysqlite does \*not\* support Decimal objects natively, and SQLAlchemy must convert from floating point - rounding errors and other issues may occur',
-]


### PR DESCRIPTION
Previously we made use of two sqlalchemy features that are now deprecated.

1) `Model.query.get(pk)` is now deprecated and was replaced with
```
orm = Model.query.filter(id=pk).first()
assert orm
```

2) `backref` and `relationship` cascades will be removed in sqlachemy 2.0. We implemented the recommended steps from their documentation at https://docs.sqlalchemy.org/en/14/errors.html#object-is-being-merged-into-a-session-along-the-backref-cascade

No certs needed.