### PR TITLE
Implement rudimentary benchmark framework

### DIFF
--- a/.autoformattingrc
+++ b/.autoformattingrc
@@ -2,6 +2,7 @@ arbeitszeit/
 arbeitszeit_web/
 tests/
 arbeitszeit_flask/
+arbeitszeit_benchmark/
 format_code.py
 type_stubs
 run-checks

--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,18 @@ Regenerate the API docs via:
 
      ./regenerate-api-docs
 
+Benchmarking
+------------
+
+Included in the source code for this project there is a rudimentary
+framework for testing the run time of our code called
+``arbeitszeit_benchmark``.  You can run all the benchmarks via
+``python -m arbeitszeit_benchmark``.  This benchmarking tool can be
+used to compare the change in runtime characteristics between
+changes. A contributor to the ``arbeitszeitapp`` might want to compare
+the results of those benchmarks from the master branch to the results
+from their changes. The output of this tool is in JSON.
+
 Using a binary cache
 --------------------
 

--- a/arbeitszeit_benchmark/__main__.py
+++ b/arbeitszeit_benchmark/__main__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import timeit
+from typing import Dict
+
+from .get_company_transactions import GetCompanyTransactionsBenchmark
+from .runner import BenchmarkCatalog, BenchmarkResult, render_results_as_json
+
+
+def main() -> None:
+    repeats = 5
+    results: Dict[str, BenchmarkResult] = dict()
+    catalog = BenchmarkCatalog()
+    catalog.register_benchmark(
+        name="get_company_transactions", benchmark_class=GetCompanyTransactionsBenchmark
+    )
+    for name, benchmark in catalog.get_all_benchmarks():
+        try:
+            average_benchmark_time = (
+                timeit.timeit(benchmark.run, number=repeats) / repeats
+            )
+        finally:
+            benchmark.tear_down()
+        results[name] = BenchmarkResult(
+            name=name, average_execution_time_in_secs=average_benchmark_time
+        )
+    print(render_results_as_json(results))
+
+
+main()

--- a/arbeitszeit_benchmark/get_company_transactions.py
+++ b/arbeitszeit_benchmark/get_company_transactions.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+from arbeitszeit.use_cases.get_company_transactions import GetCompanyTransactions
+from tests.data_generators import CompanyGenerator, PlanGenerator, PurchaseGenerator
+from tests.flask_integration.dependency_injection import get_dependency_injector
+
+
+class GetCompanyTransactionsBenchmark:
+    """This benchmark measures the execution time of the
+    GetCompanyTransactions use case where there are 1000 transactions
+    in the database.
+    """
+
+    def __init__(self) -> None:
+        self.injector = get_dependency_injector()
+        self.db = self.injector.get(SQLAlchemy)
+        self.app = self.injector.get(Flask)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        self.db.drop_all()
+        self.db.create_all()
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.purchase_generator = self.injector.get(PurchaseGenerator)
+        self.get_company_transactions = self.injector.get(GetCompanyTransactions)
+        self.buyer = self.company_generator.create_company()
+        for _ in range(100):
+            plan = self.plan_generator.create_plan()
+            for _ in range(10):
+                self.purchase_generator.create_resource_purchase_by_company(
+                    buyer=self.buyer, plan=plan.id
+                )
+
+    def tear_down(self) -> None:
+        self.app_context.pop()
+
+    def run(self) -> None:
+        self.get_company_transactions(self.buyer)

--- a/arbeitszeit_benchmark/runner.py
+++ b/arbeitszeit_benchmark/runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Dict, Iterable, Protocol, Tuple, Type
+
+
+class BenchmarkCatalog:
+    def __init__(self) -> None:
+        self.registered_benchmark_classes: Dict[str, Type[Benchmark]] = dict()
+
+    def register_benchmark(self, name: str, benchmark_class: Type[Benchmark]) -> None:
+        self.registered_benchmark_classes[name] = benchmark_class
+
+    def get_all_benchmarks(self) -> Iterable[Tuple[str, Benchmark]]:
+        for name, benchmark_class in self.registered_benchmark_classes.items():
+            yield name, benchmark_class()
+
+
+class Benchmark(Protocol):
+    def __init__(self) -> None:
+        ...
+
+    def tear_down(self) -> None:
+        ...
+
+    def run(self) -> None:
+        ...
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    average_execution_time_in_secs: float
+
+
+def render_results_as_json(results: Dict[str, BenchmarkResult]) -> str:
+    def result_to_json(result: BenchmarkResult):
+        return {
+            "name": result.name,
+            "average_execution_time_in_secs": result.average_execution_time_in_secs,
+        }
+
+    report_json = {name: result_to_json(result) for name, result in results.items()}
+    return json.dumps(report_json, indent=4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ files = [
     "arbeitszeit/**/*.py",
     "tests/**/*.py",
     "arbeitszeit_flask/__init__.py",
-    "arbeitszeit_web/**/*.py"
+    "arbeitszeit_web/**/*.py",
+    "arbeitszeit_benchmark/**/*.py"
 ]
 mypy_path = "type_stubs"
 exclude = '''


### PR DESCRIPTION
With this changeset we start providing a basic framework to measure the runtime characteristics of our code. Those benchmarks can be found under `/arbeitszeit_benchmark` and contain one example for now.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd

I was motivated to do this change because the `arbeitszeitapp` is significantly slowing down when viewing the transaction overview for companies. Here is an excerpt from the profiling output:

![Screenshot from 2023-05-12 08-56-30](https://github.com/arbeitszeit/arbeitszeitapp/assets/4805746/4dfab1c5-a5b7-43b9-b085-d6424f2f5f96)

Before making any changes to the code I wanted to measure the current performance and compare it to the performance after the changes. The code that resulted from that is provided with this change. I hope that this will be useful in the future when people are optimizing the code for performance.

Here is sample output from the benchmarking app:

```
$ python -m arbeitszeit_benchmark
{
    "get_company_transactions": {
        "name": "get_company_transactions",
        "average_execution_time_in_secs": 6.5062871638001525
    }
}
```