### PR TITLE
Remove redundant `account_type` model from database

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 from uuid import UUID
 
 
@@ -15,6 +15,11 @@ class SocialAccounting:
 
     def get_name(self) -> str:
         return "Social Accounting"
+
+    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
+        if account == self.account.id:
+            return AccountTypes.accounting
+        return None
 
 
 @dataclass
@@ -32,6 +37,17 @@ class Member:
     def get_name(self) -> str:
         return self.name
 
+    def get_account_by_type(self, account_type: AccountTypes) -> Optional[UUID]:
+        if account_type == AccountTypes.member:
+            return self.account
+        return None
+
+    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
+        if self.account == account:
+            return AccountTypes.member
+        else:
+            return None
+
 
 @dataclass
 class Company:
@@ -45,16 +61,31 @@ class Company:
     registered_on: datetime
     confirmed_on: Optional[datetime]
 
+    def _accounts_by_type(self) -> Dict[AccountTypes, UUID]:
+        return {
+            AccountTypes.p: self.means_account,
+            AccountTypes.r: self.raw_material_account,
+            AccountTypes.a: self.work_account,
+            AccountTypes.prd: self.product_account,
+        }
+
     def accounts(self) -> List[UUID]:
-        return [
-            self.means_account,
-            self.raw_material_account,
-            self.work_account,
-            self.product_account,
-        ]
+        return list(self._accounts_by_type().values())
 
     def get_name(self) -> str:
         return self.name
+
+    def get_account_by_type(self, account_type: AccountTypes) -> Optional[UUID]:
+        return self._accounts_by_type().get(account_type)
+
+    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
+        account_types = {
+            self.means_account: AccountTypes.p,
+            self.raw_material_account: AccountTypes.r,
+            self.work_account: AccountTypes.a,
+            self.product_account: AccountTypes.prd,
+        }
+        return account_types.get(account)
 
 
 class AccountTypes(Enum):
@@ -69,7 +100,6 @@ class AccountTypes(Enum):
 @dataclass
 class Account:
     id: UUID
-    account_type: AccountTypes
 
 
 @dataclass

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -21,7 +21,6 @@ from typing_extensions import Self
 from arbeitszeit.entities import (
     Account,
     Accountant,
-    AccountTypes,
     Company,
     CompanyPurchase,
     CompanyWorkInvite,
@@ -331,7 +330,7 @@ class TransactionRepository(ABC):
 
 class AccountRepository(ABC):
     @abstractmethod
-    def create_account(self, account_type: AccountTypes) -> Account:
+    def create_account(self) -> Account:
         pass
 
     @abstractmethod
@@ -368,7 +367,7 @@ class MemberRepository(ABC):
 class AccountOwnerRepository(ABC):
     @abstractmethod
     def get_account_owner(
-        self, account: Account
+        self, account: UUID
     ) -> Union[Member, Company, SocialAccounting]:
         pass
 

--- a/arbeitszeit/use_cases/get_company_transactions.py
+++ b/arbeitszeit/use_cases/get_company_transactions.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 from typing import List
 from uuid import UUID
 
-from arbeitszeit.entities import AccountTypes, Company, Transaction
-from arbeitszeit.repositories import AccountRepository, CompanyRepository
+from arbeitszeit.entities import AccountTypes
+from arbeitszeit.repositories import CompanyRepository
 from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 
 
@@ -27,52 +27,20 @@ class GetCompanyTransactionsResponse:
 class GetCompanyTransactions:
     accounting_service: UserAccountingService
     company_repository: CompanyRepository
-    account_repository: AccountRepository
 
     def __call__(self, company_id: UUID) -> GetCompanyTransactionsResponse:
         company = self.company_repository.get_companies().with_id(company_id).first()
         assert company
         transactions = [
-            self._create_info(company, transaction)
-            for transaction in self.accounting_service.get_all_transactions_sorted(
-                company
+            TransactionInfo(
+                transaction_type=row.transaction_type,
+                date=row.transaction.date,
+                transaction_volume=row.volume,
+                account_type=row.account_type,
+                purpose=row.transaction.purpose,
+            )
+            for row in self.accounting_service.get_statement_of_account(
+                company, company.accounts()
             )
         ]
         return GetCompanyTransactionsResponse(transactions=transactions)
-
-    def _create_info(
-        self,
-        company: Company,
-        transaction: Transaction,
-    ) -> TransactionInfo:
-        user_is_sender = self.accounting_service.user_is_sender(transaction, company)
-        transaction_type = self.accounting_service.get_transaction_type(
-            transaction, user_is_sender
-        )
-        account_type = self._get_account_type(transaction, user_is_sender)
-        transaction_volume = self.accounting_service.get_transaction_volume(
-            transaction,
-            user_is_sender,
-        )
-        return TransactionInfo(
-            transaction_type,
-            transaction.date,
-            transaction_volume,
-            account_type,
-            transaction.purpose,
-        )
-
-    def _get_account_type(
-        self, transaction: Transaction, user_is_sender: bool
-    ) -> AccountTypes:
-        account = (
-            self.account_repository.get_accounts()
-            .with_id(
-                transaction.sending_account
-                if user_is_sender
-                else transaction.receiving_account
-            )
-            .first()
-        )
-        assert account
-        return account.account_type

--- a/arbeitszeit/use_cases/get_member_account.py
+++ b/arbeitszeit/use_cases/get_member_account.py
@@ -4,13 +4,7 @@ from decimal import Decimal
 from typing import List, Union
 from uuid import UUID
 
-from arbeitszeit.entities import (
-    AccountTypes,
-    Company,
-    Member,
-    SocialAccounting,
-    Transaction,
-)
+from arbeitszeit.entities import Company, Member, SocialAccounting, Transaction
 from arbeitszeit.repositories import (
     AccountOwnerRepository,
     AccountRepository,
@@ -48,55 +42,39 @@ class GetMemberAccount:
         member = self.member_repository.get_members().with_id(member_id).first()
         assert member
         transaction_info = [
-            self._create_info(member, transaction)
-            for transaction in self.accounting_service.get_account_transactions_sorted(
-                member, AccountTypes.member
+            TransactionInfo(
+                date=row.transaction.date,
+                peer_name=self._get_peer_name(member, row.transaction),
+                transaction_volume=row.volume,
+                purpose=row.transaction.purpose,
+                type=row.transaction_type,
+            )
+            for row in self.accounting_service.get_statement_of_account(
+                member, member.accounts()
             )
         ]
         balance = self.account_repository.get_account_balance(member.account)
         return GetMemberAccountResponse(transaction_info, balance)
 
-    def _create_info(
-        self,
-        user: Member,
-        transaction: Transaction,
-    ) -> TransactionInfo:
-        sending_account = (
-            self.account_repository.get_accounts()
-            .with_id(transaction.sending_account)
-            .first()
-        )
-        assert sending_account
-        receiving_account = (
-            self.account_repository.get_accounts()
-            .with_id(transaction.receiving_account)
-            .first()
-        )
-        assert receiving_account
-        sender = self.acount_owner_repository.get_account_owner(sending_account)
-        receiver = self.acount_owner_repository.get_account_owner(receiving_account)
+    def _get_peer_name(self, user: Member, transaction: Transaction) -> str:
         user_is_sender = self.accounting_service.user_is_sender(transaction, user)
-        peer_name = self._get_peer_name(user_is_sender, sender, receiver)
-        transaction_volume = self.accounting_service.get_transaction_volume(
-            transaction, user_is_sender
-        )
-        return TransactionInfo(
-            date=transaction.date,
-            peer_name=peer_name,
-            transaction_volume=transaction_volume,
-            purpose=transaction.purpose,
-            type=self.accounting_service.get_transaction_type(
-                transaction, user_is_sender
-            ),
-        )
-
-    def _get_peer_name(
-        self,
-        user_is_sender: bool,
-        sender: UserOrSocialAccounting,
-        receiver: UserOrSocialAccounting,
-    ) -> str:
         if user_is_sender:
+            receiving_account = (
+                self.account_repository.get_accounts()
+                .with_id(transaction.receiving_account)
+                .first()
+            )
+            assert receiving_account
+            receiver = self.acount_owner_repository.get_account_owner(
+                receiving_account.id
+            )
             return receiver.get_name()
         else:
+            sending_account = (
+                self.account_repository.get_accounts()
+                .with_id(transaction.sending_account)
+                .first()
+            )
+            assert sending_account
+            sender = self.acount_owner_repository.get_account_owner(sending_account.id)
             return sender.get_name()

--- a/arbeitszeit/use_cases/register_company/__init__.py
+++ b/arbeitszeit/use_cases/register_company/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.entities import AccountTypes
 from arbeitszeit.repositories import AccountRepository, CompanyRepository
 from arbeitszeit.token import CompanyRegistrationMessagePresenter, TokenService
 
@@ -47,10 +46,10 @@ class RegisterCompany:
     def _register_company(self, request: Request) -> UUID:
         if self.company_repository.get_companies().with_email_address(request.email):
             raise self.Response.RejectionReason.company_already_exists
-        means_account = self.account_repository.create_account(AccountTypes.p)
-        resources_account = self.account_repository.create_account(AccountTypes.r)
-        labour_account = self.account_repository.create_account(AccountTypes.a)
-        products_account = self.account_repository.create_account(AccountTypes.prd)
+        means_account = self.account_repository.create_account()
+        resources_account = self.account_repository.create_account()
+        labour_account = self.account_repository.create_account()
+        products_account = self.account_repository.create_account()
         registered_on = self.datetime_service.now()
         company = self.company_repository.create_company(
             request.email,

--- a/arbeitszeit/use_cases/register_member/__init__.py
+++ b/arbeitszeit/use_cases/register_member/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.entities import AccountTypes
 from arbeitszeit.repositories import AccountRepository, MemberRepository
 from arbeitszeit.token import MemberRegistrationMessagePresenter, TokenService
 
@@ -48,7 +47,7 @@ class RegisterMemberUseCase:
         if self.member_repository.get_members().with_email_address(request.email):
             raise self.Response.RejectionReason.member_already_exists
 
-        member_account = self.account_repository.create_account(AccountTypes.member)
+        member_account = self.account_repository.create_account()
         registered_on = self.datetime_service.now()
         member = self.member_repository.create_member(
             email=request.email,

--- a/arbeitszeit/use_cases/show_a_account_details.py
+++ b/arbeitszeit/use_cases/show_a_account_details.py
@@ -7,7 +7,6 @@ from itertools import accumulate
 from typing import List
 from uuid import UUID
 
-from arbeitszeit.entities import AccountTypes, Company, Transaction
 from arbeitszeit.repositories import AccountRepository, CompanyRepository
 from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 
@@ -41,9 +40,14 @@ class ShowAAccountDetailsUseCase:
         company = self.company_repository.get_companies().with_id(company_id).first()
         assert company
         transactions = [
-            self._create_info(company, transaction)
-            for transaction in self.accounting_service.get_account_transactions_sorted(
-                company, AccountTypes.a
+            self.TransactionInfo(
+                transaction_type=row.transaction_type,
+                date=row.transaction.date,
+                transaction_volume=row.volume,
+                purpose=row.transaction.purpose,
+            )
+            for row in self.accounting_service.get_statement_of_account(
+                company, [company.work_account]
             )
         ]
         account_balance = self.account_repository.get_account_balance(
@@ -58,26 +62,6 @@ class ShowAAccountDetailsUseCase:
             transactions=transactions,
             account_balance=account_balance,
             plot=plot,
-        )
-
-    def _create_info(
-        self,
-        company: Company,
-        transaction: Transaction,
-    ) -> TransactionInfo:
-        user_is_sender = self.accounting_service.user_is_sender(transaction, company)
-        transaction_type = self.accounting_service.get_transaction_type(
-            transaction, user_is_sender
-        )
-        transaction_volume = self.accounting_service.get_transaction_volume(
-            transaction,
-            user_is_sender,
-        )
-        return self.TransactionInfo(
-            transaction_type,
-            transaction.date,
-            transaction_volume,
-            transaction.purpose,
         )
 
     def _get_plot_dates(self, transactions: List[TransactionInfo]) -> List[datetime]:

--- a/arbeitszeit/use_cases/show_r_account_details.py
+++ b/arbeitszeit/use_cases/show_r_account_details.py
@@ -7,7 +7,6 @@ from itertools import accumulate
 from typing import List
 from uuid import UUID
 
-from arbeitszeit.entities import AccountTypes, Company, Transaction
 from arbeitszeit.repositories import AccountRepository, CompanyRepository
 from arbeitszeit.transactions import TransactionTypes, UserAccountingService
 
@@ -41,9 +40,14 @@ class ShowRAccountDetailsUseCase:
         company = self.company_repository.get_companies().with_id(company_id).first()
         assert company
         transactions = [
-            self._create_info(company, transaction)
-            for transaction in self.accounting_service.get_account_transactions_sorted(
-                company, AccountTypes.r
+            self.TransactionInfo(
+                transaction_type=row.transaction_type,
+                date=row.transaction.date,
+                transaction_volume=row.volume,
+                purpose=row.transaction.purpose,
+            )
+            for row in self.accounting_service.get_statement_of_account(
+                company, [company.raw_material_account]
             )
         ]
         account_balance = self.account_repository.get_account_balance(
@@ -58,26 +62,6 @@ class ShowRAccountDetailsUseCase:
             transactions=transactions,
             account_balance=account_balance,
             plot=plot,
-        )
-
-    def _create_info(
-        self,
-        company: Company,
-        transaction: Transaction,
-    ) -> TransactionInfo:
-        user_is_sender = self.accounting_service.user_is_sender(transaction, company)
-        transaction_type = self.accounting_service.get_transaction_type(
-            transaction, user_is_sender
-        )
-        transaction_volume = self.accounting_service.get_transaction_volume(
-            transaction,
-            user_is_sender,
-        )
-        return self.TransactionInfo(
-            transaction_type,
-            transaction.date,
-            transaction_volume,
-            transaction.purpose,
         )
 
     def _get_plot_dates(self, transactions: List[TransactionInfo]) -> List[datetime]:

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -911,7 +911,6 @@ class AccountRepository(repositories.AccountRepository):
         assert account_orm
         return entities.Account(
             id=UUID(account_orm.id),
-            account_type=self._transform_account_type(account_orm.account_type),
         )
 
     def _transform_account_type(
@@ -935,8 +934,8 @@ class AccountRepository(repositories.AccountRepository):
         assert account_orm
         return account_orm
 
-    def create_account(self, account_type: entities.AccountTypes) -> entities.Account:
-        account = Account(id=str(uuid4()), account_type=account_type.value)
+    def create_account(self) -> entities.Account:
+        account = Account(id=str(uuid4()))
         self.db.session.add(account)
         return self.object_from_orm(account)
 
@@ -975,9 +974,9 @@ class AccountOwnerRepository(repositories.AccountOwnerRepository):
     social_accounting_repository: AccountingRepository
 
     def get_account_owner(
-        self, account: entities.Account
+        self, account: UUID
     ) -> Union[entities.Member, entities.Company, entities.SocialAccounting]:
-        account_id = str(account.id)
+        account_id = str(account)
         account_owner: Union[
             entities.Member, entities.Company, entities.SocialAccounting, None
         ] = (
@@ -1041,9 +1040,7 @@ class AccountingRepository:
             social_accounting = SocialAccounting(
                 id=str(uuid4()),
             )
-            account = self.account_repository.create_account(
-                entities.AccountTypes.accounting
-            )
+            account = self.account_repository.create_account()
             social_accounting.account = str(account.id)
             self.db.session.add(social_accounting)
         return social_accounting

--- a/arbeitszeit_flask/migrations/versions/35ec3b98a6cc_remove_account_type_field_from_account_.py
+++ b/arbeitszeit_flask/migrations/versions/35ec3b98a6cc_remove_account_type_field_from_account_.py
@@ -1,0 +1,60 @@
+"""Remove account_type field from Account table
+
+Revision ID: 35ec3b98a6cc
+Revises: 925b1eb7c332
+Create Date: 2023-03-28 09:45:31.433012
+
+"""
+from uuid import uuid4
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '35ec3b98a6cc'
+down_revision = '925b1eb7c332'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('account', schema=None) as batch_op:
+        batch_op.drop_column('account_type')
+
+
+def downgrade():
+    with op.batch_alter_table('account', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('account_type', postgresql.ENUM('p', 'r', 'a', 'prd', 'member', 'accounting', name='accounttypes'), autoincrement=False, nullable=True))
+    op.execute('''
+UPDATE account
+SET account_type = 'p'
+FROM company
+WHERE company.p_account = account.id;
+
+UPDATE account
+SET account_type = 'r'
+FROM company
+WHERE company.r_account = account.id;
+
+UPDATE account
+SET account_type = 'a'
+FROM company
+WHERE company.a_account = account.id;
+
+UPDATE account
+SET account_type = 'prd'
+FROM company
+WHERE company.prd_account = account.id;
+
+UPDATE account
+SET account_type = 'member'
+FROM member
+WHERE member.account = account.id;
+
+UPDATE account
+SET account_type = 'accounting'
+FROM social_accounting
+WHERE social_accounting.account = account.id;
+    ''')
+    with op.batch_alter_table('account', schema=None) as batch_op:
+        batch_op.alter_column('account_type', nullable=False)

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -162,7 +162,6 @@ class AccountTypes(Enum):
 
 class Account(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
-    account_type = db.Column(db.Enum(AccountTypes), nullable=False)
 
     transactions_sent = db.relationship(
         "Transaction",

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -92,9 +92,7 @@ class MemberGenerator:
             assert member
             return member
         if account is None:
-            account = self.account_generator.create_account(
-                account_type=AccountTypes.member
-            )
+            account = self.account_generator.create_account()
         if registered_on is None:
             registered_on = self.datetime_service.now()
         member = self.member_repository.create_member(
@@ -162,18 +160,10 @@ class CompanyGenerator:
             email=email,
             name=name,
             password=password,
-            means_account=self.account_generator.create_account(
-                account_type=AccountTypes.p
-            ),
-            resource_account=self.account_generator.create_account(
-                account_type=AccountTypes.r
-            ),
-            products_account=self.account_generator.create_account(
-                account_type=AccountTypes.prd
-            ),
-            labour_account=self.account_generator.create_account(
-                account_type=AccountTypes.a
-            ),
+            means_account=self.account_generator.create_account(),
+            resource_account=self.account_generator.create_account(),
+            products_account=self.account_generator.create_account(),
+            labour_account=self.account_generator.create_account(),
             registered_on=registered_on,
         )
         if workers is not None:
@@ -219,8 +209,8 @@ class CompanyGenerator:
 class AccountGenerator:
     account_repository: AccountRepository
 
-    def create_account(self, account_type: AccountTypes = AccountTypes.a) -> Account:
-        return self.account_repository.create_account(account_type)
+    def create_account(self) -> Account:
+        return self.account_repository.create_account()
 
 
 class EmailGenerator:
@@ -473,13 +463,9 @@ class TransactionGenerator:
         date=None,
     ) -> Transaction:
         if sending_account is None:
-            sending_account = self.account_generator.create_account(
-                account_type=sending_account_type
-            ).id
+            sending_account = self.account_generator.create_account().id
         if receiving_account is None:
-            receiving_account = self.account_generator.create_account(
-                account_type=receiving_account_type
-            ).id
+            receiving_account = self.account_generator.create_account().id
         if amount_sent is None:
             amount_sent = Decimal(10)
         if amount_received is None:

--- a/tests/flask_integration/database_gateway_impl/test_database_gateway_impl.py
+++ b/tests/flask_integration/database_gateway_impl/test_database_gateway_impl.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-from arbeitszeit import entities
 from arbeitszeit_flask.database.repositories import (
     AccountRepository,
     DatabaseGatewayImpl,
@@ -106,12 +105,8 @@ class LabourCertificatesPayoutTests(FlaskTestCase):
         assert self.database_gateway.get_labour_certificates_payouts().for_plan(plan)
 
     def create_transaction(self) -> UUID:
-        sending_account = self.account_repository.create_account(
-            entities.AccountTypes.accounting
-        )
-        receiving_account = self.account_repository.create_account(
-            entities.AccountTypes.a
-        )
+        sending_account = self.account_repository.create_account()
+        receiving_account = self.account_repository.create_account()
         transaction = self.transaction_repository.create_transaction(
             date=datetime(2000, 1, 1),
             sending_account=sending_account.id,

--- a/tests/flask_integration/test_account_owner_repository.py
+++ b/tests/flask_integration/test_account_owner_repository.py
@@ -1,4 +1,4 @@
-from arbeitszeit.entities import AccountTypes, SocialAccounting
+from arbeitszeit.entities import SocialAccounting
 from arbeitszeit_flask.database.repositories import (
     AccountOwnerRepository,
     AccountRepository,
@@ -19,9 +19,9 @@ class RepositoryTester(FlaskTestCase):
         self.account_repository = self.injector.get(AccountRepository)
 
     def test_can_retrieve_owner_of_member_accounts(self) -> None:
-        account = self.account_generator.create_account(AccountTypes.member)
+        account = self.account_generator.create_account()
         member = self.member_generator.create_member_entity(account=account)
-        assert self.repository.get_account_owner(account).id == member.id
+        assert self.repository.get_account_owner(account.id).id == member.id
 
     def test_can_retrieve_owner_of_company_accounts(self) -> None:
         company = self.company_generator.create_company_entity()
@@ -29,10 +29,10 @@ class RepositoryTester(FlaskTestCase):
             self.account_repository.get_accounts().with_id(company.work_account).first()
         )
         assert account
-        assert self.repository.get_account_owner(account) == company
+        assert self.repository.get_account_owner(account.id) == company
 
     def test_can_get_owner_of_public_account(self) -> None:
         assert (
-            self.repository.get_account_owner(self.social_accounting.account)
+            self.repository.get_account_owner(self.social_accounting.account.id)
             == self.social_accounting
         )

--- a/tests/flask_integration/test_company_repository.py
+++ b/tests/flask_integration/test_company_repository.py
@@ -6,7 +6,7 @@ from flask_sqlalchemy import SQLAlchemy
 from pytest import raises
 from sqlalchemy.exc import IntegrityError
 
-from arbeitszeit.entities import AccountTypes, Company
+from arbeitszeit.entities import Company
 from arbeitszeit_flask.database.repositories import AccountRepository, CompanyRepository
 from tests.data_generators import CompanyGenerator, MemberGenerator
 
@@ -66,10 +66,10 @@ class RepositoryTester(FlaskTestCase):
         )
 
     def test_can_create_company_with_correct_name(self) -> None:
-        means_account = self.account_repository.create_account(AccountTypes.p)
-        labour_account = self.account_repository.create_account(AccountTypes.a)
-        resource_account = self.account_repository.create_account(AccountTypes.r)
-        products_account = self.account_repository.create_account(AccountTypes.prd)
+        means_account = self.account_repository.create_account()
+        labour_account = self.account_repository.create_account()
+        resource_account = self.account_repository.create_account()
+        products_account = self.account_repository.create_account()
         expected_name = "Rosa"
         company = self.company_repository.create_company(
             email="rosa@cp.org",
@@ -172,10 +172,10 @@ class CreateCompanyTests(FlaskTestCase):
         self.repository = self.injector.get(CompanyRepository)
         self.account_repository = self.injector.get(AccountRepository)
         self.company_generator = self.injector.get(CompanyGenerator)
-        self.means_account = self.account_repository.create_account(AccountTypes.p)
-        self.labour_account = self.account_repository.create_account(AccountTypes.a)
-        self.resource_account = self.account_repository.create_account(AccountTypes.r)
-        self.products_account = self.account_repository.create_account(AccountTypes.prd)
+        self.means_account = self.account_repository.create_account()
+        self.labour_account = self.account_repository.create_account()
+        self.resource_account = self.account_repository.create_account()
+        self.products_account = self.account_repository.create_account()
         self.timestamp = datetime(2000, 1, 1)
         self.member_generator = self.injector.get(MemberGenerator)
 
@@ -222,10 +222,10 @@ class ConfirmCompanyTests(FlaskTestCase):
         self.assertFalse(self.repository.is_company_confirmed(company=uuid4()))
 
     def _create_company(self, email: str = "test@test.test") -> Company:
-        means_account = self.account_repository.create_account(AccountTypes.p)
-        labour_account = self.account_repository.create_account(AccountTypes.a)
-        resource_account = self.account_repository.create_account(AccountTypes.r)
-        products_account = self.account_repository.create_account(AccountTypes.prd)
+        means_account = self.account_repository.create_account()
+        labour_account = self.account_repository.create_account()
+        resource_account = self.account_repository.create_account()
+        products_account = self.account_repository.create_account()
         return self.repository.create_company(
             email=email,
             name="test name",

--- a/tests/flask_integration/test_member_repository.py
+++ b/tests/flask_integration/test_member_repository.py
@@ -4,7 +4,6 @@ from uuid import UUID, uuid4
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import IntegrityError
 
-from arbeitszeit.entities import AccountTypes
 from arbeitszeit_flask.database.repositories import AccountRepository, MemberRepository
 from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
 
@@ -20,7 +19,7 @@ class RepositoryTests(FlaskTestCase):
         self.account_repository = self.injector.get(AccountRepository)
 
     def test_that_users_can_be_converted_from_and_to_orm_objects(self) -> None:
-        account = self.account_repository.create_account(AccountTypes.member)
+        account = self.account_repository.create_account()
         expected_member = self.member_repository.create_member(
             email="member@cp.org",
             name="karl",
@@ -63,7 +62,7 @@ class RepositoryTests(FlaskTestCase):
     def test_cannot_find_member_by_email_before_it_was_added(self) -> None:
         members = self.member_repository.get_members()
         assert not members.with_email_address("member@cp.org")
-        account = self.account_repository.create_account(AccountTypes.member)
+        account = self.account_repository.create_account()
         self.member_repository.create_member(
             email="member@cp.org",
             name="karl",
@@ -82,7 +81,7 @@ class RepositoryTests(FlaskTestCase):
         assert not self.member_repository.get_members().with_id(company.id)
 
     def test_does_identify_member_id_as_member(self) -> None:
-        account = self.account_repository.create_account(AccountTypes.member)
+        account = self.account_repository.create_account()
         member = self.member_repository.create_member(
             email="member@cp.org",
             name="karl",
@@ -148,9 +147,7 @@ class ValidateCredentialTests(FlaskTestCase):
         super().setUp()
         self.repository = self.injector.get(MemberRepository)
         self.account_repository = self.injector.get(AccountRepository)
-        self.account = self.account_repository.create_account(
-            account_type=AccountTypes.member
-        )
+        self.account = self.account_repository.create_account()
         self.timestamp = datetime(2000, 1, 1)
 
     def test_correct_email_and_password_can_be_validated(self) -> None:
@@ -231,9 +228,7 @@ class ConfirmMemberTests(FlaskTestCase):
         super().setUp()
         self.repository = self.injector.get(MemberRepository)
         self.account_repository = self.injector.get(AccountRepository)
-        self.account = self.account_repository.create_account(
-            account_type=AccountTypes.member
-        )
+        self.account = self.account_repository.create_account()
         self.timestamp = datetime(2000, 1, 1)
         self.member_generator = self.injector.get(MemberGenerator)
 
@@ -268,9 +263,7 @@ class CreateMemberTests(FlaskTestCase):
         self.company_generator = self.injector.get(CompanyGenerator)
         self.accountant_generator = self.injector.get(AccountantGenerator)
         self.account_repository = self.injector.get(AccountRepository)
-        self.account = self.account_repository.create_account(
-            account_type=AccountTypes.member
-        )
+        self.account = self.account_repository.create_account()
         self.timestamp = datetime(2000, 1, 1)
         self.db = self.injector.get(SQLAlchemy)
 
@@ -311,9 +304,7 @@ class MemberUpdateTests(FlaskTestCase):
         super().setUp()
         self.repository = self.injector.get(MemberRepository)
         self.account_repository = self.injector.get(AccountRepository)
-        self.account = self.account_repository.create_account(
-            account_type=AccountTypes.member
-        )
+        self.account = self.account_repository.create_account()
         self.timestamp = datetime(2000, 1, 1)
         self.member_generator = self.injector.get(MemberGenerator)
 


### PR DESCRIPTION
This PR removes the redundant field "account_type" from the database. This field used to contain an identifier for the accounts purpose, e.g. "p" for fixed means account or "member" for consumer account. This information is redundant since the purpose of an account can already be determined without that identifier by looking at how the account is linked to a company, member or social accounting.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (2x)