### PR TITLE
Refactor PlanDraftRepository

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -184,6 +184,14 @@ class PlanUpdate(Protocol):
         """
 
 
+class PlanDraftResult(QueryResult[PlanDraft], Protocol):
+    def with_id(self, id_: UUID) -> Self:
+        ...
+
+    def planned_by(self, *company: UUID) -> Self:
+        ...
+
+
 class CooperationResult(QueryResult[Cooperation], Protocol):
     def with_id(self, id_: UUID) -> Self:
         ...
@@ -431,15 +439,11 @@ class PlanDraftRepository(ABC):
         pass
 
     @abstractmethod
-    def get_by_id(self, id: UUID) -> Optional[PlanDraft]:
+    def get_plan_drafts(self) -> PlanDraftResult:
         pass
 
     @abstractmethod
     def delete_draft(self, id: UUID) -> None:
-        pass
-
-    @abstractmethod
-    def all_drafts_of_company(self, id: UUID) -> Iterable[PlanDraft]:
         pass
 
 

--- a/arbeitszeit/use_cases/delete_draft.py
+++ b/arbeitszeit/use_cases/delete_draft.py
@@ -23,7 +23,7 @@ class DeleteDraftUseCase:
 
     def delete_draft(self, request: Request) -> Response:
         deleter = self.database.get_companies().with_id(request.deleter).first()
-        draft = self.draft_repository.get_by_id(request.draft)
+        draft = self.draft_repository.get_plan_drafts().with_id(request.draft).first()
         if not draft or not deleter:
             raise self.Failure()
         if draft.planner != deleter.id:

--- a/arbeitszeit/use_cases/edit_draft.py
+++ b/arbeitszeit/use_cases/edit_draft.py
@@ -30,7 +30,12 @@ class EditDraftUseCase:
 
     def edit_draft(self, request: Request) -> Response:
         if (
-            (draft := self.draft_repository.get_by_id(request.draft)) is not None
+            (
+                draft := self.draft_repository.get_plan_drafts()
+                .with_id(request.draft)
+                .first()
+            )
+            is not None
         ) and draft.planner == request.editor:
             self.draft_repository.update_draft(
                 update=self.draft_repository.UpdateDraft(

--- a/arbeitszeit/use_cases/file_plan_with_accounting.py
+++ b/arbeitszeit/use_cases/file_plan_with_accounting.py
@@ -27,7 +27,9 @@ class FilePlanWithAccounting:
     accountant_notifier: AccountantNotifier
 
     def file_plan_with_accounting(self, request: Request) -> Response:
-        draft = self.draft_repository.get_by_id(id=request.draft_id)
+        draft = (
+            self.draft_repository.get_plan_drafts().with_id(request.draft_id).first()
+        )
         if draft is not None and draft.planner == request.filing_company:
             plan = self.database_gateway.create_plan(
                 creation_timestamp=self.datetime_service.now(),

--- a/arbeitszeit/use_cases/get_draft_summary.py
+++ b/arbeitszeit/use_cases/get_draft_summary.py
@@ -29,7 +29,7 @@ class GetDraftSummary:
     draft_repository: PlanDraftRepository
 
     def __call__(self, draft_id: UUID) -> DraftSummaryResponse:
-        draft = self.draft_repository.get_by_id(draft_id)
+        draft = self.draft_repository.get_plan_drafts().with_id(draft_id).first()
         if draft is None:
             return None
         return DraftSummarySuccess(

--- a/arbeitszeit/use_cases/show_my_plans.py
+++ b/arbeitszeit/use_cases/show_my_plans.py
@@ -56,7 +56,7 @@ class ShowMyPlansUseCase:
         drafts = list(
             map(
                 self._create_plan_info_from_draft,
-                self.draft_repository.all_drafts_of_company(id=request.company_id),
+                self.draft_repository.get_plan_drafts().planned_by(request.company_id),
             )
         )
         drafts.sort(key=lambda x: x.plan_creation_date, reverse=True)

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -360,7 +360,9 @@ class PlanGenerator:
         )
         assert not response.is_rejected
         assert response.draft_id
-        draft = self.draft_repository.get_by_id(response.draft_id)
+        draft = (
+            self.draft_repository.get_plan_drafts().with_id(response.draft_id).first()
+        )
         assert draft
         return draft
 

--- a/tests/flask_integration/test_create_draft_view.py
+++ b/tests/flask_integration/test_create_draft_view.py
@@ -70,5 +70,5 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
 
     def _count_drafts_of_company(self) -> int:
         return len(
-            list(self.plan_draft_repository.all_drafts_of_company(self.company.id))
+            self.plan_draft_repository.get_plan_drafts().planned_by(self.company.id)
         )

--- a/tests/use_cases/test_create_plan_draft.py
+++ b/tests/use_cases/test_create_plan_draft.py
@@ -37,9 +37,9 @@ class UseCaseTests(BaseTestCase):
     def test_that_create_plan_creates_a_plan_draft_that_is_not_rejected(self) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner)
-        assert not len(self.plan_draft_repository)
+        assert not self.plan_draft_repository.get_plan_drafts()
         response = self.create_plan_draft(request)
-        assert len(self.plan_draft_repository) == 1
+        assert len(self.plan_draft_repository.get_plan_drafts()) == 1
         assert not response.is_rejected
 
     def test_that_create_plan_returns_a_draft_id(self) -> None:


### PR DESCRIPTION
This change brings the PlanDraftRepository more in line with the rest of the repositories.  There is now a `get_plan_drafts` method that returns a "proper" `PlanDraftResult`. These `PlanDraftResult` objects can be filtered by id and planner.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd