### PR TITLE
Fix bug in migration ed5e327140bf

### DIFF
--- a/arbeitszeit_flask/migrations/versions/ed5e327140bf_create_user_model.py
+++ b/arbeitszeit_flask/migrations/versions/ed5e327140bf_create_user_model.py
@@ -125,11 +125,9 @@ class ForwardMigrator:
     def _fetch_user_credentials(self, table):
         for id_, email, password in self.connection.execute(
             sa.select(
-                [
-                    table.c.id,
-                    table.c.email,
-                    table.c.password,
-                ]
+                table.c.id,
+                table.c.email,
+                table.c.password,
             )
         ).fetchall():
             yield {


### PR DESCRIPTION
There was a bug in migration ed5e327140bf, this PR fixed it. I ran into this bug after upgrading to NixOS 23.05 in https://github.com/arbeitszeit/arbeitszeitapp-deployment
My guess is that this bug suddenly showed up since NixOS 23.05 ships a newer version of sqlalchemy. I tested this change with the integration tests from https://github.com/arbeitszeit/arbeitszeitapp-deployment and it fixed the migration errors.

No certs required.