### PR TITLE
Optimize ShowPRDAccountDetails use case

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -21,6 +21,9 @@ class SocialAccounting:
             return AccountTypes.accounting
         return None
 
+    def is_member(self) -> bool:
+        return False
+
 
 @dataclass
 class Member:
@@ -48,6 +51,9 @@ class Member:
             return AccountTypes.member
         else:
             return None
+
+    def is_member(self) -> bool:
+        return True
 
 
 @dataclass
@@ -88,6 +94,9 @@ class Company:
             self.product_account: AccountTypes.prd,
         }
         return account_types.get(account)
+
+    def is_member(self) -> bool:
+        return False
 
 
 class AccountTypes(Enum):

--- a/arbeitszeit/transactions.py
+++ b/arbeitszeit/transactions.py
@@ -40,6 +40,7 @@ class AccountStatementRow:
     volume: Decimal
     transaction_type: TransactionTypes
     account_type: AccountTypes
+    peer: AccountOwner
 
 
 @dataclass
@@ -180,6 +181,7 @@ class UserAccountingService:
                 else transaction.receiving_account
             )
             assert account_type
+            peer = receiver if user_is_sender else sender
             yield AccountStatementRow(
                 transaction=transaction,
                 volume=-transaction.amount_sent
@@ -192,6 +194,7 @@ class UserAccountingService:
                     receiver=receiver,
                 ),
                 account_type=account_type,
+                peer=peer,
             )
 
     def _get_account_owner(self, account_id: UUID) -> AccountOwner:

--- a/arbeitszeit_benchmark/__main__.py
+++ b/arbeitszeit_benchmark/__main__.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 from .get_company_transactions import GetCompanyTransactionsBenchmark
 from .runner import BenchmarkCatalog, BenchmarkResult, render_results_as_json
+from .show_prd_account_details_benchmark import ShowPrdAccountDetailsBenchmark
 
 
 def main() -> None:
@@ -13,6 +14,9 @@ def main() -> None:
     catalog = BenchmarkCatalog()
     catalog.register_benchmark(
         name="get_company_transactions", benchmark_class=GetCompanyTransactionsBenchmark
+    )
+    catalog.register_benchmark(
+        name="show_prd_account_details", benchmark_class=ShowPrdAccountDetailsBenchmark
     )
     for name, benchmark in catalog.get_all_benchmarks():
         try:

--- a/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
+++ b/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+from arbeitszeit.use_cases.show_prd_account_details import ShowPRDAccountDetailsUseCase
+from tests.data_generators import CompanyGenerator, PlanGenerator, PurchaseGenerator
+from tests.flask_integration.dependency_injection import get_dependency_injector
+
+
+class ShowPrdAccountDetailsBenchmark:
+    """This benchmark measures the execution time of the
+    GetCompanyTransactions use case where there are 1000 transactions
+    in the database.
+    """
+
+    def __init__(self) -> None:
+        self.injector = get_dependency_injector()
+        self.db = self.injector.get(SQLAlchemy)
+        self.app = self.injector.get(Flask)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        self.db.drop_all()
+        self.db.create_all()
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.purchase_generator = self.injector.get(PurchaseGenerator)
+        self.email = "test@test.test"
+        self.password = "test1234123"
+        self.seller = self.company_generator.create_company(
+            confirmed=True, email=self.email, password=self.password
+        )
+        plan = self.plan_generator.create_plan(planner=self.seller)
+        for _ in range(1000):
+            self.purchase_generator.create_resource_purchase_by_company(plan=plan.id)
+        self.use_case = self.injector.get(ShowPRDAccountDetailsUseCase)
+
+    def tear_down(self) -> None:
+        self.app_context.pop()
+
+    def run(self) -> None:
+        self.use_case(self.seller)


### PR DESCRIPTION
This change optimizes the ShowPRDAccountDetails use case with regards to DB access.

First I implemented a basic benchmark for the use case and recorded the average time to execute the benchmark:

```json
{
    [...],
    "show_prd_account_details": {
        "name": "show_prd_account_details",
        "average_execution_time_in_secs": 6.97218787400052
    }
}
```

Afterwards I implemented the fix and recorded the following timing:

```json
{
    [...],
    "show_prd_account_details": {
        "name": "show_prd_account_details",
        "average_execution_time_in_secs": 1.416829142998904
    }
}
```

This is a speed increase by 500%. I think that this use case could be optimized more since 1.4 seconds sounds like a lot for handling a couple of 100 transactions.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd