### PR TITLE
Merge TransactionRepository with DatabaseGateway interface

### DIFF
--- a/arbeitszeit/giro_office.py
+++ b/arbeitszeit/giro_office.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from arbeitszeit.control_thresholds import ControlThresholds
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Member, Transaction
-from arbeitszeit.repositories import AccountRepository, TransactionRepository
+from arbeitszeit.repositories import AccountRepository, DatabaseGateway
 
 
 class TransactionRejection(Exception, enum.Enum):
@@ -19,7 +19,7 @@ class GiroOffice:
 
     account_repository: AccountRepository
     control_thresholds: ControlThresholds
-    transaction_repository: TransactionRepository
+    database_gateway: DatabaseGateway
     datetime_service: DatetimeService
 
     def record_transaction_from_member(
@@ -33,7 +33,7 @@ class GiroOffice:
         sending_account = sender.account
         if not self._is_account_balance_sufficient(amount_sent, sending_account):
             raise TransactionRejection.insufficient_account_balance
-        return self.transaction_repository.create_transaction(
+        return self.database_gateway.create_transaction(
             date=self.datetime_service.now(),
             sending_account=sending_account,
             receiving_account=receiving_account,

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -343,24 +343,6 @@ class PayoutFactorResult(QueryResult[PayoutFactor], Protocol):
         ...
 
 
-class TransactionRepository(ABC):
-    @abstractmethod
-    def get_transactions(self) -> TransactionResult:
-        pass
-
-    @abstractmethod
-    def create_transaction(
-        self,
-        date: datetime,
-        sending_account: UUID,
-        receiving_account: UUID,
-        amount_sent: Decimal,
-        amount_received: Decimal,
-        purpose: str,
-    ) -> Transaction:
-        pass
-
-
 class AccountRepository(ABC):
     @abstractmethod
     def create_account(self) -> Account:
@@ -570,10 +552,10 @@ class DatabaseGateway(Protocol):
         duration_in_days: int,
         is_public_service: bool,
     ) -> Plan:
-        pass
+        ...
 
     def get_plans(self) -> PlanResult:
-        pass
+        ...
 
     def create_cooperation(
         self,
@@ -582,7 +564,21 @@ class DatabaseGateway(Protocol):
         definition: str,
         coordinator: UUID,
     ) -> Cooperation:
-        pass
+        ...
 
     def get_cooperations(self) -> CooperationResult:
-        pass
+        ...
+
+    def get_transactions(self) -> TransactionResult:
+        ...
+
+    def create_transaction(
+        self,
+        date: datetime,
+        sending_account: UUID,
+        receiving_account: UUID,
+        amount_sent: Decimal,
+        amount_received: Decimal,
+        purpose: str,
+    ) -> Transaction:
+        ...

--- a/arbeitszeit/transactions.py
+++ b/arbeitszeit/transactions.py
@@ -5,11 +5,7 @@ from typing import Iterable, List, Union
 from uuid import UUID
 
 from .entities import AccountTypes, Company, Member, SocialAccounting, Transaction
-from .repositories import (
-    AccountOwnerRepository,
-    AccountRepository,
-    TransactionRepository,
-)
+from .repositories import AccountOwnerRepository, AccountRepository, DatabaseGateway
 
 
 class TransactionTypes(Enum):
@@ -41,7 +37,7 @@ class AccountStatementRow:
 
 @dataclass
 class UserAccountingService:
-    transaction_repository: TransactionRepository
+    database_gateway: DatabaseGateway
     account_owner_repository: AccountOwnerRepository
     account_repository: AccountRepository
 
@@ -49,7 +45,7 @@ class UserAccountingService:
         self, user: Union[Member, Company]
     ) -> List[Transaction]:
         return list(
-            self.transaction_repository.get_transactions()
+            self.database_gateway.get_transactions()
             .where_account_is_sender_or_receiver(*user.accounts())
             .ordered_by_transaction_date(descending=True)
         )
@@ -62,7 +58,7 @@ class UserAccountingService:
             return []
         else:
             return list(
-                self.transaction_repository.get_transactions()
+                self.database_gateway.get_transactions()
                 .where_account_is_sender_or_receiver(account)
                 .ordered_by_transaction_date(descending=True)
             )
@@ -164,7 +160,7 @@ class UserAccountingService:
     ) -> Iterable[AccountStatementRow]:
         accounts = set(accounts) & set(user.accounts())
         transactions = (
-            self.transaction_repository.get_transactions()
+            self.database_gateway.get_transactions()
             .where_account_is_sender_or_receiver(*accounts)
             .ordered_by_transaction_date(descending=True)
         )

--- a/arbeitszeit/use_cases/approve_plan.py
+++ b/arbeitszeit/use_cases/approve_plan.py
@@ -6,11 +6,7 @@ from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Plan, SocialAccounting
-from arbeitszeit.repositories import (
-    CompanyRepository,
-    DatabaseGateway,
-    TransactionRepository,
-)
+from arbeitszeit.repositories import CompanyRepository, DatabaseGateway
 
 
 @dataclass
@@ -26,7 +22,6 @@ class ApprovePlanUseCase:
     database_gateway: DatabaseGateway
     datetime_service: DatetimeService
     social_accounting: SocialAccounting
-    transaction_repository: TransactionRepository
     company_repository: CompanyRepository
 
     def approve_plan(self, request: Request) -> Response:
@@ -55,7 +50,7 @@ class ApprovePlanUseCase:
     def _create_transaction_from_social_accounting(
         self, plan: Plan, account: UUID, amount: Decimal
     ) -> None:
-        self.transaction_repository.create_transaction(
+        self.database_gateway.create_transaction(
             date=self.datetime_service.now(),
             sending_account=self.social_accounting.account.id,
             receiving_account=account,

--- a/arbeitszeit/use_cases/pay_means_of_production.py
+++ b/arbeitszeit/use_cases/pay_means_of_production.py
@@ -8,11 +8,7 @@ from uuid import UUID
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Company, Plan, PurposesOfPurchases
 from arbeitszeit.price_calculator import PriceCalculator
-from arbeitszeit.repositories import (
-    CompanyRepository,
-    DatabaseGateway,
-    TransactionRepository,
-)
+from arbeitszeit.repositories import CompanyRepository, DatabaseGateway
 
 
 @dataclass
@@ -44,7 +40,6 @@ class PayMeansOfProduction:
     company_repository: CompanyRepository
     price_calculator: PriceCalculator
     datetime_service: DatetimeService
-    transaction_repository: TransactionRepository
     database_gateway: DatabaseGateway
 
     def __call__(
@@ -112,7 +107,7 @@ class PayMeansOfProduction:
             sending_account = buyer.raw_material_account
         planner = self.company_repository.get_companies().with_id(plan.planner).first()
         assert planner
-        transaction = self.transaction_repository.create_transaction(
+        transaction = self.database_gateway.create_transaction(
             date=self.datetime_service.now(),
             sending_account=sending_account,
             receiving_account=planner.product_account,

--- a/arbeitszeit/use_cases/send_work_certificates_to_worker.py
+++ b/arbeitszeit/use_cases/send_work_certificates_to_worker.py
@@ -7,8 +7,8 @@ from uuid import UUID
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.repositories import (
     CompanyRepository,
+    DatabaseGateway,
     MemberRepository,
-    TransactionRepository,
 )
 
 
@@ -35,7 +35,7 @@ class SendWorkCertificatesToWorkerResponse:
 class SendWorkCertificatesToWorker:
     company_repository: CompanyRepository
     member_repository: MemberRepository
-    transaction_repository: TransactionRepository
+    database_gateway: DatabaseGateway
     datetime_service: DatetimeService
 
     def __call__(
@@ -60,7 +60,7 @@ class SendWorkCertificatesToWorker:
             return SendWorkCertificatesToWorkerResponse(
                 rejection_reason=SendWorkCertificatesToWorkerResponse.RejectionReason.worker_not_at_company
             )
-        self.transaction_repository.create_transaction(
+        self.database_gateway.create_transaction(
             date=self.datetime_service.now(),
             sending_account=company.work_account,
             receiving_account=worker.account,

--- a/arbeitszeit/use_cases/update_plans_and_payout.py
+++ b/arbeitszeit/use_cases/update_plans_and_payout.py
@@ -4,17 +4,12 @@ from decimal import Decimal
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Plan, SocialAccounting
 from arbeitszeit.payout_factor import PayoutFactorService
-from arbeitszeit.repositories import (
-    CompanyRepository,
-    DatabaseGateway,
-    TransactionRepository,
-)
+from arbeitszeit.repositories import CompanyRepository, DatabaseGateway
 
 
 @dataclass
 class UpdatePlansAndPayout:
     datetime_service: DatetimeService
-    transaction_repository: TransactionRepository
     social_accounting: SocialAccounting
     payout_factor_service: PayoutFactorService
     company_repository: CompanyRepository
@@ -58,7 +53,7 @@ class UpdatePlansAndPayout:
         amount = payout_factor * plan.production_costs.labour_cost / plan.timeframe
         planner = self.company_repository.get_companies().with_id(plan.planner).first()
         assert planner
-        transaction = self.transaction_repository.create_transaction(
+        transaction = self.database_gateway.create_transaction(
             date=self.datetime_service.now(),
             sending_account=self.social_accounting.account.id,
             receiving_account=planner.work_account,

--- a/arbeitszeit_flask/database/__init__.py
+++ b/arbeitszeit_flask/database/__init__.py
@@ -12,7 +12,6 @@ from .repositories import (
     AccountRepository,
     CompanyRepository,
     MemberRepository,
-    TransactionRepository,
 )
 
 __all__ = [
@@ -21,7 +20,6 @@ __all__ = [
     "AccountingRepository",
     "CompanyRepository",
     "MemberRepository",
-    "TransactionRepository",
     "commit_changes",
 ]
 

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -34,7 +34,6 @@ from arbeitszeit_flask.database.repositories import (
     DatabaseGatewayImpl,
     MemberRepository,
     PlanDraftRepository,
-    TransactionRepository,
     UserAddressBookImpl,
     WorkerInviteRepository,
 )
@@ -166,7 +165,6 @@ class FlaskModule(Module):
         binder[interfaces.LanguageRepository] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
         binder[LanguageService] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
         binder[EmailConfiguration] = AliasProvider(FlaskEmailConfiguration)  # type: ignore
-        binder[interfaces.TransactionRepository] = AliasProvider(TransactionRepository)  # type: ignore
         binder[interfaces.AccountantRepository] = AliasProvider(AccountantRepository)  # type: ignore
         binder.bind(
             interfaces.DatabaseGateway,  # type: ignore

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -29,7 +29,6 @@ from arbeitszeit.repositories import (
     DatabaseGateway,
     MemberRepository,
     PlanDraftRepository,
-    TransactionRepository,
 )
 from arbeitszeit.use_cases import pay_consumer_product, pay_means_of_production
 from arbeitszeit.use_cases.accept_cooperation import (
@@ -447,8 +446,8 @@ class PurchaseGenerator:
 @dataclass
 class TransactionGenerator:
     account_generator: AccountGenerator
-    transaction_repository: TransactionRepository
     datetime_service: FakeDatetimeService
+    database_gateway: DatabaseGateway
 
     def create_transaction(
         self,
@@ -473,7 +472,7 @@ class TransactionGenerator:
             purpose = "test purpose"
         if date is None:
             date = self.datetime_service.now_minus_one_day()
-        return self.transaction_repository.create_transaction(
+        return self.database_gateway.create_transaction(
             date=date,
             sending_account=sending_account,
             receiving_account=receiving_account,

--- a/tests/flask_integration/database_gateway_impl/test_database_gateway_impl.py
+++ b/tests/flask_integration/database_gateway_impl/test_database_gateway_impl.py
@@ -5,7 +5,6 @@ from uuid import UUID, uuid4
 from arbeitszeit_flask.database.repositories import (
     AccountRepository,
     DatabaseGatewayImpl,
-    TransactionRepository,
 )
 from tests.control_thresholds import ControlThresholdsTestImpl
 from tests.data_generators import (
@@ -22,7 +21,6 @@ class LabourCertificatesPayoutTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.database_gateway = self.injector.get(DatabaseGatewayImpl)
-        self.transaction_repository = self.injector.get(TransactionRepository)
         self.account_repository = self.injector.get(AccountRepository)
         self.plan_generator = self.injector.get(PlanGenerator)
 
@@ -107,7 +105,7 @@ class LabourCertificatesPayoutTests(FlaskTestCase):
     def create_transaction(self) -> UUID:
         sending_account = self.account_repository.create_account()
         receiving_account = self.account_repository.create_account()
-        transaction = self.transaction_repository.create_transaction(
+        transaction = self.database_gateway.create_transaction(
             date=datetime(2000, 1, 1),
             sending_account=sending_account.id,
             receiving_account=receiving_account.id,

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -45,9 +45,6 @@ class InMemoryModule(Module):
         )
         binder[InvitationTokenValidator] = AliasProvider(FakeTokenService)  # type: ignore
         binder[InvitationTokenValidator] = AliasProvider(FakeTokenService)  # type: ignore
-        binder[interfaces.TransactionRepository] = AliasProvider(  # type: ignore
-            repositories.TransactionRepository
-        )
         binder[interfaces.WorkerInviteRepository] = AliasProvider(  # type: ignore
             repositories.WorkerInviteRepository
         )

--- a/tests/use_cases/test_approve_plan.py
+++ b/tests/use_cases/test_approve_plan.py
@@ -23,7 +23,7 @@ from arbeitszeit.use_cases.query_plans import (
 )
 
 from .base_test_case import BaseTestCase
-from .repositories import PlanDraftRepository, TransactionRepository
+from .repositories import PlanDraftRepository
 
 
 class UseCaseTests(BaseTestCase):
@@ -34,7 +34,6 @@ class UseCaseTests(BaseTestCase):
         self.query_plans = self.injector.get(QueryPlans)
         self.draft_repository = self.injector.get(PlanDraftRepository)
         self.pay_means_of_production = self.injector.get(PayMeansOfProduction)
-        self.transaction_repository = self.injector.get(TransactionRepository)
         self.get_company_transactions_use_case = self.injector.get(
             GetCompanyTransactions
         )

--- a/tests/use_cases/test_pay_means_of_production.py
+++ b/tests/use_cases/test_pay_means_of_production.py
@@ -13,14 +13,14 @@ from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 from arbeitszeit_web.get_company_transactions import GetCompanyTransactionsResponse
 
 from .base_test_case import BaseTestCase
-from .repositories import CompanyRepository, TransactionRepository
+from .repositories import CompanyRepository, EntityStorage
 
 
 class PayMeansOfProductionTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.pay_means_of_production = self.injector.get(PayMeansOfProduction)
-        self.transaction_repository = self.injector.get(TransactionRepository)
+        self.entity_storage = self.injector.get(EntityStorage)
         self.update_plans_and_payout = self.injector.get(UpdatePlansAndPayout)
         self.company_repository = self.injector.get(CompanyRepository)
         self.query_company_purchases = self.injector.get(
@@ -155,19 +155,17 @@ class PayMeansOfProductionTests(BaseTestCase):
         plan = self.plan_generator.create_plan()
         purpose = PurposesOfPurchases.means_of_prod
         pieces = 5
-        transactions_before_payment = len(
-            self.transaction_repository.get_transactions()
-        )
+        transactions_before_payment = len(self.entity_storage.get_transactions())
         self.pay_means_of_production(
             PayMeansOfProductionRequest(sender.id, plan.id, pieces, purpose)
         )
         price_total = pieces * self.price_checker.get_unit_price(plan.id)
         assert (
-            len(self.transaction_repository.get_transactions())
+            len(self.entity_storage.get_transactions())
             == transactions_before_payment + 1
         )
         latest_transaction = (
-            self.transaction_repository.get_transactions()
+            self.entity_storage.get_transactions()
             .ordered_by_transaction_date(descending=True)
             .first()
         )
@@ -184,19 +182,17 @@ class PayMeansOfProductionTests(BaseTestCase):
         plan = self.plan_generator.create_plan()
         purpose = PurposesOfPurchases.raw_materials
         pieces = 5
-        transactions_before_payment = len(
-            self.transaction_repository.get_transactions()
-        )
+        transactions_before_payment = len(self.entity_storage.get_transactions())
         self.pay_means_of_production(
             PayMeansOfProductionRequest(sender.id, plan.id, pieces, purpose)
         )
         price_total = pieces * self.price_checker.get_unit_price(plan.id)
         assert (
-            len(self.transaction_repository.get_transactions())
+            len(self.entity_storage.get_transactions())
             == transactions_before_payment + 1
         )
         latest_transaction = (
-            self.transaction_repository.get_transactions()
+            self.entity_storage.get_transactions()
             .ordered_by_transaction_date(descending=True)
             .first()
         )

--- a/tests/use_cases/test_send_work_certificates_to_worker.py
+++ b/tests/use_cases/test_send_work_certificates_to_worker.py
@@ -7,7 +7,7 @@ from arbeitszeit.use_cases.send_work_certificates_to_worker import (
 )
 
 from .base_test_case import BaseTestCase
-from .repositories import MemberRepository, TransactionRepository
+from .repositories import EntityStorage, MemberRepository
 
 
 class UseCaseTester(BaseTestCase):
@@ -17,7 +17,7 @@ class UseCaseTester(BaseTestCase):
             SendWorkCertificatesToWorker
         )
         self.member_repository = self.injector.get(MemberRepository)
-        self.transaction_repository = self.injector.get(TransactionRepository)
+        self.entity_storage = self.injector.get(EntityStorage)
 
     def test_that_transfer_is_rejected_if_money_is_sent_to_worker_not_working_in_company(
         self,
@@ -72,7 +72,7 @@ class UseCaseTester(BaseTestCase):
         self.send_work_certificates_to_worker(
             SendWorkCertificatesToWorkerRequest(company.id, worker, amount_to_transfer)
         )
-        assert len(self.transaction_repository.get_transactions()) == 1
+        assert len(self.entity_storage.get_transactions()) == 1
 
     def test_that_after_transfer_correct_transaction_is_added(self) -> None:
         worker = self.member_generator.create_member_entity()
@@ -84,8 +84,8 @@ class UseCaseTester(BaseTestCase):
             )
         )
 
-        assert len(self.transaction_repository.get_transactions()) == 1
-        transaction = self.transaction_repository.get_transactions().first()
+        assert len(self.entity_storage.get_transactions()) == 1
+        transaction = self.entity_storage.get_transactions().first()
         assert transaction
         assert transaction.amount_sent == amount_to_transfer
         assert transaction.amount_received == amount_to_transfer

--- a/tests/use_cases/test_update_plans_and_payout.py
+++ b/tests/use_cases/test_update_plans_and_payout.py
@@ -9,7 +9,7 @@ from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 from tests.use_cases.base_test_case import BaseTestCase
 
 from .dependency_injection import get_dependency_injector
-from .repositories import CompanyRepository, TransactionRepository
+from .repositories import CompanyRepository
 
 
 class UseCaseTests(BaseTestCase):
@@ -17,7 +17,6 @@ class UseCaseTests(BaseTestCase):
         super().setUp()
         self.injector = get_dependency_injector()
         self.payout = self.injector.get(UpdatePlansAndPayout)
-        self.transaction_repository = self.injector.get(TransactionRepository)
         self.show_my_accounts = self.injector.get(ShowMyAccounts)
         self.company_repository = self.injector.get(CompanyRepository)
         self.get_company_transactions = self.injector.get(


### PR DESCRIPTION
This change merges the TransactionRepository interface with the DatabaseGateway interface. This change necessitated also merging the implementations of these interfaces. No functional changes were made. The tests for the sqlalchemy implementation of these interfaces were moved but otherwise left unchanged.