### PR TITLE
Changed labour certificate payout modalities

### DIFF
--- a/arbeitszeit/plan_summary.py
+++ b/arbeitszeit/plan_summary.py
@@ -36,7 +36,6 @@ class PlanSummary:
 
 @dataclass
 class PlanSummaryService:
-
     plan_repository: PlanRepository
     company_repository: CompanyRepository
     price_calculator: PriceCalculator

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -121,6 +121,18 @@ class PlanResult(QueryResult[Plan], Protocol):
         included in a result set.
         """
 
+    def where_payout_counts_are_less_then_active_days(
+        self, timestamp: datetime
+    ) -> PlanResult:
+        """Filter only those plans where the plan duration that is
+        already passed in days is lower than the amount of times where
+        labor certificates where payed.
+
+        The plan duration considered for the comparison with the
+        payout count can never be more than the total plan duration in
+        days.
+        """
+
     def update(self) -> PlanUpdate:
         """Prepare an update for all selected Plans."""
 

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -191,6 +191,20 @@ class Transaction(db.Model):
     amount_received = db.Column(db.Numeric(), nullable=False)
     purpose = db.Column(db.String(1000), nullable=True)  # Verwendungszweck
 
+    def __repr__(self) -> str:
+        fields = ", ".join(
+            [
+                f"id={self.id!r}",
+                f"date={self.date!r}",
+                f"sending_account={self.sending_account!r}",
+                f"receiving_account={self.receiving_account!r}",
+                f"amount_sent={self.amount_sent!r}",
+                f"amount_received={self.amount_received!r}",
+                f"purpose={self.purpose!r}",
+            ]
+        )
+        return f"Transaction({fields})"
+
 
 class ConsumerPurchase(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
@@ -218,6 +232,15 @@ class LabourCertificatesPayout(db.Model):
         primary_key=True,
     )
     plan_id = db.Column(db.String, db.ForeignKey("plan.id"), nullable=False)
+
+    def __repr__(self) -> str:
+        fields = ", ".join(
+            [
+                f"transaction_id={self.transaction_id!r}",
+                f"plan_id={self.plan_id!r}",
+            ]
+        )
+        return f"LabourCertificatesPayout({fields})"
 
 
 class CompanyWorkInvite(db.Model):


### PR DESCRIPTION
With this change the labour certificate payout is changed such that certificates going to the A account of companies get transferred at the end of every full day the plan is active. Before this change the certificates got transferred at the start of each day a plan was active.

Also a bug was fixed were a company would get too many certificates if the payout use case was triggered exactly on the same time as the plan would expire.

Thirdly we introduced a method to filter plans from the DB such that only plans with pending payouts for labour certificates are selected.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418