### PR TITLE
Change arbeitszeit.entities.PlanDraft.planner from Company to UUID

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -114,7 +114,7 @@ class ProductionCosts:
 class PlanDraft:
     id: UUID
     creation_date: datetime
-    planner: Company
+    planner: UUID
     production_costs: ProductionCosts
     product_name: str
     unit_of_distribution: str

--- a/arbeitszeit/use_cases/delete_draft.py
+++ b/arbeitszeit/use_cases/delete_draft.py
@@ -28,7 +28,7 @@ class DeleteDraftUseCase:
         draft = self.draft_repository.get_by_id(request.draft)
         if not draft or not deleter:
             raise self.Failure()
-        if draft.planner.id != deleter.id:
+        if draft.planner != deleter.id:
             raise self.Failure()
         self.draft_repository.delete_draft(request.draft)
         return self.Response(product_name=draft.product_name)

--- a/arbeitszeit/use_cases/edit_draft.py
+++ b/arbeitszeit/use_cases/edit_draft.py
@@ -31,7 +31,7 @@ class EditDraftUseCase:
     def edit_draft(self, request: Request) -> Response:
         if (
             (draft := self.draft_repository.get_by_id(request.draft)) is not None
-        ) and draft.planner.id == request.editor:
+        ) and draft.planner == request.editor:
             self.draft_repository.update_draft(
                 update=self.draft_repository.UpdateDraft(
                     id=request.draft,

--- a/arbeitszeit/use_cases/file_plan_with_accounting.py
+++ b/arbeitszeit/use_cases/file_plan_with_accounting.py
@@ -28,10 +28,10 @@ class FilePlanWithAccounting:
 
     def file_plan_with_accounting(self, request: Request) -> Response:
         draft = self.draft_repository.get_by_id(id=request.draft_id)
-        if draft is not None and draft.planner.id == request.filing_company:
+        if draft is not None and draft.planner == request.filing_company:
             plan = self.database_gateway.create_plan(
                 creation_timestamp=self.datetime_service.now(),
-                planner=draft.planner.id,
+                planner=draft.planner,
                 production_costs=draft.production_costs,
                 product_name=draft.product_name,
                 distribution_unit=draft.unit_of_distribution,

--- a/arbeitszeit/use_cases/get_draft_summary.py
+++ b/arbeitszeit/use_cases/get_draft_summary.py
@@ -34,7 +34,7 @@ class GetDraftSummary:
             return None
         return DraftSummarySuccess(
             draft_id=draft.id,
-            planner_id=draft.planner.id,
+            planner_id=draft.planner,
             product_name=draft.product_name,
             description=draft.description,
             timeframe=draft.timeframe,

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -1123,7 +1123,6 @@ class TransactionRepository(repositories.TransactionRepository):
 @dataclass
 class PlanDraftRepository(repositories.PlanDraftRepository):
     db: SQLAlchemy
-    company_repository: CompanyRepository
 
     def create_plan_draft(
         self,
@@ -1205,12 +1204,10 @@ class PlanDraftRepository(repositories.PlanDraftRepository):
         PlanDraft.query.filter_by(id=str(id)).delete()
 
     def _object_from_orm(self, orm: PlanDraft) -> entities.PlanDraft:
-        planner = self.company_repository.get_companies().with_id(orm.planner).first()
-        assert planner is not None
         return entities.PlanDraft(
             id=orm.id,
             creation_date=orm.plan_creation_date,
-            planner=planner,
+            planner=UUID(orm.planner),
             production_costs=entities.ProductionCosts(
                 labour_cost=orm.costs_a,
                 resource_cost=orm.costs_r,

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -268,7 +268,7 @@ class PlanGenerator:
         )
         file_plan_response = self.file_plan_with_accounting.file_plan_with_accounting(
             request=FilePlanWithAccounting.Request(
-                draft_id=draft.id, filing_company=draft.planner.id
+                draft_id=draft.id, filing_company=draft.planner
             )
         )
         assert file_plan_response.plan_id

--- a/tests/flask_integration/test_plan_draft_repository.py
+++ b/tests/flask_integration/test_plan_draft_repository.py
@@ -71,7 +71,7 @@ class PlanDraftRepositoryTests(PlanDraftRepositoryBaseTests):
     def test_created_draft_has_planner_that_it_was_created_with(self) -> None:
         expected_planner = self.company_generator.create_company()
         draft = self.create_plan_draft(planner=expected_planner)
-        assert draft.planner.id == expected_planner
+        assert draft.planner == expected_planner
 
     def test_that_created_draft_as_production_costs_specified_on_creation(self) -> None:
         expected_production_costs = ProductionCosts(Decimal(5), Decimal(3), Decimal(1))

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -817,14 +817,8 @@ class CompanyRepository(interfaces.CompanyRepository):
 
 @singleton
 class PlanDraftRepository(interfaces.PlanDraftRepository):
-    def __init__(
-        self,
-        datetime_service: DatetimeService,
-        company_repository: interfaces.CompanyRepository,
-    ) -> None:
+    def __init__(self) -> None:
         self.drafts: List[PlanDraft] = []
-        self.datetime_service = datetime_service
-        self.company_repository = company_repository
 
     def create_plan_draft(
         self,
@@ -838,12 +832,10 @@ class PlanDraftRepository(interfaces.PlanDraftRepository):
         is_public_service: bool,
         creation_timestamp: datetime,
     ) -> PlanDraft:
-        company = self.company_repository.get_companies().with_id(planner).first()
-        assert company is not None
         draft = PlanDraft(
             id=uuid4(),
             creation_date=creation_timestamp,
-            planner=company,
+            planner=planner,
             product_name=product_name,
             production_costs=costs,
             unit_of_distribution=production_unit,
@@ -894,7 +886,7 @@ class PlanDraftRepository(interfaces.PlanDraftRepository):
     def all_drafts_of_company(self, id: UUID) -> Iterable[PlanDraft]:
         result = []
         for draft in self.drafts:
-            if draft.planner.id == id:
+            if draft.planner == id:
                 result.append(draft)
         return result
 

--- a/tests/use_cases/test_create_plan_draft.py
+++ b/tests/use_cases/test_create_plan_draft.py
@@ -97,4 +97,4 @@ class UseCaseTests(BaseTestCase):
     def test_that_drafted_plan_has_same_planner_as_specified_on_creation(self) -> None:
         planner = self.company_generator.create_company()
         draft = self.plan_generator.draft_plan(planner=planner)
-        assert draft.planner.id == planner
+        assert draft.planner == planner

--- a/tests/use_cases/test_list_plans_with_pending_review.py
+++ b/tests/use_cases/test_list_plans_with_pending_review.py
@@ -80,7 +80,7 @@ class UseCaseTests(BaseTestCase):
             product_name=product_name, planner=planner
         )
         request = FilePlanWithAccounting.Request(
-            draft_id=draft.id, filing_company=draft.planner.id
+            draft_id=draft.id, filing_company=draft.planner
         )
         response = self.file_plan_with_accounting_use_case.file_plan_with_accounting(
             request


### PR DESCRIPTION
This patch changes the type of the `planner` field of the `PlanDraft` entity from being of type `Company` to `UUID`.  The UUID in this field is the id of the planning company. All code consuming the `PlanDraft` class was updated accordingly.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd