### PR TITLE
Implement override protection for company passwords

### DIFF
--- a/arbeitszeit_web/presenters/register_company_presenter.py
+++ b/arbeitszeit_web/presenters/register_company_presenter.py
@@ -20,9 +20,17 @@ class RegisterCompanyPresenter:
         self, response: RegisterCompany.Response, form: RegisterForm
     ) -> ViewModel:
         if response.is_rejected:
-            form.email_field.attach_error(
-                self.translator.gettext("This email address is already registered.")
-            )
+            if (
+                response.rejection_reason
+                == RegisterCompany.Response.RejectionReason.company_already_exists
+            ):
+                form.email_field.attach_error(
+                    self.translator.gettext("This email address is already registered.")
+                )
+            else:
+                form.password_field.attach_error(
+                    self.translator.gettext("Wrong password.")
+                )
             return ViewModel(is_success_view=False)
         assert response.company_id
         self.session.login_company(company=response.company_id)

--- a/tests/presenters/test_register_company_presenter.py
+++ b/tests/presenters/test_register_company_presenter.py
@@ -12,6 +12,8 @@ from tests.translator import FakeTranslator
 
 from .dependency_injection import get_dependency_injector
 
+RejectionReason = RegisterCompany.Response.RejectionReason
+
 
 class PresenterTests(TestCase):
     def setUp(self) -> None:
@@ -24,27 +26,42 @@ class PresenterTests(TestCase):
     def test_that_correct_error_message_is_displayed_when_email_is_already_registered(
         self,
     ) -> None:
-        reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = self.create_response(rejection_reason=reason)
+        response = self.create_response(
+            rejection_reason=RejectionReason.company_already_exists
+        )
         self.presenter.present_company_registration(response, self.form)
         self.assertEqual(
             self.form.email_field.errors[0],
             self.translator.gettext("This email address is already registered."),
         )
 
+    def test_that_correct_error_message_is_displayed_on_password_field_when_password_is_invalid(
+        self,
+    ) -> None:
+        response = self.create_response(
+            rejection_reason=RejectionReason.user_password_is_invalid
+        )
+        self.presenter.present_company_registration(response, self.form)
+        self.assertEqual(
+            self.form.password_field.errors[0],
+            self.translator.gettext("Wrong password."),
+        )
+
     def test_that_view_model_signals_unsuccessful_view_when_registration_was_rejected(
         self,
     ) -> None:
-        reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = self.create_response(rejection_reason=reason)
+        response = self.create_response(
+            rejection_reason=RejectionReason.company_already_exists
+        )
         view_model = self.presenter.present_company_registration(response, self.form)
         self.assertFalse(view_model.is_success_view)
 
     def test_that_user_is_not_logged_in_when_registration_was_rejected(
         self,
     ) -> None:
-        reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = self.create_response(rejection_reason=reason)
+        response = self.create_response(
+            rejection_reason=RejectionReason.company_already_exists
+        )
         self.presenter.present_company_registration(response, self.form)
         self.assertFalse(self.session.is_logged_in())
 


### PR DESCRIPTION
Before this change it was possible to change a companies password by registering a member account with the same email address. This possible attack vector is eliminated with this change. The use will see a minimal error message if they try to register a company with the email address of a preexisting member account and the provided password does not match the members password.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd