### PR TITLE
database: Move email address specific info into new email table

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -139,7 +139,7 @@ def login_member(
 @login_required
 def resend_confirmation_member(use_case: ResendConfirmationMailUseCase):
     assert (
-        current_user.user.email
+        current_user.user.email_address
     )  # current user object must have email because it is logged in
 
     request = use_case.Request(user=UUID(current_user.id))
@@ -229,7 +229,7 @@ def confirm_email_company(
 @login_required
 def resend_confirmation_company(use_case: ResendConfirmationMailUseCase):
     assert (
-        current_user.user.email
+        current_user.user.email_address
     )  # current user object must have email because it is logged in
 
     request = use_case.Request(user=UUID(current_user.id))

--- a/arbeitszeit_flask/migrations/versions/7a550048df32_create_email_table.py
+++ b/arbeitszeit_flask/migrations/versions/7a550048df32_create_email_table.py
@@ -1,0 +1,90 @@
+"""Create email table
+
+Revision ID: 7a550048df32
+Revises: 8cdaf3b82da6
+Create Date: 2023-06-21 05:44:25.570799
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "7a550048df32"
+down_revision = "8cdaf3b82da6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "email",
+        sa.Column("address", sa.String(), nullable=False),
+        sa.Column("confirmed_on", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("address"),
+    )
+    op.execute(
+        """
+        INSERT INTO email (address, confirmed_on)
+        SELECT "user".email AS address, "user".email_confirmed_on AS confirmed_on
+        FROM "user"
+    """
+    )
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("email_address", sa.String(), nullable=True))
+        batch_op.create_unique_constraint(
+            "user_email_address_unique", ["email_address"]
+        )
+        batch_op.create_foreign_key(
+            "user_email_address_fkey", "email", ["email_address"], ["address"]
+        )
+    op.execute(
+        """
+        UPDATE "user"
+        SET email_address = "user".email
+    """
+    )
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column(
+            "email_address", existing_type=sa.VARCHAR(), nullable=False
+        )
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_constraint("user_email_key", type_="unique")
+        batch_op.drop_column("email_confirmed_on")
+        batch_op.drop_column("email")
+
+
+def downgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "email", sa.VARCHAR(length=100), autoincrement=False, nullable=True
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "email_confirmed_on",
+                postgresql.TIMESTAMP(),
+                autoincrement=False,
+                nullable=True,
+            )
+        )
+        batch_op.create_unique_constraint("user_email_key", ["email"])
+    op.execute(
+        """
+        UPDATE "user"
+        SET email = e.address, email_confirmed_on = e.confirmed_on
+        FROM email e
+        WHERE e.address = "user".email_address
+    """
+    )
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column("email", existing_type=sa.VARCHAR(), nullable=False)
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column(
+            "email_address", existing_type=sa.VARCHAR(), nullable=True
+        )
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_constraint("user_email_address_fkey", type_="foreignkey")
+        batch_op.drop_constraint("user_email_address_unique", type_="unique")
+        batch_op.drop_column("email_address")
+    op.drop_table("email")

--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -16,12 +16,18 @@ def generate_uuid() -> str:
 
 class User(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
-    email = db.Column(db.String(100), unique=True, nullable=False)
     password = db.Column(db.String(100), nullable=False)
-    email_confirmed_on = db.Column(db.DateTime, nullable=True)
+    email_address = db.Column(
+        db.ForeignKey("email.address"), nullable=False, unique=True
+    )
 
     def __str__(self) -> str:
-        return f"User {self.email} ({self.id})"
+        return f"User {self.email_address} ({self.id})"
+
+
+class Email(db.Model):
+    address = db.Column(db.String, primary_key=True, nullable=False)
+    confirmed_on = db.Column(db.DateTime, nullable=True)
 
 
 class SocialAccounting(db.Model):

--- a/type_stubs/flask_login.pyi
+++ b/type_stubs/flask_login.pyi
@@ -12,8 +12,7 @@ def logout_user() -> None:
 def login_required(callable: T) -> T: ...
 
 class User:
-    email: str
-    email_confirmed_on: Optional[datetime]
+    email_address: str
 
 class CurrentUser:
     id: str


### PR DESCRIPTION
This change creates a new database table "email". The purpose of this table is to store information associated with email addresses. This was done in preparation to implement a "change email address" feature for users.

This table will allow us to separate the steps of confirming an email address and changing a users email address.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd (2x)