### PR TITLE
Seperate email confirmation info into EmailAddress entity

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -9,6 +9,12 @@ from uuid import UUID
 
 
 @dataclass
+class EmailAddress:
+    address: str
+    confirmed_on: Optional[datetime]
+
+
+@dataclass
 class SocialAccounting:
     id: UUID
     account: UUID
@@ -32,7 +38,6 @@ class Member:
     email: str
     account: UUID
     registered_on: datetime
-    confirmed_on: Optional[datetime]
     password_hash: str
 
     def accounts(self) -> List[UUID]:
@@ -66,7 +71,6 @@ class Company:
     work_account: UUID
     product_account: UUID
     registered_on: datetime
-    confirmed_on: Optional[datetime]
     password_hash: str
 
     def _accounts_by_type(self) -> Dict[AccountTypes, UUID]:

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -18,6 +18,7 @@ from arbeitszeit.entities import (
     CompanyWorkInvite,
     ConsumerPurchase,
     Cooperation,
+    EmailAddress,
     LabourCertificatesPayout,
     Member,
     PayoutFactor,
@@ -207,6 +208,9 @@ class MemberResult(QueryResult[Member], Protocol):
     def with_email_address(self, email: str) -> MemberResult:
         ...
 
+    def joined_with_email_address(self) -> QueryResult[Tuple[Member, EmailAddress]]:
+        ...
+
     def update(self) -> MemberUpdate:
         """Prepare an update for all selected members."""
 
@@ -277,6 +281,9 @@ class CompanyResult(QueryResult[Company], Protocol):
         ...
 
     def that_are_confirmed(self) -> Self:
+        ...
+
+    def joined_with_email_address(self) -> QueryResult[Tuple[Company, EmailAddress]]:
         ...
 
     def update(self) -> CompanyUpdate:
@@ -370,6 +377,10 @@ class CompanyWorkInviteResult(QueryResult[CompanyWorkInvite], Protocol):
 
     def delete(self) -> None:
         ...
+
+
+class EmailAddressResult(QueryResult[EmailAddress], Protocol):
+    ...
 
 
 class AccountRepository(ABC):

--- a/arbeitszeit/use_cases/confirm_company.py
+++ b/arbeitszeit/use_cases/confirm_company.py
@@ -23,17 +23,19 @@ class ConfirmCompanyUseCase:
     datetime_service: DatetimeService
 
     def confirm_company(self, request: Request) -> Response:
-        company = (
+        record = (
             self.database.get_companies()
             .with_email_address(request.email_address)
+            .joined_with_email_address()
             .first()
         )
-        if not company:
+        if not record:
             return self.Response(
                 user_id=None,
                 is_confirmed=False,
             )
-        elif company.confirmed_on is None:
+        company, email = record
+        if email.confirmed_on is None:
             self.database.get_companies().with_email_address(
                 request.email_address
             ).update().set_confirmation_timestamp(self.datetime_service.now()).perform()

--- a/tests/flask_integration/database_gateway_impl/test_company_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_company_result.py
@@ -301,3 +301,20 @@ class WithEmailContainingTests(FlaskTestCase):
         )
         assert returned_company
         assert returned_company[0].id == expected_company_id
+
+
+class JoinedWithEmailTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company_generator = self.injector.get(CompanyGenerator)
+
+    def test_that_company_email_is_yielded(self) -> None:
+        expected_email = "test@test.test"
+        company = self.company_generator.create_company(email=expected_email)
+        record = (
+            self.database_gateway.get_companies()
+            .with_id(company)
+            .joined_with_email_address()
+            .first()
+        )
+        assert record

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -220,9 +220,15 @@ class MemberUpdateTests(FlaskTestCase):
         self.database_gateway.get_members().with_id(
             member_id
         ).update().set_confirmation_timestamp(expected_timestamp).perform()
-        member = self.database_gateway.get_members().with_id(member_id).first()
-        assert member
-        assert member.confirmed_on == expected_timestamp
+        record = (
+            self.database_gateway.get_members()
+            .with_id(member_id)
+            .joined_with_email_address()
+            .first()
+        )
+        assert record
+        _, email = record
+        assert email.confirmed_on == expected_timestamp
 
     def test_that_member_confirmation_returns_the_count_of_update_members(self) -> None:
         expected_count = 5
@@ -243,9 +249,15 @@ class MemberUpdateTests(FlaskTestCase):
         self.database_gateway.get_members().with_id(
             member_id
         ).update().set_confirmation_timestamp(expected_timestamp).perform()
-        member = self.database_gateway.get_members().with_id(other_member_id).first()
-        assert member
-        assert member.confirmed_on is None
+        record = (
+            self.database_gateway.get_members()
+            .with_id(other_member_id)
+            .joined_with_email_address()
+            .first()
+        )
+        assert record
+        _, email = record
+        assert email.confirmed_on is None
 
     def create_member(self) -> UUID:
         member = self.database_gateway.create_member(

--- a/tests/flask_integration/test_resend_confirmation_view.py
+++ b/tests/flask_integration/test_resend_confirmation_view.py
@@ -32,15 +32,14 @@ class AuthTests(ViewTestCase):
 
 
 class AuthenticatedButUnconfirmedMemberTests(ViewTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = "/member/resend"
         self.member = self.login_member(confirm_member=False)
 
     def test_authenticated_and_unconfirmed_users_get_redirected_and_mail_gets_send(
         self,
-    ):
-        assert not self.member.confirmed_on
+    ) -> None:
         response = self.client.get(self.url)
         with mail.record_messages() as outbox:
             response = self.client.get(
@@ -51,15 +50,14 @@ class AuthenticatedButUnconfirmedMemberTests(ViewTestCase):
 
 
 class ConfirmedMemberTests(ViewTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = "/member/resend"
         self.member = self.login_member(confirm_member=True)
 
     def test_already_confirmed_member_gets_redirected_and_no_mail_gets_sent(
         self,
-    ):
-        assert self.member.confirmed_on
+    ) -> None:
         response = self.client.get(self.url)
         with mail.record_messages() as outbox:
             response = self.client.get(


### PR DESCRIPTION
This change makes the separation of email info and member/company accounts explicit in the business logic.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (2x)