### PR TITLE
Encode redirection url after login in cookie instead of url query

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -41,13 +41,9 @@ auth = Blueprint("auth", __name__, template_folder="templates", static_folder="s
 @with_injection()
 def start(
     template_renderer: AnonymousUserTemplateRenderer,
-    session: FlaskSession,
     start_page: StartPageUseCase,
     start_page_presenter: StartPagePresenter,
 ):
-    next_url = request.args.get("next")
-    if next_url is not None:
-        session.set_next_url(next_url)
     response = start_page.show_start_page()
     view_model = start_page_presenter.show_start_page(response)
     return template_renderer.render_template(

--- a/arbeitszeit_flask/company/blueprint.py
+++ b/arbeitszeit_flask/company/blueprint.py
@@ -1,14 +1,11 @@
 from functools import wraps
 from typing import Any, Callable
 
-from flask import Blueprint, redirect, url_for
+from flask import Blueprint, redirect
 
 from arbeitszeit_flask import types
-from arbeitszeit_flask.database.repositories import CompanyRepository
 from arbeitszeit_flask.dependency_injection import CompanyModule, with_injection
-from arbeitszeit_flask.flask_session import FlaskSession
-from arbeitszeit_web.notification import Notifier
-from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.authentication import CompanyAuthenticator
 
 main_company = Blueprint(
     "main_company", __name__, template_folder="templates", static_folder="static"
@@ -40,30 +37,13 @@ class CompanyRoute:
     def _check_is_company_and_confirmed(
         self,
         func,
-        company_repository: CompanyRepository,
-        session: FlaskSession,
-        notifier: Notifier,
-        translator: Translator,
+        authenticator: CompanyAuthenticator,
     ):
         @wraps(func)
         def decorated_function(*args, **kwargs):
-            user_id = session.get_current_user()
-            if not user_id:
-                # not an authenticated user
-                notifier.display_warning(
-                    translator.gettext("Please log in to view this page.")
-                )
-                return redirect(url_for("auth.start", next=self.route_string))
-            elif not company_repository.get_companies().with_id(user_id):
-                # not a company
-                notifier.display_warning(
-                    translator.gettext("You are not logged with the correct account.")
-                )
-                session.logout()
-                return redirect(url_for("auth.start", next=self.route_string))
-            elif not company_repository.is_company_confirmed(user_id):
-                # not a confirmed company
-                return redirect(url_for("auth.unconfirmed_company"))
+            redirect_url = authenticator.redirect_user_to_company_login()
+            if redirect_url:
+                return redirect(redirect_url)
             return func(*args, **kwargs)
 
         return decorated_function

--- a/arbeitszeit_flask/flask_request.py
+++ b/arbeitszeit_flask/flask_request.py
@@ -28,3 +28,6 @@ class FlaskRequest:
 
     def get_header(self, key: str) -> Optional[str]:
         return request.headers.get(key, None)
+
+    def get_request_target(self) -> str:
+        return request.url

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -181,6 +181,12 @@ class GeneralUrlIndex:
     def get_unconfirmed_member_url(self) -> str:
         return url_for(endpoint="auth.unconfirmed_member")
 
+    def get_unconfirmed_company_url(self) -> str:
+        return url_for(endpoint="auth.unconfirmed_company")
+
+    def get_start_page_url(self) -> str:
+        return url_for(endpoint="auth.start")
+
 
 class CompanyUrlIndex:
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/arbeitszeit_web/authentication.py
+++ b/arbeitszeit_web/authentication.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from arbeitszeit.repositories import CompanyRepository, MemberRepository
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.request import Request
+from arbeitszeit_web.session import Session
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class MemberAuthenticator:
+    member_repository: MemberRepository
+    session: Session
+    translator: Translator
+    notifier: Notifier
+    request: Request
+    url_index: UrlIndex
+
+    def redirect_user_to_member_login(self) -> Optional[str]:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            # not an authenticated user
+            self.notifier.display_warning(
+                self.translator.gettext("Please log in to view this page.")
+            )
+            self.session.set_next_url(self.request.get_request_target())
+            return self.url_index.get_start_page_url()
+        elif not self.member_repository.get_members().with_id(user_id):
+            # not a member
+            self.notifier.display_warning(
+                self.translator.gettext("You are not logged with the correct account.")
+            )
+            self.session.logout()
+            self.session.set_next_url(self.request.get_request_target())
+            return self.url_index.get_start_page_url()
+        elif (
+            not self.member_repository.get_members()
+            .with_id(user_id)
+            .that_are_confirmed()
+        ):
+            # not a confirmed member
+            return self.url_index.get_unconfirmed_member_url()
+        return None
+
+
+@dataclass
+class CompanyAuthenticator:
+    company_repository: CompanyRepository
+    session: Session
+    translator: Translator
+    notifier: Notifier
+    request: Request
+    url_index: UrlIndex
+
+    def redirect_user_to_company_login(self) -> Optional[str]:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            # not an authenticated user
+            self.notifier.display_warning(
+                self.translator.gettext("Please log in to view this page.")
+            )
+            self.session.set_next_url(self.request.get_request_target())
+            return self.url_index.get_start_page_url()
+        elif not self.company_repository.get_companies().with_id(user_id):
+            # not a company
+            self.notifier.display_warning(
+                self.translator.gettext("You are not logged with the correct account.")
+            )
+            self.session.logout()
+            self.session.set_next_url(self.request.get_request_target())
+            return self.url_index.get_start_page_url()
+        elif not self.company_repository.is_company_confirmed(user_id):
+            # not a confirmed company
+            return self.url_index.get_unconfirmed_company_url()
+        return None

--- a/arbeitszeit_web/request.py
+++ b/arbeitszeit_web/request.py
@@ -13,6 +13,9 @@ class Request(Protocol):
     def get_header(self, key: str) -> Optional[str]:
         ...
 
+    def get_request_target(self) -> str:
+        ...
+
 
 class QueryString(Protocol):
     def get(self, key: str) -> Optional[str]:

--- a/arbeitszeit_web/session.py
+++ b/arbeitszeit_web/session.py
@@ -23,6 +23,9 @@ class Session(Protocol):
     def login_accountant(self, accountant: UUID, remember: bool = ...) -> None:
         ...
 
+    def logout(self) -> None:
+        ...
+
     def pop_next_url(self) -> Optional[str]:
         ...
 

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -133,6 +133,12 @@ class UrlIndex(Protocol):
     def get_unconfirmed_member_url(self) -> str:
         ...
 
+    def get_unconfirmed_company_url(self) -> str:
+        ...
+
+    def get_start_page_url(self) -> str:
+        ...
+
 
 class RenewPlanUrlIndex(Protocol):
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/tests/flask_integration/test_company_dashboard_view.py
+++ b/tests/flask_integration/test_company_dashboard_view.py
@@ -16,7 +16,7 @@ class AnonymousUserTest(ViewTestCase):
         self,
     ):
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fcompany%2Fdashboard")
+        self.assertEqual(response.location, "/")
 
 
 class MemberTest(ViewTestCase):
@@ -33,7 +33,7 @@ class MemberTest(ViewTestCase):
         self,
     ) -> None:
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fcompany%2Fdashboard")
+        self.assertEqual(response.location, "/")
 
 
 class UnconfirmedCompanyTests(ViewTestCase):

--- a/tests/flask_integration/test_company_purchases_view.py
+++ b/tests/flask_integration/test_company_purchases_view.py
@@ -16,7 +16,7 @@ class AnonymousUserTest(ViewTestCase):
         self,
     ):
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fcompany%2Fpurchases")
+        self.assertEqual(response.location, "/")
 
 
 class MemberTest(ViewTestCase):
@@ -33,7 +33,7 @@ class MemberTest(ViewTestCase):
         self,
     ) -> None:
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fcompany%2Fpurchases")
+        self.assertEqual(response.location, "/")
 
 
 class UnconfirmedCompanyTests(ViewTestCase):

--- a/tests/flask_integration/test_login_company_view.py
+++ b/tests/flask_integration/test_login_company_view.py
@@ -1,0 +1,23 @@
+from .flask import ViewTestCase
+
+
+class StartViewTests(ViewTestCase):
+    def test_that_user_gets_redirected_after_successful_login_to_original_target_url(
+        self,
+    ) -> None:
+        expected_email = "test@test.test"
+        expected_password = "my password"
+        expected_target_url = "/company/query_plans"
+        self.company_generator.create_company(
+            email=expected_email, password=expected_password, confirmed=True
+        )
+        response = self.client.get(expected_target_url)
+        assert response.location == "/"
+        response = self.client.post(
+            "/company/login",
+            data=dict(
+                email=expected_email,
+                password=expected_password,
+            ),
+        )
+        assert response.location.endswith(expected_target_url)

--- a/tests/flask_integration/test_login_member_view.py
+++ b/tests/flask_integration/test_login_member_view.py
@@ -1,0 +1,23 @@
+from .flask import ViewTestCase
+
+
+class StartViewTests(ViewTestCase):
+    def test_that_user_gets_redirected_after_successful_login_to_original_target_url(
+        self,
+    ) -> None:
+        expected_email = "test@test.test"
+        expected_password = "my password"
+        expected_target_url = "/member/query_plans"
+        self.member_generator.create_member(
+            email=expected_email, password=expected_password, confirmed=True
+        )
+        response = self.client.get(expected_target_url)
+        assert response.location == "/"
+        response = self.client.post(
+            "/member/login",
+            data=dict(
+                email=expected_email,
+                password=expected_password,
+            ),
+        )
+        assert response.location.endswith(expected_target_url)

--- a/tests/flask_integration/test_member_dashboard_view.py
+++ b/tests/flask_integration/test_member_dashboard_view.py
@@ -12,11 +12,11 @@ class AnonymousUserTest(ViewTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
 
-    def test_anonymous_user_gets_redirected_to_start_with_next_url_set_correctly(
+    def test_anonymous_user_gets_redirected_to_start(
         self,
     ):
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fmember%2Fdashboard")
+        self.assertEqual(response.location, "/")
 
 
 class CompanyTest(ViewTestCase):
@@ -29,11 +29,11 @@ class CompanyTest(ViewTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
 
-    def test_company_gets_redirected_to_start_page_with_next_url_set_correctly(
+    def test_company_gets_redirected_to_start_page(
         self,
     ) -> None:
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fmember%2Fdashboard")
+        self.assertEqual(response.location, "/")
 
 
 class UnconfirmedMemberTests(ViewTestCase):

--- a/tests/flask_integration/test_member_purchases_view.py
+++ b/tests/flask_integration/test_member_purchases_view.py
@@ -16,7 +16,7 @@ class AnonymousUserTest(ViewTestCase):
         self,
     ):
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fmember%2Fpurchases")
+        self.assertEqual(response.location, "/")
 
 
 class CompanyTest(ViewTestCase):
@@ -33,7 +33,7 @@ class CompanyTest(ViewTestCase):
         self,
     ) -> None:
         response = self.client.get(self.url)
-        self.assertEqual(response.location, "/?next=%2Fmember%2Fpurchases")
+        self.assertEqual(response.location, "/")
 
 
 class UnconfirmedMemberTests(ViewTestCase):

--- a/tests/request.py
+++ b/tests/request.py
@@ -27,3 +27,6 @@ class FakeRequest:
 
     def set_header(self, key: str, value: str) -> None:
         self._environ[key] = value
+
+    def get_request_target(self) -> str:
+        return "/"


### PR DESCRIPTION
When accessing a page that requires authentication we redirect users back to the start page and notify them that they need to log in. Previously we would encode the original target url in a url query. With this change we encode the original target location in the session cookie instead.

Also the code for authenticating client requests was moved from the flask specific folder `arbeitszeit_flask` to the folder for framework agnostic web code `arbeitszeit_web`. This allows us to test the redirection logic more easily in later changes to our code.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (2x)