### PR TITLE
Change DB interface for creating plans

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -283,7 +283,18 @@ class PayoutFactorResult(QueryResult[PayoutFactor], Protocol):
 
 class PlanRepository(ABC):
     @abstractmethod
-    def create_plan_from_draft(self, draft_id: UUID) -> Optional[UUID]:
+    def create_plan(
+        self,
+        creation_timestamp: datetime,
+        planner: UUID,
+        production_costs: ProductionCosts,
+        product_name: str,
+        distribution_unit: str,
+        amount_produced: int,
+        product_description: str,
+        duration_in_days: int,
+        is_public_service: bool,
+    ) -> Plan:
         pass
 
     @abstractmethod


### PR DESCRIPTION
Previously the DB interface for creating a plan accepted simply a PlanDraft.id to create a plan from the PlanDraft that the id referenced. With this change there is a dedicated methods for creating a plan independently from PlanDraft. The goal is to have a more flexible DB interface which is achieved by this change since now Plan records can be created without the need for a preexisting PlanDraft. Secondly the removes implicit logic from the DB. The previous approach relied on the DB implementation filling in the correct fields in the Plan from the PlanDraft that the Plan was created from. Now the business logic has complete control over what fields Plan records are created with. This means that we can test the usage of correct values once in the business logic instead of having to test this in the DB implementation.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418