### PR TITLE
Separate password validation from password hash storage

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -30,6 +30,7 @@ class Member:
     account: UUID
     registered_on: datetime
     confirmed_on: Optional[datetime]
+    password_hash: str
 
     def accounts(self) -> List[UUID]:
         return [self.account]
@@ -60,6 +61,7 @@ class Company:
     product_account: UUID
     registered_on: datetime
     confirmed_on: Optional[datetime]
+    password_hash: str
 
     def _accounts_by_type(self) -> Dict[AccountTypes, UUID]:
         return {
@@ -270,6 +272,7 @@ class Accountant:
     id: UUID
     email_address: str
     name: str
+    password_hash: str
 
 
 @dataclass

--- a/arbeitszeit/password_hasher.py
+++ b/arbeitszeit/password_hasher.py
@@ -1,0 +1,9 @@
+from typing import Protocol
+
+
+class PasswordHasher(Protocol):
+    def calculate_password_hash(self, password: str) -> str:
+        ...
+
+    def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
+        ...

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -372,14 +372,10 @@ class MemberRepository(ABC):
         *,
         email: str,
         name: str,
-        password: str,
+        password_hash: str,
         account: Account,
         registered_on: datetime,
     ) -> Member:
-        pass
-
-    @abstractmethod
-    def validate_credentials(self, email: str, password: str) -> Optional[UUID]:
         pass
 
     @abstractmethod
@@ -393,7 +389,7 @@ class CompanyRepository(ABC):
         self,
         email: str,
         name: str,
-        password: str,
+        password_hash: str,
         means_account: Account,
         labour_account: Account,
         resource_account: Account,
@@ -404,10 +400,6 @@ class CompanyRepository(ABC):
 
     @abstractmethod
     def get_companies(self) -> CompanyResult:
-        pass
-
-    @abstractmethod
-    def validate_credentials(self, email_address: str, password: str) -> Optional[UUID]:
         pass
 
     @abstractmethod
@@ -466,10 +458,7 @@ class PlanDraftRepository(ABC):
 
 
 class AccountantRepository(Protocol):
-    def create_accountant(self, email: str, name: str, password: str) -> UUID:
-        ...
-
-    def validate_credentials(self, email: str, password: str) -> Optional[UUID]:
+    def create_accountant(self, email: str, name: str, password_hash: str) -> UUID:
         ...
 
     def get_accountants(self) -> AccountantResult:

--- a/arbeitszeit/use_cases/register_accountant.py
+++ b/arbeitszeit/use_cases/register_accountant.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 from uuid import UUID
 
+from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.repositories import AccountantRepository
 from arbeitszeit.token import InvitationTokenValidator
 
@@ -23,6 +24,7 @@ class RegisterAccountantUseCase:
 
     token_service: InvitationTokenValidator
     accountant_repository: AccountantRepository
+    password_hasher: PasswordHasher
 
     def register_accountant(self, request: Request) -> Response:
         invited_email = self.token_service.unwrap_invitation_token(request.token)
@@ -34,7 +36,9 @@ class RegisterAccountantUseCase:
         user_id = self.accountant_repository.create_accountant(
             email=request.email,
             name=request.name,
-            password=request.password,
+            password_hash=self.password_hasher.calculate_password_hash(
+                request.password
+            ),
         )
         return self.Response(
             is_accepted=True, user_id=user_id, email_address=request.email

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -15,6 +15,7 @@ from arbeitszeit.injector import (
     Injector,
     Module,
 )
+from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.token import (
     CompanyRegistrationMessagePresenter,
     InvitationTokenValidator,
@@ -48,6 +49,7 @@ from arbeitszeit_flask.mail_service import (
     get_mail_service,
 )
 from arbeitszeit_flask.notifications import FlaskFlashNotifier
+from arbeitszeit_flask.password_hasher import PasswordHasherImpl
 from arbeitszeit_flask.template import (
     AccountantTemplateIndex,
     CompanyTemplateIndex,
@@ -186,6 +188,10 @@ class FlaskModule(Module):
         binder.bind(
             AccountantInvitationUrlIndex,  # type: ignore
             to=AliasProvider(GeneralUrlIndex),
+        )
+        binder.bind(
+            PasswordHasher,  # type: ignore
+            to=AliasProvider(PasswordHasherImpl),
         )
 
     @staticmethod

--- a/arbeitszeit_flask/password_hasher.py
+++ b/arbeitszeit_flask/password_hasher.py
@@ -1,0 +1,9 @@
+from werkzeug.security import check_password_hash, generate_password_hash
+
+
+class PasswordHasherImpl:
+    def calculate_password_hash(self, password: str) -> str:
+        return generate_password_hash(password, method="sha256")
+
+    def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
+        return check_password_hash(password_hash, password)

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -23,6 +23,7 @@ from arbeitszeit.entities import (
     PurposesOfPurchases,
     Transaction,
 )
+from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.repositories import (
     AccountRepository,
     CompanyRepository,
@@ -63,6 +64,7 @@ class MemberGenerator:
     member_repository: MemberRepository
     datetime_service: FakeDatetimeService
     register_member_use_case: RegisterMemberUseCase
+    password_hasher: PasswordHasher
 
     def create_member_entity(
         self,
@@ -96,7 +98,7 @@ class MemberGenerator:
         member = self.member_repository.create_member(
             email=email,
             name=name,
-            password=password,
+            password_hash=self.password_hasher.calculate_password_hash(password),
             account=account,
             registered_on=registered_on,
         )
@@ -140,6 +142,7 @@ class CompanyGenerator:
     datetime_service: FakeDatetimeService
     company_manager: CompanyManager
     register_company_use_case: RegisterCompany
+    password_hasher: PasswordHasher
 
     def create_company_entity(
         self,
@@ -157,7 +160,7 @@ class CompanyGenerator:
         company = self.company_repository.create_company(
             email=email,
             name=name,
-            password=password,
+            password_hash=self.password_hasher.calculate_password_hash(password),
             means_account=self.account_generator.create_account(),
             resource_account=self.account_generator.create_account(),
             products_account=self.account_generator.create_account(),

--- a/tests/flask_integration/test_accountant_repository.py
+++ b/tests/flask_integration/test_accountant_repository.py
@@ -20,7 +20,7 @@ class CreateAccountantTests(FlaskTestCase):
         self.uuid = self.repository.create_accountant(
             email=self.expected_email,
             name=self.expected_name,
-            password=self.expected_password,
+            password_hash=self.expected_password,
         )
 
     def test_repository_stores_email_address_correctly(self) -> None:
@@ -33,19 +33,12 @@ class CreateAccountantTests(FlaskTestCase):
         assert accountant
         self.assertEqual(accountant.name, self.expected_name)
 
-    def test_can_validate_password_specified_at_creation(self) -> None:
-        self.assertIsNotNone(
-            self.repository.validate_credentials(
-                self.expected_email, self.expected_password
-            )
-        )
-
     def test_cannot_create_accountant_with_same_email_twice(self) -> None:
         with self.assertRaises(IntegrityError):
             self.uuid = self.repository.create_accountant(
                 email=self.expected_email,
                 name=self.expected_name,
-                password=self.expected_password,
+                password_hash=self.expected_password,
             )
             self.db.session.flush()
 
@@ -65,7 +58,7 @@ class CreateAccountantWithExistingMemberEmailTests(FlaskTestCase):
         self.repository.create_accountant(
             email=self.expected_email,
             name=self.expected_name,
-            password=self.expected_password,
+            password_hash=self.expected_password,
         )
         self.db.session.flush()
 
@@ -79,17 +72,7 @@ class ValidationTests(FlaskTestCase):
         self.uuid = self.repository.create_accountant(
             email=self.expected_email,
             name="test name",
-            password=self.expected_password,
-        )
-
-    def test_cannot_validate_user_that_was_not_created(self) -> None:
-        self.assertIsNone(
-            self.repository.validate_credentials("non.existing@email.org", "pw123")
-        )
-
-    def test_cannot_validate_user_with_different_password(self) -> None:
-        self.assertIsNone(
-            self.repository.validate_credentials(self.expected_email, "pw123")
+            password_hash=self.expected_password,
         )
 
 
@@ -103,14 +86,14 @@ class GetAccountantsTests(FlaskTestCase):
 
     def test_that_one_item_is_shown_after_accountant_was_created(self) -> None:
         self.repository.create_accountant(
-            email="test@test.test", name="test accountant", password="1234"
+            email="test@test.test", name="test accountant", password_hash="1234"
         )
         assert len(self.repository.get_accountants()) == 1
 
     def test_that_correct_email_address_is_retrieved(self) -> None:
         expected_email_address = "test@email.com"
         self.repository.create_accountant(
-            email=expected_email_address, name="test accountant", password="1234"
+            email=expected_email_address, name="test accountant", password_hash="1234"
         )
         item = list(self.repository.get_accountants())[0]
         assert item.email_address == expected_email_address
@@ -118,7 +101,7 @@ class GetAccountantsTests(FlaskTestCase):
     def test_that_correct_name_is_retrieved(self) -> None:
         expected_name = "test name 123"
         self.repository.create_accountant(
-            email="test@test.test", name=expected_name, password="1234"
+            email="test@test.test", name=expected_name, password_hash="1234"
         )
         item = list(self.repository.get_accountants())[0]
         assert item.name == expected_name
@@ -136,7 +119,7 @@ class WithIdTests(FlaskTestCase):
         self,
     ) -> None:
         self.repository.create_accountant(
-            email="test@test.test", name="test name", password="1234"
+            email="test@test.test", name="test name", password_hash="1234"
         )
         assert not self.repository.get_accountants().with_id(uuid4())
 
@@ -144,7 +127,7 @@ class WithIdTests(FlaskTestCase):
         self,
     ) -> None:
         accountant_id = self.repository.create_accountant(
-            email="test@test.test", name="test name", password="1234"
+            email="test@test.test", name="test name", password_hash="1234"
         )
         assert len(self.repository.get_accountants().with_id(accountant_id)) == 1
 
@@ -163,7 +146,7 @@ class WithEmailAddressTests(FlaskTestCase):
         self,
     ) -> None:
         self.repository.create_accountant(
-            email="test@test.test", name="test name", password="1234"
+            email="test@test.test", name="test name", password_hash="1234"
         )
         assert not self.repository.get_accountants().with_email_address(
             "fake@mail.test"
@@ -173,7 +156,7 @@ class WithEmailAddressTests(FlaskTestCase):
         self,
     ) -> None:
         self.repository.create_accountant(
-            email="test@test.test", name="test name", password="1234"
+            email="test@test.test", name="test name", password_hash="1234"
         )
         assert (
             len(self.repository.get_accountants().with_email_address("test@test.test"))

--- a/tests/flask_integration/test_company_repository.py
+++ b/tests/flask_integration/test_company_repository.py
@@ -63,7 +63,7 @@ class RepositoryTester(FlaskTestCase):
         company = self.company_repository.create_company(
             email="rosa@cp.org",
             name=expected_name,
-            password="testpassword",
+            password_hash="testpassword",
             means_account=means_account,
             labour_account=labour_account,
             resource_account=resource_account,
@@ -115,45 +115,6 @@ class RepositoryTester(FlaskTestCase):
         assert company_in_companies(expected_company2, all_companies)
 
 
-class ValidateCredentialsTest(FlaskTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.repository = self.injector.get(CompanyRepository)
-        self.company_generator = self.injector.get(CompanyGenerator)
-
-    def test_cannot_validate_random_user_with_empty_database(self) -> None:
-        company_id = self.repository.validate_credentials(
-            email_address="test@test.test",
-            password="test password",
-        )
-        self.assertIsNone(company_id)
-
-    def test_can_validate_company_with_correct_credentials(self) -> None:
-        expected_email = "test@test.test"
-        expected_password = "test password"
-        expected_company = self.company_generator.create_company_entity(
-            email=expected_email,
-            password=expected_password,
-        )
-        company_id = self.repository.validate_credentials(
-            expected_email,
-            expected_password,
-        )
-        self.assertEqual(company_id, expected_company.id)
-
-    def test_cannot_validate_user_with_wrong_password(self) -> None:
-        expected_email = "test@test.test"
-        self.company_generator.create_company_entity(
-            email=expected_email,
-            password="test password",
-        )
-        company_id = self.repository.validate_credentials(
-            expected_email,
-            "wrong_password",
-        )
-        self.assertIsNone(company_id)
-
-
 class CreateCompanyTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -176,7 +137,7 @@ class CreateCompanyTests(FlaskTestCase):
         self.repository.create_company(
             email=email,
             name="test name",
-            password="testpassword",
+            password_hash="testpassword",
             means_account=self.means_account,
             labour_account=self.labour_account,
             resource_account=self.resource_account,
@@ -218,7 +179,7 @@ class ConfirmCompanyTests(FlaskTestCase):
         return self.repository.create_company(
             email=email,
             name="test name",
-            password="some password",
+            password_hash="some password",
             means_account=means_account,
             labour_account=labour_account,
             resource_account=resource_account,

--- a/tests/flask_integration/test_member_repository.py
+++ b/tests/flask_integration/test_member_repository.py
@@ -18,22 +18,6 @@ class RepositoryTests(FlaskTestCase):
         self.member_repository = self.injector.get(MemberRepository)
         self.account_repository = self.injector.get(AccountRepository)
 
-    def test_that_users_can_be_converted_from_and_to_orm_objects(self) -> None:
-        account = self.account_repository.create_account()
-        expected_member = self.member_repository.create_member(
-            email="member@cp.org",
-            name="karl",
-            password="password",
-            account=account,
-            registered_on=datetime.now(),
-        )
-        converted_member = self.member_repository.member_from_orm(
-            self.member_repository.object_to_orm(
-                expected_member,
-            )
-        )
-        assert converted_member == expected_member
-
     def test_that_member_can_be_retrieved_by_its_id(self) -> None:
         expected_member = self.member_generator.create_member()
         retrieved_member = (
@@ -66,7 +50,7 @@ class RepositoryTests(FlaskTestCase):
         self.member_repository.create_member(
             email="member@cp.org",
             name="karl",
-            password="password",
+            password_hash="password",
             account=account,
             registered_on=datetime.now(),
         )
@@ -85,7 +69,7 @@ class RepositoryTests(FlaskTestCase):
         member = self.member_repository.create_member(
             email="member@cp.org",
             name="karl",
-            password="password",
+            password_hash="password",
             account=account,
             registered_on=datetime.now(),
         )
@@ -142,87 +126,6 @@ class GetAllMembersTests(FlaskTestCase):
         assert len(self.repository.get_members().working_at_company(company.id)) == 1
 
 
-class ValidateCredentialTests(FlaskTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.repository = self.injector.get(MemberRepository)
-        self.account_repository = self.injector.get(AccountRepository)
-        self.account = self.account_repository.create_account()
-        self.timestamp = datetime(2000, 1, 1)
-
-    def test_correct_email_and_password_can_be_validated(self) -> None:
-        expected_email = "test@test.test"
-        password = "test password"
-        self.repository.create_member(
-            email=expected_email,
-            name="test",
-            password=password,
-            account=self.account,
-            registered_on=self.timestamp,
-        )
-        self.assertTrue(
-            self.repository.validate_credentials(
-                email=expected_email, password=password
-            )
-        )
-
-    def test_correct_member_id_is_returned(self) -> None:
-        expected_email = "test@test.test"
-        password = "test password"
-        member = self.repository.create_member(
-            email=expected_email,
-            name="test",
-            password=password,
-            account=self.account,
-            registered_on=self.timestamp,
-        )
-        self.assertEqual(
-            self.repository.validate_credentials(
-                email=expected_email, password=password
-            ),
-            member.id,
-        )
-
-    def test_cannot_validate_with_wrong_password(self) -> None:
-        expected_email = "test@test.test"
-        self.repository.create_member(
-            email=expected_email,
-            name="test",
-            password="test password",
-            account=self.account,
-            registered_on=self.timestamp,
-        )
-        self.assertFalse(
-            self.repository.validate_credentials(
-                email=expected_email,
-                password="other password",
-            )
-        )
-
-    def test_cannot_validate_with_wrong_email(self) -> None:
-        password = "test password"
-        self.repository.create_member(
-            email="test@test.test",
-            name="test",
-            password=password,
-            account=self.account,
-            registered_on=self.timestamp,
-        )
-        self.assertFalse(
-            self.repository.validate_credentials(
-                email="other@email.test",
-                password=password,
-            )
-        )
-
-    def test_that_validation_fails_with_no_members_in_db(self) -> None:
-        self.assertFalse(
-            self.repository.validate_credentials(
-                email="test@test.test", password="test"
-            )
-        )
-
-
 class ConfirmMemberTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -249,7 +152,7 @@ class ConfirmMemberTests(FlaskTestCase):
         member = self.repository.create_member(
             email="test email",
             name="test name",
-            password="test password",
+            password_hash="test password",
             account=self.account,
             registered_on=self.timestamp,
         )
@@ -273,7 +176,7 @@ class CreateMemberTests(FlaskTestCase):
         self.repository.create_member(
             email=email,
             name="test name",
-            password="test password",
+            password_hash="test password",
             account=self.account,
             registered_on=self.timestamp,
         )
@@ -284,7 +187,7 @@ class CreateMemberTests(FlaskTestCase):
         self.repository.create_member(
             email=email,
             name="test name",
-            password="test password",
+            password_hash="test password",
             account=self.account,
             registered_on=self.timestamp,
         )
@@ -292,7 +195,7 @@ class CreateMemberTests(FlaskTestCase):
             self.repository.create_member(
                 email=email,
                 name="test name",
-                password="test password",
+                password_hash="test password",
                 account=self.account,
                 registered_on=self.timestamp,
             )
@@ -345,7 +248,7 @@ class MemberUpdateTests(FlaskTestCase):
         member = self.repository.create_member(
             email="test email",
             name="test name",
-            password="test password",
+            password_hash="test password",
             account=self.account,
             registered_on=self.timestamp,
         )

--- a/tests/flask_integration/test_password_hasher.py
+++ b/tests/flask_integration/test_password_hasher.py
@@ -1,0 +1,22 @@
+from arbeitszeit_flask.password_hasher import PasswordHasherImpl
+
+from .flask import FlaskTestCase
+
+
+class PasswordHasherTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.password_hasher = self.injector.get(PasswordHasherImpl)
+
+    def test_that_previously_hashed_password_matches_its_hash(self) -> None:
+        password = "test 123 password"
+        hashed = self.password_hasher.calculate_password_hash(password)
+        assert self.password_hasher.is_password_matching_hash(
+            password=password, password_hash=hashed
+        )
+
+    def test_random_string_does_not_match_hashed_password(self) -> None:
+        hashed = self.password_hasher.calculate_password_hash("the password 123")
+        assert not self.password_hasher.is_password_matching_hash(
+            password="random string", password_hash=hashed
+        )

--- a/tests/password_hasher.py
+++ b/tests/password_hasher.py
@@ -1,0 +1,6 @@
+class PasswordHasherImpl:
+    def calculate_password_hash(self, password: str) -> str:
+        return "123-" + password
+
+    def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
+        return password == password_hash[4:]

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -10,12 +10,14 @@ from arbeitszeit.injector import (
     Injector,
     Module,
 )
+from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.token import InvitationTokenValidator, TokenService
 from arbeitszeit.use_cases.send_accountant_registration_token.accountant_invitation_presenter import (
     AccountantInvitationPresenter,
 )
 from tests.accountant_invitation_presenter import AccountantInvitationPresenterTestImpl
 from tests.dependency_injection import TestingModule
+from tests.password_hasher import PasswordHasherImpl
 from tests.token import FakeTokenService
 
 from . import repositories
@@ -67,6 +69,10 @@ class InMemoryModule(Module):
         binder.bind(
             interfaces.DatabaseGateway,  # type: ignore
             to=AliasProvider(repositories.EntityStorage),
+        )
+        binder.bind(
+            PasswordHasher,  # type: ignore
+            to=AliasProvider(PasswordHasherImpl),
         )
 
 


### PR DESCRIPTION
With this change we introduce a new interface, the PasswordHasher. The PasswordHasher can caluculate password hashes and compare passwords to those hashes.  Also the validate_credentials methods were removed from MemberRepository, AccountantRepository and CompanyRepository. Instead the respectiv entities Member, Accountant and Company store password hashes that can be used with the newly declared PasswordHasher interface.

This change will allow us develop the DB scheme independently of password validation.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd