### PR TITLE
Refactor arbeitszeit.repositories.AccountantRepository

### DIFF
--- a/arbeitszeit/accountant_notifications.py
+++ b/arbeitszeit/accountant_notifications.py
@@ -25,7 +25,7 @@ class AccountantNotifier:
     def notify_all_accountants_about_new_plan(
         self, product_name: str, plan_id: UUID
     ) -> None:
-        for accountant in self.accountant_repository.get_all_accountants():
+        for accountant in self.accountant_repository.get_accountants():
             self.presenter.notify_accountant_about_new_plan(
                 Notification(
                     product_name=product_name,

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -272,6 +272,14 @@ class CompanyResult(QueryResult[Company], Protocol):
         ...
 
 
+class AccountantResult(QueryResult[Accountant], Protocol):
+    def with_email_address(self, email: str) -> Self:
+        ...
+
+    def with_id(self, id_: UUID) -> Self:
+        ...
+
+
 class TransactionResult(QueryResult[Transaction], Protocol):
     def where_account_is_sender_or_receiver(self, *account: UUID) -> TransactionResult:
         ...
@@ -529,16 +537,10 @@ class AccountantRepository(Protocol):
     def create_accountant(self, email: str, name: str, password: str) -> UUID:
         ...
 
-    def has_accountant_with_email(self, email: str) -> bool:
-        ...
-
-    def get_by_id(self, id: UUID) -> Optional[Accountant]:
-        ...
-
     def validate_credentials(self, email: str, password: str) -> Optional[UUID]:
         ...
 
-    def get_all_accountants(self) -> QueryResult[Accountant]:
+    def get_accountants(self) -> AccountantResult:
         ...
 
 

--- a/arbeitszeit/use_cases/get_accountant_dashboard.py
+++ b/arbeitszeit/use_cases/get_accountant_dashboard.py
@@ -18,7 +18,7 @@ class GetAccountantDashboardUseCase:
     accountant_repository: AccountantRepository
 
     def get_dashboard(self, user: UUID) -> Response:
-        accountant = self.accountant_repository.get_by_id(user)
+        accountant = self.accountant_repository.get_accountants().with_id(user).first()
         if not accountant:
             raise self.Failure()
         return self.Response(

--- a/arbeitszeit/use_cases/log_in_accountant.py
+++ b/arbeitszeit/use_cases/log_in_accountant.py
@@ -28,9 +28,8 @@ class LogInAccountantUseCase:
     accountant_repository: AccountantRepository
 
     def log_in_accountant(self, request: Request) -> Response:
-        if not self.accountant_repository.has_accountant_with_email(
-            request.email_address
-        ):
+        accountants = self.accountant_repository.get_accountants()
+        if not accountants.with_email_address(request.email_address):
             return self.Response(
                 rejection_reason=self.RejectionReason.email_is_not_accountant
             )

--- a/arbeitszeit/use_cases/register_accountant.py
+++ b/arbeitszeit/use_cases/register_accountant.py
@@ -28,7 +28,8 @@ class RegisterAccountantUseCase:
         invited_email = self.token_service.unwrap_invitation_token(request.token)
         if invited_email != request.email:
             return self._failed_registration(request)
-        if self.accountant_repository.has_accountant_with_email(request.email):
+        accountants = self.accountant_repository.get_accountants()
+        if accountants.with_email_address(request.email):
             return self._failed_registration(request)
         user_id = self.accountant_repository.create_accountant(
             email=request.email,

--- a/arbeitszeit/use_cases/send_accountant_registration_token/__init__.py
+++ b/arbeitszeit/use_cases/send_accountant_registration_token/__init__.py
@@ -28,4 +28,6 @@ class SendAccountantRegistrationTokenUseCase:
         return self.Response()
 
     def _is_user_existing(self, email: str) -> bool:
-        return self.accountant_repository.has_accountant_with_email(email)
+        return bool(
+            self.accountant_repository.get_accountants().with_email_address(email)
+        )


### PR DESCRIPTION
We removed the `has_accountant_with_email` and `get_by_id` methods from AccountantRepository and created a proper AccountantResult interface that offers replacements for the removed methods. Also the `get_all_accountants` method was renamed to `get_accountants` to be more consitent with the naming scheme of the database gateway.