### PR TITLE
Update PlanDraftRepository

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -193,6 +193,9 @@ class PlanDraftResult(QueryResult[PlanDraft], Protocol):
     def planned_by(self, *company: UUID) -> Self:
         ...
 
+    def delete(self) -> int:
+        ...
+
 
 class CooperationResult(QueryResult[Cooperation], Protocol):
     def with_id(self, id_: UUID) -> Self:
@@ -432,10 +435,6 @@ class PlanDraftRepository(ABC):
 
     @abstractmethod
     def get_plan_drafts(self) -> PlanDraftResult:
-        pass
-
-    @abstractmethod
-    def delete_draft(self, id: UUID) -> None:
         pass
 
 

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import Generic, Iterable, Iterator, Optional, Protocol, Tuple, TypeVar
@@ -193,7 +192,39 @@ class PlanDraftResult(QueryResult[PlanDraft], Protocol):
     def planned_by(self, *company: UUID) -> Self:
         ...
 
+    def update(self) -> PlanDraftUpdate:
+        ...
+
     def delete(self) -> int:
+        ...
+
+
+class PlanDraftUpdate(DatabaseUpdate, Protocol):
+    def set_product_name(self, name: str) -> Self:
+        ...
+
+    def set_amount(self, n: int) -> Self:
+        ...
+
+    def set_description(self, description: str) -> Self:
+        ...
+
+    def set_labour_cost(self, costs: Decimal) -> Self:
+        ...
+
+    def set_means_cost(self, costs: Decimal) -> Self:
+        ...
+
+    def set_resource_cost(self, costs: Decimal) -> Self:
+        ...
+
+    def set_is_public_service(self, is_public_service: bool) -> Self:
+        ...
+
+    def set_timeframe(self, days: int) -> Self:
+        ...
+
+    def set_unit_of_distribution(self, unit: str) -> Self:
         ...
 
 
@@ -414,23 +445,6 @@ class PlanDraftRepository(ABC):
         is_public_service: bool,
         creation_timestamp: datetime,
     ) -> PlanDraft:
-        pass
-
-    @dataclass
-    class UpdateDraft:
-        id: UUID
-        product_name: Optional[str] = None
-        amount: Optional[int] = None
-        description: Optional[str] = None
-        labour_cost: Optional[Decimal] = None
-        means_cost: Optional[Decimal] = None
-        resource_cost: Optional[Decimal] = None
-        is_public_service: Optional[bool] = None
-        timeframe: Optional[int] = None
-        unit_of_distribution: Optional[str] = None
-
-    @abstractmethod
-    def update_draft(self, update: UpdateDraft) -> None:
         pass
 
     @abstractmethod

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -50,6 +50,13 @@ class QueryResult(Protocol, Generic[T]):
         ...
 
 
+class DatabaseUpdate(Protocol):
+    def perform(self) -> int:
+        """Peform the update and return the number of records/rows
+        affected.
+        """
+
+
 class PlanResult(QueryResult[Plan], Protocol):
     def ordered_by_creation_date(self, ascending: bool = ...) -> PlanResult:
         ...
@@ -142,7 +149,7 @@ class PlanResult(QueryResult[Plan], Protocol):
         """Prepare an update for all selected Plans."""
 
 
-class PlanUpdate(Protocol):
+class PlanUpdate(DatabaseUpdate, Protocol):
     """Aggregate updates on a previously selected set of plan rows in
     the DB and execute them all in one.
     """
@@ -177,11 +184,6 @@ class PlanUpdate(Protocol):
 
     def toggle_product_availability(self) -> Self:
         ...
-
-    def perform(self) -> int:
-        """Perform the update action and return the number of rows
-        affected.
-        """
 
 
 class PlanDraftResult(QueryResult[PlanDraft], Protocol):
@@ -226,14 +228,9 @@ class MemberResult(QueryResult[Member], Protocol):
         ...
 
 
-class MemberUpdate(Protocol):
+class MemberUpdate(DatabaseUpdate, Protocol):
     def set_confirmation_timestamp(self, timestamp: datetime) -> MemberUpdate:
         ...
-
-    def perform(self) -> int:
-        """Perform the update action and return the number of rows
-        affected.
-        """
 
 
 class ConsumerPurchaseResult(QueryResult[ConsumerPurchase], Protocol):
@@ -298,14 +295,9 @@ class CompanyResult(QueryResult[Company], Protocol):
         ...
 
 
-class CompanyUpdate(Protocol):
+class CompanyUpdate(DatabaseUpdate, Protocol):
     def set_confirmation_timestamp(self, timestamp: datetime) -> Self:
         ...
-
-    def perform(self) -> int:
-        """Perform the update action and return the number of rows
-        affected.
-        """
 
 
 class AccountantResult(QueryResult[Accountant], Protocol):

--- a/arbeitszeit/use_cases/delete_draft.py
+++ b/arbeitszeit/use_cases/delete_draft.py
@@ -23,10 +23,11 @@ class DeleteDraftUseCase:
 
     def delete_draft(self, request: Request) -> Response:
         deleter = self.database.get_companies().with_id(request.deleter).first()
-        draft = self.draft_repository.get_plan_drafts().with_id(request.draft).first()
+        draft_query = self.draft_repository.get_plan_drafts().with_id(request.draft)
+        draft = draft_query.first()
         if not draft or not deleter:
             raise self.Failure()
         if draft.planner != deleter.id:
             raise self.Failure()
-        self.draft_repository.delete_draft(request.draft)
+        draft_query.delete()
         return self.Response(product_name=draft.product_name)

--- a/arbeitszeit/use_cases/edit_draft.py
+++ b/arbeitszeit/use_cases/edit_draft.py
@@ -37,20 +37,28 @@ class EditDraftUseCase:
             )
             is not None
         ) and draft.planner == request.editor:
-            self.draft_repository.update_draft(
-                update=self.draft_repository.UpdateDraft(
-                    id=request.draft,
-                    product_name=request.product_name,
-                    amount=request.amount,
-                    description=request.description,
-                    labour_cost=request.labour_cost,
-                    means_cost=request.means_cost,
-                    resource_cost=request.resource_cost,
-                    is_public_service=request.is_public_service,
-                    timeframe=request.timeframe,
-                    unit_of_distribution=request.unit_of_distribution,
-                )
+            update = (
+                self.draft_repository.get_plan_drafts().with_id(request.draft).update()
             )
+            if request.product_name is not None:
+                update = update.set_product_name(request.product_name)
+            if request.amount is not None:
+                update = update.set_amount(request.amount)
+            if request.description is not None:
+                update = update.set_description(request.description)
+            if request.labour_cost is not None:
+                update = update.set_labour_cost(request.labour_cost)
+            if request.means_cost is not None:
+                update = update.set_means_cost(request.means_cost)
+            if request.resource_cost is not None:
+                update = update.set_resource_cost(request.resource_cost)
+            if request.is_public_service is not None:
+                update = update.set_is_public_service(request.is_public_service)
+            if request.timeframe is not None:
+                update = update.set_timeframe(request.timeframe)
+            if request.unit_of_distribution is not None:
+                update = update.set_unit_of_distribution(request.unit_of_distribution)
+            update.perform()
             is_success = True
         else:
             is_success = False

--- a/arbeitszeit/use_cases/file_plan_with_accounting.py
+++ b/arbeitszeit/use_cases/file_plan_with_accounting.py
@@ -27,9 +27,8 @@ class FilePlanWithAccounting:
     accountant_notifier: AccountantNotifier
 
     def file_plan_with_accounting(self, request: Request) -> Response:
-        draft = (
-            self.draft_repository.get_plan_drafts().with_id(request.draft_id).first()
-        )
+        draft_query = self.draft_repository.get_plan_drafts().with_id(request.draft_id)
+        draft = draft_query.first()
         if draft is not None and draft.planner == request.filing_company:
             plan = self.database_gateway.create_plan(
                 creation_timestamp=self.datetime_service.now(),
@@ -43,7 +42,7 @@ class FilePlanWithAccounting:
                 is_public_service=draft.is_public_service,
             )
             assert plan
-            self.draft_repository.delete_draft(id=request.draft_id)
+            draft_query.delete()
             is_plan_successfully_filed = True
             self.accountant_notifier.notify_all_accountants_about_new_plan(
                 product_name=draft.product_name,

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -372,6 +372,9 @@ class PlanDraftResult(FlaskQueryResult[entities.PlanDraft]):
             )
         )
 
+    def delete(self) -> int:
+        return self.query.delete()
+
 
 class MemberQueryResult(FlaskQueryResult[entities.Member]):
     def working_at_company(self, company: UUID) -> MemberQueryResult:
@@ -1208,9 +1211,6 @@ class PlanDraftRepository(repositories.PlanDraftRepository):
             query=models.PlanDraft.query,
             mapper=self.plan_draft_from_orm,
         )
-
-    def delete_draft(self, id: UUID) -> None:
-        PlanDraft.query.filter_by(id=str(id)).delete()
 
     @classmethod
     def plan_draft_from_orm(cls, orm: models.PlanDraft) -> entities.PlanDraft:

--- a/tests/flask_integration/test_plan_draft_repository.py
+++ b/tests/flask_integration/test_plan_draft_repository.py
@@ -116,8 +116,15 @@ class PlanDraftRepositoryTests(PlanDraftRepositoryBaseTests):
 
     def test_deleted_drafts_cannot_be_retrieved_anymore(self) -> None:
         draft = self.create_plan_draft()
-        self.repo.delete_draft(draft.id)
+        self.repo.get_plan_drafts().with_id(draft.id).delete()
         self.assertIsNone(self.repo.get_plan_drafts().with_id(draft.id).first())
+
+    def test_that_deletion_of_one_plan_returns_1_if_plan_existed(self) -> None:
+        draft = self.create_plan_draft()
+        assert self.repo.get_plan_drafts().with_id(draft.id).delete() == 1
+
+    def test_that_deletion_of_non_existing_plan_returns_0(self) -> None:
+        assert self.repo.get_plan_drafts().with_id(uuid4()).delete() == 0
 
     def test_all_drafts_can_be_retrieved(self) -> None:
         expected_draft1 = self.create_plan_draft()

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -350,6 +350,107 @@ class PlanDraftResult(QueryResultImpl[entities.PlanDraft]):
                 drafts_deleted += 1
         return drafts_deleted
 
+    def update(self) -> PlanDraftUpdate:
+        return PlanDraftUpdate(
+            entities=self.entities,
+            items=self.items,
+        )
+
+
+@dataclass
+class PlanDraftUpdate:
+    entities: EntityStorage
+    items: Callable[[], Iterable[PlanDraft]]
+    changes: Callable[[PlanDraft], None] = lambda _: None
+
+    def set_product_name(self, name: str) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.product_name = name
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_amount(self, n: int) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.amount_produced = n
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_description(self, description: str) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.description = description
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_labour_cost(self, costs: Decimal) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.production_costs.labour_cost = costs
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_means_cost(self, costs: Decimal) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.production_costs.means_cost = costs
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_resource_cost(self, costs: Decimal) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.production_costs.resource_cost = costs
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_is_public_service(self, is_public_service: bool) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.is_public_service = is_public_service
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_timeframe(self, days: int) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.timeframe = days
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def set_unit_of_distribution(self, unit: str) -> Self:
+        def update(draft: PlanDraft) -> None:
+            draft.unit_of_distribution = unit
+
+        return replace(
+            self,
+            changes=update,
+        )
+
+    def perform(self) -> int:
+        items_affected = 0
+        for item in self.items():
+            self.changes(item)
+            items_affected += 1
+        return items_affected
+
 
 class CooperationResult(QueryResultImpl[Cooperation]):
     def with_id(self, id_: UUID) -> Self:
@@ -937,30 +1038,6 @@ class PlanDraftRepository(interfaces.PlanDraftRepository):
         )
         self.entities.drafts[draft.id] = draft
         return draft
-
-    def update_draft(self, update: interfaces.PlanDraftRepository.UpdateDraft) -> None:
-        draft = self.get_plan_drafts().with_id(update.id).first()
-        if draft is None:
-            return
-        if update.product_name is not None:
-            draft.product_name = update.product_name
-        if update.amount is not None:
-            draft.amount_produced = update.amount
-        if update.description is not None:
-            draft.description = update.description
-        if update.labour_cost is not None:
-            draft.production_costs.labour_cost = update.labour_cost
-        if update.means_cost is not None:
-            draft.production_costs.means_cost = update.means_cost
-        if update.resource_cost is not None:
-            draft.production_costs.resource_cost = update.resource_cost
-        if update.is_public_service is not None:
-            draft.is_public_service = update.is_public_service
-        if update.timeframe is not None:
-            draft.timeframe = update.timeframe
-        if update.unit_of_distribution is not None:
-            draft.unit_of_distribution = update.unit_of_distribution
-        return
 
     def get_plan_drafts(self) -> PlanDraftResult:
         return PlanDraftResult(


### PR DESCRIPTION
# Intention

This PR wants to bring the PlanDraftRepository more in line with our best practices of DB interfacing.

## database_gateway: Declare common interface for DB update objects

This change makes it so that all update operations on the DB should
yield the number of rows affected.

## database_gateway: Move delete method for drafts to PlanDraftResult

This changes allows us to drafts from any selection instead of only
one draft at a time.

## PlanDraftRepository: Remove UpdateDraft in favour of PlanDraftUpdate

This change removes the UpdateDraft dataclass from our code in favour
of the a new PlanDraftUpdate interface. This new interface follows our
coding guidlines for DB update operations. All DB implementations and
our use cases were adjusted accordingly.


Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (3x)