### PR TITLE
Database: Implement method to join Transactions with their sender and receiver

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -316,6 +316,11 @@ class TransactionResult(QueryResult[Transaction], Protocol):
         UUID.
         """
 
+    def joined_with_sender_and_receiver(
+        self,
+    ) -> QueryResult[Tuple[Transaction, AccountOwner, AccountOwner]]:
+        ...
+
 
 class AccountResult(QueryResult[Account], Protocol):
     def with_id(self, id_: UUID) -> AccountResult:

--- a/arbeitszeit/transactions.py
+++ b/arbeitszeit/transactions.py
@@ -168,7 +168,11 @@ class UserAccountingService:
             .where_account_is_sender_or_receiver(*accounts)
             .ordered_by_transaction_date(descending=True)
         )
-        for transaction in transactions:
+        for (
+            transaction,
+            sender,
+            receiver,
+        ) in transactions.joined_with_sender_and_receiver():
             user_is_sender = transaction.sending_account in accounts
             account_type = user.get_account_type(
                 transaction.sending_account
@@ -184,8 +188,8 @@ class UserAccountingService:
                 transaction_type=self._get_transaction_type(
                     transaction=transaction,
                     user_is_sender=user_is_sender,
-                    sender=self._get_account_owner(transaction.sending_account),
-                    receiver=self._get_account_owner(transaction.receiving_account),
+                    sender=sender,
+                    receiver=receiver,
                 ),
                 account_type=account_type,
             )

--- a/tests/flask_integration/database_gateway_impl/test_transaction_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_transaction_result.py
@@ -1,11 +1,18 @@
 from datetime import datetime
 from decimal import Decimal
+from typing import Optional
 from uuid import UUID
 
 from arbeitszeit.entities import SocialAccounting, Transaction
 from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
 from tests.control_thresholds import ControlThresholdsTestImpl
-from tests.data_generators import AccountGenerator, PlanGenerator, PurchaseGenerator
+from tests.data_generators import (
+    AccountGenerator,
+    CompanyGenerator,
+    MemberGenerator,
+    PlanGenerator,
+    PurchaseGenerator,
+)
 from tests.datetime_service import FakeDatetimeService
 
 from ..flask import FlaskTestCase
@@ -238,3 +245,184 @@ class ThatWereASaleForPlanResultTests(FlaskTestCase):
         assert not self.database_gateway.get_transactions().that_were_a_sale_for_plan(
             plan.id
         )
+
+
+class JoinedWithSenderAndReceiverTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.database_gateway = self.injector.get(DatabaseGatewayImpl)
+        self.member_generator = self.injector.get(MemberGenerator)
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.social_accounting: SocialAccounting = self.injector.get(SocialAccounting)
+
+    def test_that_with_no_transactions_in_db_the_joined_result_set_is_empty(
+        self,
+    ) -> None:
+        assert (
+            len(
+                self.database_gateway.get_transactions().joined_with_sender_and_receiver()
+            )
+            == 0
+        )
+
+    def test_that_sender_is_correctly_retrieved_for_transaction_from_member_account(
+        self,
+    ) -> None:
+        member = self.member_generator.create_member_entity()
+        self.create_transaction(sender=member.account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            member.account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == member
+
+    def test_that_sender_is_correctly_retrieved_for_transaction_from_company_r_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(sender=company.raw_material_account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            company.raw_material_account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == company
+
+    def test_that_sender_is_correctly_retrieved_for_transactions_from_company_p_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(sender=company.means_account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            company.means_account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == company
+
+    def test_that_sender_is_correctly_retrieved_for_transaction_from_company_a_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(sender=company.work_account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            company.work_account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == company
+
+    def test_that_sender_is_correctly_retrieved_for_transactions_from_company_prd_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(sender=company.product_account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            company.product_account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == company
+
+    def test_that_sender_is_correctly_retrieved_for_transactions_from_social_accounting(
+        self,
+    ) -> None:
+        self.create_transaction(sender=self.social_accounting.account)
+        transactions = self.database_gateway.get_transactions().where_account_is_sender(
+            self.social_accounting.account
+        )
+        _, sender, _ = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert sender == self.social_accounting
+
+    def test_that_receiver_is_correctly_retrieved_for_transaction_to_member_account(
+        self,
+    ) -> None:
+        member = self.member_generator.create_member_entity()
+        self.create_transaction(receiver=member.account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                member.account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == member
+
+    def test_that_receiver_is_correctly_retrieved_for_transaction_to_company_r_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(receiver=company.raw_material_account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                company.raw_material_account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == company
+
+    def test_that_receiver_is_correctly_retrieved_for_transactions_to_company_p_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(receiver=company.means_account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                company.means_account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == company
+
+    def test_that_receiver_is_correctly_retrieved_for_transaction_to_company_a_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(receiver=company.work_account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                company.work_account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == company
+
+    def test_that_receiver_is_correctly_retrieved_for_transactions_to_company_prd_account(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company_entity()
+        self.create_transaction(receiver=company.product_account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                company.product_account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == company
+
+    def test_that_receiver_is_correctly_retrieved_for_transactions_to_accounting(
+        self,
+    ) -> None:
+        self.create_transaction(receiver=self.social_accounting.account)
+        transactions = (
+            self.database_gateway.get_transactions().where_account_is_receiver(
+                self.social_accounting.account
+            )
+        )
+        _, _, receiver = transactions.joined_with_sender_and_receiver().first()  # type: ignore
+        assert receiver == self.social_accounting
+
+    def create_transaction(
+        self, sender: Optional[UUID] = None, receiver: Optional[UUID] = None
+    ) -> None:
+        if sender is None:
+            sender = self.create_account()
+        if receiver is None:
+            receiver = self.create_account()
+        self.database_gateway.create_transaction(
+            date=datetime(2000, 1, 1),
+            sending_account=sender,
+            receiving_account=receiver,
+            amount_sent=Decimal(1),
+            amount_received=Decimal(1),
+            purpose="test purpose",
+        )
+
+    def create_account(self) -> UUID:
+        member = self.member_generator.create_member_entity()
+        return member.account


### PR DESCRIPTION
This changeset introduces a new method on the TransactionResult interface: joined_with_sender_and_receiver.  This method was introduced to optimize the GetCompanyTransactions use case.  Before this change there were two separate DB query for each transaction made from or to a company.  With the new method there is only one single DB query made for all the transactions from/to a company combined. This speeds up the execution time for the use case by orders of magnitude.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (3x)