### PR TITLE
Add CI check for nixos-23.05 package set

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -78,7 +78,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-  nixos-stable:
+  nixos-22-11:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -91,13 +91,50 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     # One might be tempted to run all the tests from `./run-checks`
     # but this could be a bad idea.  The python packages used with
-    # nixos-stable are older then nixos-unstable.  This means that
+    # nixos-22-11 are older then nixos-unstable.  This means that
     # there might be incompatibilities between different versions of
     # the tools used, e.g. mypy, flake8, black and so on. To avoid
     # running into these incompatibilities we simply don't run
     # them. As long as all the tests from `pytest` run successfully we
     # should be okay.
-    - run: nix develop .#stable --command pytest
+    - run: nix develop .#nixos-22-11 --command pytest
+      env:
+        ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+  nixos-23-05:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+    - uses: cachix/cachix-action@v12
+      with:
+        name: arbeitszeit
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    # One might be tempted to run all the tests from `./run-checks`
+    # but this could be a bad idea.  The python packages used with
+    # nixos-23-05 are older then nixos-unstable.  This means that
+    # there might be incompatibilities between different versions of
+    # the tools used, e.g. mypy, flake8, black and so on. To avoid
+    # running into these incompatibilities we simply don't run
+    # them. As long as all the tests from `pytest` run successfully we
+    # should be okay.
+    - run: nix develop .#nixos-23-05 --command pytest
       env:
         ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
     services:

--- a/constraints.txt
+++ b/constraints.txt
@@ -45,7 +45,7 @@ jsonschema==4.17.3
 kiwisolver==1.4.4
 Mako==1.2.4
 MarkupSafe==2.1.2
-matplotlib==3.7.0
+matplotlib==3.7.1
 mccabe==0.7.0
 mypy==1.0.1
 mypy-extensions==0.4.3
@@ -74,7 +74,7 @@ PyStemmer==2.2.0
 pytest==7.2.1
 python-dateutil==2.8.2
 pytz==2023.3
-requests==2.29.0
+requests==2.31.0
 setuptools==67.4.0
 six==1.16.0
 snowballstemmer==2.2.0
@@ -87,7 +87,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4
-SQLAlchemy==2.0.13
+SQLAlchemy==2.0.15
 tomli==2.0.1
 types-python-dateutil==2.8.19
 typing_extensions==4.5.0

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -55,18 +55,34 @@
         "type": "github"
       }
     },
-    "nixos-stable": {
+    "nixos-22-11": {
       "locked": {
-        "lastModified": 1685043448,
-        "narHash": "sha256-U3BwyDc2OzBcZ8tD09qXibyivgOtOQFTFCVgFyJ+6MM=",
+        "lastModified": 1685650716,
+        "narHash": "sha256-sDd7QIcMbIb37nuqMrJElvuyE5eVgWuKGtIPP8IWwCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9886352ec9ab3945896ee8a4185e961fe29df209",
+        "rev": "f7c1500e2eefa58f3c80dd046cba256e10440201",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixos-23-05": {
+      "locked": {
+        "lastModified": 1685620773,
+        "narHash": "sha256-iQ+LmporQNdLz8uMJdP62TaAWeLUwl43/MYUBtWqulM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f0ba8235153dd2e25cf06cbf70d43efdd4443592",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -89,11 +105,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685012353,
-        "narHash": "sha256-U3oOge4cHnav8OLGdRVhL45xoRj4Ppd+It6nPC9nNIU=",
+        "lastModified": 1685677062,
+        "narHash": "sha256-zoHF7+HNwNwne2XEomphbdc4Y8tdWT16EUxUTXpOKpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aeb75dba965e790de427b73315d5addf91a54955",
+        "rev": "95be94370d09f97f6af6a1df1eb9649b5260724e",
         "type": "github"
       },
       "original": {
@@ -107,7 +123,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-stable": "nixos-stable",
+        "nixos-22-11": "nixos-22-11",
+        "nixos-23-05": "nixos-23-05",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,14 @@
   description = "Arbeitszeitapp";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-stable.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixos-22-11.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixos-23-05.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
 
-  outputs = { self, nixpkgs, flake-utils, flask-profiler, nixos-stable }:
+  outputs =
+    { self, nixpkgs, flake-utils, flask-profiler, nixos-22-11, nixos-23-05 }:
     let
       supportedSystems = [ "x86_64-linux" ];
       systemDependent = flake-utils.lib.eachSystem supportedSystems (system:
@@ -16,14 +18,19 @@
             inherit system;
             overlays = [ self.overlays.default ];
           };
-          pkgsStable = import nixos-stable {
+          pkgs-22-11 = import nixos-22-11 {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          };
+          pkgs-23-05 = import nixos-23-05 {
             inherit system;
             overlays = [ self.overlays.default ];
           };
         in {
           devShells = {
             default = pkgs.callPackage nix/devShell.nix { };
-            stable = pkgsStable.callPackage nix/devShell.nix { };
+            nixos-22-11 = pkgs-22-11.callPackage nix/devShell.nix { };
+            nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
           };
           packages = {
             default = pkgs.python3.pkgs.arbeitszeitapp;


### PR DESCRIPTION
This change adds support for the nixpkgs branch `nixos-23.05`, which is the current stable version of NixOS as of this commit.

The nix flake inputs where updated.

No certs needed.