### PR TITLE
Member password override protection

### DIFF
--- a/arbeitszeit_flask/migrations/versions/fb341bf85b13_move_confirmed_on_from_member_company_.py
+++ b/arbeitszeit_flask/migrations/versions/fb341bf85b13_move_confirmed_on_from_member_company_.py
@@ -1,0 +1,67 @@
+"""Move confirmed_on from member/company to user table
+
+Revision ID: fb341bf85b13
+Revises: 35ec3b98a6cc
+Create Date: 2023-04-20 17:02:15.682408
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'fb341bf85b13'
+down_revision = '35ec3b98a6cc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('email_confirmed_on', sa.DateTime(), nullable=True))
+    op.execute('''
+UPDATE "user"
+SET email_confirmed_on = member.confirmed_on
+FROM member
+WHERE "user".id = member.user_id AND
+      member.confirmed_on IS NOT NULL;
+
+UPDATE "user"
+SET email_confirmed_on = company.confirmed_on
+FROM company
+WHERE
+  "user".id = company.user_id AND
+  company.confirmed_on IS NOT NULL;
+UPDATE "user"
+SET email_confirmed_on = NOW()
+FROM accountant
+WHERE
+  "user".id = accountant.user_id;
+    ''')
+    with op.batch_alter_table('company', schema=None) as batch_op:
+        batch_op.drop_column('confirmed_on')
+
+    with op.batch_alter_table('member', schema=None) as batch_op:
+        batch_op.drop_column('confirmed_on')
+
+
+def downgrade():
+    with op.batch_alter_table('member', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('confirmed_on', postgresql.TIMESTAMP(), autoincrement=False, nullable=True))
+
+    with op.batch_alter_table('company', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('confirmed_on', postgresql.TIMESTAMP(), autoincrement=False, nullable=True))
+    op.execute('''
+UPDATE member
+SET confirmed_on = "user".email_confirmed_on
+FROM "user"
+WHERE
+    "user".id = member.user_id;
+UPDATE company
+SET confirmed_on = "user".email_confirmed_on
+FROM "user"
+WHERE
+    "user".id = company.user_id;
+    ''')
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('email_confirmed_on')

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -18,6 +18,7 @@ class User(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     email = db.Column(db.String(100), unique=True, nullable=False)
     password = db.Column(db.String(100), nullable=False)
+    email_confirmed_on = db.Column(db.DateTime, nullable=True)
 
     def __str__(self) -> str:
         return f"User {self.email} ({self.id})"
@@ -41,7 +42,6 @@ class Member(UserMixin, db.Model):
     user_id = db.Column(db.ForeignKey("user.id"), nullable=False)
     name = db.Column(db.String(1000), nullable=False)
     registered_on = db.Column(db.DateTime, nullable=False)
-    confirmed_on = db.Column(db.DateTime, nullable=True)
     account = db.Column(db.ForeignKey("account.id"), nullable=False)
 
     user = db.relationship(
@@ -63,7 +63,6 @@ class Company(UserMixin, db.Model):
     user_id = db.Column(db.ForeignKey("user.id"), nullable=False, unique=True)
     name = db.Column(db.String(1000), nullable=False)
     registered_on = db.Column(db.DateTime, nullable=False)
-    confirmed_on = db.Column(db.DateTime, nullable=True)
     p_account = db.Column(db.ForeignKey("account.id"), nullable=False)
     r_account = db.Column(db.ForeignKey("account.id"), nullable=False)
     a_account = db.Column(db.ForeignKey("account.id"), nullable=False)

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -178,6 +178,9 @@ class GeneralUrlIndex:
     def get_company_query_companies_url(self) -> str:
         return url_for(endpoint="main_company.query_companies")
 
+    def get_unconfirmed_member_url(self) -> str:
+        return url_for(endpoint="auth.unconfirmed_member")
+
 
 class CompanyUrlIndex:
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/arbeitszeit_flask/views/signup_member_view.py
+++ b/arbeitszeit_flask/views/signup_member_view.py
@@ -37,7 +37,7 @@ class SignupMemberView:
         view_model = self.register_member_presenter.present_member_registration(
             response, register_form
         )
-        if view_model.is_success_view:
-            return redirect(url_for("auth.unconfirmed_member"))
+        if view_model.redirect_to:
+            return redirect(view_model.redirect_to)
         else:
             return render_template("auth/signup_member.html", form=register_form)

--- a/arbeitszeit_web/presenters/register_member_presenter.py
+++ b/arbeitszeit_web/presenters/register_member_presenter.py
@@ -1,20 +1,23 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from arbeitszeit.use_cases.register_member import RegisterMemberUseCase
 from arbeitszeit_web.forms import RegisterForm
 from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
 
 
 @dataclass
 class RegisterMemberViewModel:
-    is_success_view: bool
+    redirect_to: Optional[str]
 
 
 @dataclass
 class RegisterMemberPresenter:
     session: Session
     translator: Translator
+    url_index: UrlIndex
 
     def present_member_registration(
         self, response: RegisterMemberUseCase.Response, form: RegisterForm
@@ -27,8 +30,21 @@ class RegisterMemberPresenter:
                 form.email_field.attach_error(
                     self.translator.gettext("This email address is already registered.")
                 )
-            return RegisterMemberViewModel(is_success_view=False)
+            if (
+                response.rejection_reason
+                == RegisterMemberUseCase.Response.RejectionReason.company_with_different_password_exists
+            ):
+                form.email_field.attach_error(
+                    self.translator.gettext(
+                        "A company with the same email address already exists but the provided password does not match."
+                    )
+                )
+            return RegisterMemberViewModel(redirect_to=None)
         else:
             assert response.user_id
             self.session.login_member(response.user_id)
-            return RegisterMemberViewModel(is_success_view=True)
+            return RegisterMemberViewModel(
+                redirect_to=self.url_index.get_unconfirmed_member_url()
+                if response.is_confirmation_required
+                else self.url_index.get_member_dashboard_url(),
+            )

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -130,6 +130,9 @@ class UrlIndex(Protocol):
     def get_company_query_companies_url(self) -> str:
         ...
 
+    def get_unconfirmed_member_url(self) -> str:
+        ...
+
 
 class RenewPlanUrlIndex(Protocol):
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -323,3 +323,9 @@ class GeneralUrlIndexTests(ViewTestCase):
         url = self.url_index.get_member_query_companies_url()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_unconfirmed_member_url_leads_to_function_route(self) -> None:
+        self.login_member()
+        url = self.url_index.get_unconfirmed_member_url()
+        response = self.client.get(url)
+        assert response.status_code < 400

--- a/tests/presenters/test_register_member_presenter.py
+++ b/tests/presenters/test_register_member_presenter.py
@@ -7,6 +7,7 @@ from tests.forms import RegisterFormImpl
 from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
+from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(TestCase):
@@ -14,12 +15,11 @@ class PresenterTests(TestCase):
         self.injector = get_dependency_injector()
         self.presenter = self.injector.get(RegisterMemberPresenter)
         self.translator = self.injector.get(FakeTranslator)
+        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_no_errors_are_rendered_when_registration_was_a_success(self) -> None:
         form = RegisterFormImpl.create()
-        response = RegisterMemberUseCase.Response(
-            rejection_reason=None, user_id=uuid4()
-        )
+        response = self.create_success_response()
         self.presenter.present_member_registration(response, form)
         assert not form.errors()
 
@@ -27,10 +27,67 @@ class PresenterTests(TestCase):
         self,
     ) -> None:
         form = RegisterFormImpl.create()
-        reason = RegisterMemberUseCase.Response.RejectionReason.member_already_exists
-        response = RegisterMemberUseCase.Response(rejection_reason=reason, user_id=None)
+        response = self.create_failure_response(
+            reason=RegisterMemberUseCase.Response.RejectionReason.member_already_exists
+        )
         self.presenter.present_member_registration(response, form)
         error = form.errors()[0]
         self.assertEqual(
             error, self.translator.gettext("This email address is already registered.")
+        )
+
+    def test_that_error_message_states_password_mismatch_when_rejection_reason_was_company_with_different_password(
+        self,
+    ) -> None:
+        form = RegisterFormImpl.create()
+        response = self.create_failure_response(
+            reason=RegisterMemberUseCase.Response.RejectionReason.company_with_different_password_exists
+        )
+        self.presenter.present_member_registration(response, form)
+        error = form.errors()[0]
+        self.assertEqual(
+            error,
+            self.translator.gettext(
+                "A company with the same email address already exists but the provided password does not match."
+            ),
+        )
+
+    def test_that_user_is_not_redirected_on_failure_response(self) -> None:
+        form = RegisterFormImpl.create()
+        response = self.create_failure_response()
+        view_model = self.presenter.present_member_registration(response, form)
+        assert view_model.redirect_to is None
+
+    def test_that_user_is_redirected_to_unconfirmed_paged_if_confirmation_is_necessary(
+        self,
+    ) -> None:
+        form = RegisterFormImpl.create()
+        response = self.create_success_response(is_confirmation_required=True)
+        view_model = self.presenter.present_member_registration(response, form)
+        assert view_model.redirect_to == self.url_index.get_unconfirmed_member_url()
+
+    def test_that_user_is_redirected_to_dashboard_if_confirmation_is_not_necessary(
+        self,
+    ) -> None:
+        form = RegisterFormImpl.create()
+        response = self.create_success_response(is_confirmation_required=False)
+        view_model = self.presenter.present_member_registration(response, form)
+        assert view_model.redirect_to == self.url_index.get_member_dashboard_url()
+
+    def create_success_response(
+        self, is_confirmation_required: bool = True
+    ) -> RegisterMemberUseCase.Response:
+        return RegisterMemberUseCase.Response(
+            rejection_reason=None,
+            user_id=uuid4(),
+            is_confirmation_required=is_confirmation_required,
+        )
+
+    def create_failure_response(
+        self,
+        *,
+        reason: RegisterMemberUseCase.Response.RejectionReason = RegisterMemberUseCase.Response.RejectionReason.member_already_exists,
+    ) -> RegisterMemberUseCase.Response:
+        return RegisterMemberUseCase.Response(
+            rejection_reason=reason, user_id=None, is_confirmation_required=False
         )

--- a/tests/presenters/url_index.py
+++ b/tests/presenters/url_index.py
@@ -69,6 +69,7 @@ class UrlIndexTestImpl:
     get_company_query_plans_url = UrlIndexMethod()
     get_member_query_companies_url = UrlIndexMethod()
     get_company_query_companies_url = UrlIndexMethod()
+    get_unconfirmed_member_url = UrlIndexMethod()
 
     def get_member_confirmation_url(self, *, token: str) -> str:
         return f"get_member_confirmation_url {token}"

--- a/tests/use_cases/test_register_member.py
+++ b/tests/use_cases/test_register_member.py
@@ -36,7 +36,7 @@ class RegisterMemberTests(BaseTestCase):
             response.user_id,
         )
 
-    def test_confirmation_is_required_is_email_is_not_already_known(self) -> None:
+    def test_confirmation_is_required_if_email_is_not_already_known(self) -> None:
         request_args = DEFAULT.copy()
         response = self.use_case.register_member(
             RegisterMemberUseCase.Request(**request_args)

--- a/type_stubs/flask_login.pyi
+++ b/type_stubs/flask_login.pyi
@@ -13,12 +13,12 @@ def login_required(callable: T) -> T: ...
 
 class User:
     email: str
+    email_confirmed_on: Optional[datetime]
 
 class CurrentUser:
     id: str
     user: User
     is_authenticated: bool
-    confirmed_on: Optional[datetime]
     name: str
 
 current_user: CurrentUser


### PR DESCRIPTION
The following description is composed from the descriptions of the individual commits of this change set. There is still a lot of work to do with respect to account management and email confirmation. If this PR gets merged I will try to make further changes going in the same direction as the changes presented here.

```
Before this change it was possible to override an existing companies
password by registering a member with the same email address. This
change does not allow this behavior anymore. Instead the registering
member is required to enter the same password as the company already
has set up.
```

```
This change moves the `confirmed_on` fields from the member and
company tables to the user table. A result of this is that companies
and member with the same email address don't need to verify their
email addresses separately.
```
