### PR TITLE
Database: Reorganize CompanyRepository interface

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -178,7 +178,7 @@ class PlanUpdate(Protocol):
         ...
 
     def perform(self) -> int:
-        """Perform the update action and return the number of columns
+        """Perform the update action and return the number of rows
         affected.
         """
 
@@ -219,7 +219,7 @@ class MemberUpdate(Protocol):
         ...
 
     def perform(self) -> int:
-        """Perform the update action and return the number of columns
+        """Perform the update action and return the number of rows
         affected.
         """
 
@@ -275,6 +275,22 @@ class CompanyResult(QueryResult[Company], Protocol):
 
     def with_email_containing(self, query: str) -> CompanyResult:
         ...
+
+    def that_are_confirmed(self) -> Self:
+        ...
+
+    def update(self) -> CompanyUpdate:
+        ...
+
+
+class CompanyUpdate(Protocol):
+    def set_confirmation_timestamp(self, timestamp: datetime) -> Self:
+        ...
+
+    def perform(self) -> int:
+        """Perform the update action and return the number of rows
+        affected.
+        """
 
 
 class AccountantResult(QueryResult[Accountant], Protocol):
@@ -405,14 +421,6 @@ class CompanyRepository(ABC):
 
     @abstractmethod
     def get_companies(self) -> CompanyResult:
-        pass
-
-    @abstractmethod
-    def is_company_confirmed(self, company: UUID) -> bool:
-        pass
-
-    @abstractmethod
-    def confirm_company(self, company: UUID, confirmation_timestamp: datetime) -> None:
         pass
 
 

--- a/arbeitszeit/use_cases/confirm_company.py
+++ b/arbeitszeit/use_cases/confirm_company.py
@@ -34,9 +34,9 @@ class ConfirmCompanyUseCase:
                 is_confirmed=False,
             )
         elif company.confirmed_on is None:
-            self.company_repository.confirm_company(
-                company.id, self.datetime_service.now()
-            )
+            self.company_repository.get_companies().with_email_address(
+                request.email_address
+            ).update().set_confirmation_timestamp(self.datetime_service.now()).perform()
             return self.Response(is_confirmed=True, user_id=company.id)
         else:
             return self.Response(is_confirmed=False, user_id=None)

--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -160,7 +160,11 @@ def resend_confirmation_member(use_case: ResendConfirmationMailUseCase):
 @with_injection()
 @login_required
 def unconfirmed_company(company_repository: CompanyRepository):
-    if company_repository.is_company_confirmed(UUID(current_user.id)):
+    if (
+        company_repository.get_companies()
+        .with_id(UUID(current_user.id))
+        .that_are_confirmed()
+    ):
         return redirect(url_for("auth.start"))
     return render_template("auth/unconfirmed_company.html")
 

--- a/arbeitszeit_web/authentication.py
+++ b/arbeitszeit_web/authentication.py
@@ -71,7 +71,11 @@ class CompanyAuthenticator:
             self.session.logout()
             self.session.set_next_url(self.request.get_request_target())
             return self.url_index.get_start_page_url()
-        elif not self.company_repository.is_company_confirmed(user_id):
+        elif (
+            not self.company_repository.get_companies()
+            .with_id(user_id)
+            .that_are_confirmed()
+        ):
             # not a confirmed company
             return self.url_index.get_unconfirmed_company_url()
         return None

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -37,6 +37,7 @@ from arbeitszeit.use_cases.accept_cooperation import (
     AcceptCooperationRequest,
 )
 from arbeitszeit.use_cases.approve_plan import ApprovePlanUseCase
+from arbeitszeit.use_cases.confirm_company import ConfirmCompanyUseCase
 from arbeitszeit.use_cases.create_plan_draft import (
     CreatePlanDraft,
     CreatePlanDraftRequest,
@@ -142,6 +143,7 @@ class CompanyGenerator:
     datetime_service: FakeDatetimeService
     company_manager: CompanyManager
     register_company_use_case: RegisterCompany
+    confirm_company_use_case: ConfirmCompanyUseCase
     password_hasher: PasswordHasher
 
     def create_company_entity(
@@ -202,7 +204,10 @@ class CompanyGenerator:
                 self.company_manager.add_worker_to_company(company, worker)
         if not confirmed:
             return company
-        self.company_repository.confirm_company(company, self.datetime_service.now())
+        confirm_response = self.confirm_company_use_case.confirm_company(
+            request=ConfirmCompanyUseCase.Request(email_address=email)
+        )
+        assert confirm_response.is_confirmed
         return company
 
 

--- a/tests/flask_integration/test_company_repository.py
+++ b/tests/flask_integration/test_company_repository.py
@@ -155,21 +155,35 @@ class ConfirmCompanyTests(FlaskTestCase):
 
     def test_that_newly_created_company_is_not_confirmed(self) -> None:
         company = self._create_company()
-        self.assertFalse(self.repository.is_company_confirmed(company.id))
+        self.assertFalse(
+            self.repository.get_companies().with_id(company.id).that_are_confirmed()
+        )
 
     def test_that_company_is_confirmed_after_confirm_was_called(self) -> None:
         company = self._create_company()
-        self.repository.confirm_company(company.id, datetime(2000, 1, 2))
-        self.assertTrue(self.repository.is_company_confirmed(company.id))
+        self.repository.get_companies().with_id(
+            company.id
+        ).update().set_confirmation_timestamp(datetime(2000, 1, 2)).perform()
+        self.assertTrue(
+            self.repository.get_companies().with_id(company.id).that_are_confirmed()
+        )
 
     def test_when_confirming_company_other_company_stays_unconfirmed(self) -> None:
         company = self._create_company()
         other_company = self._create_company("other@company.org")
-        self.repository.confirm_company(company.id, datetime(2000, 1, 2))
-        self.assertFalse(self.repository.is_company_confirmed(other_company.id))
+        self.repository.get_companies().with_id(
+            company.id
+        ).update().set_confirmation_timestamp(datetime(2000, 1, 2)).perform()
+        self.assertFalse(
+            self.repository.get_companies()
+            .with_id(other_company.id)
+            .that_are_confirmed()
+        )
 
     def test_non_existing_company_counts_as_unconfirmed(self) -> None:
-        self.assertFalse(self.repository.is_company_confirmed(company=uuid4()))
+        self.assertFalse(
+            self.repository.get_companies().with_id(uuid4()).that_are_confirmed()
+        )
 
     def _create_company(self, email: str = "test@test.test") -> Company:
         means_account = self.account_repository.create_account()


### PR DESCRIPTION
This change reworks the CompanyRepository interface. Before this change the CompanyRepository interface provided the `confirm_company` and `is_company_confirmed` methods. The `confirm_company` method was moved to the newly created `CompanyUpdate` interface. The `is_company_confirmed` method was replaced by the
`CompanyResult.that_are_confirmed` method. The implementations were adjusted respectivly.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd