### PR TITLE
tests: Rework tests for ShowPRDAccountDetailsUseCase

### DIFF
--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -19,10 +19,11 @@ class FakeDatetimeService(DatetimeService):
     def unfreeze_time(self) -> None:
         self.frozen_time = None
 
-    def advance_time(self, dt: timedelta) -> None:
+    def advance_time(self, dt: timedelta) -> datetime:
         assert dt > timedelta(0)
         assert self.frozen_time
         self.frozen_time += dt
+        return self.frozen_time
 
     def now(self) -> datetime:
         return self.frozen_time if self.frozen_time else datetime.now()

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generic, Type, TypeVar
 from unittest import TestCase
 
+from tests.control_thresholds import ControlThresholdsTestImpl
 from tests.data_generators import (
     AccountantGenerator,
     CompanyGenerator,
@@ -61,6 +62,7 @@ class BaseTestCase(TestCase):
     accountant_generator = _lazy_property(AccountantGenerator)
     balance_checker = _lazy_property(BalanceChecker)
     company_generator = _lazy_property(CompanyGenerator)
+    control_thresholds = _lazy_property(ControlThresholdsTestImpl)
     coop_generator = _lazy_property(CooperationGenerator)
     cooperation_generator = _lazy_property(CooperationGenerator)
     datetime_service = _lazy_property(FakeDatetimeService)

--- a/tests/use_cases/test_pay_consumer_product.py
+++ b/tests/use_cases/test_pay_consumer_product.py
@@ -13,7 +13,6 @@ from arbeitszeit.use_cases.pay_consumer_product import (
     RejectionReason,
 )
 from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
-from tests.control_thresholds import ControlThresholdsTestImpl
 from tests.data_generators import TransactionGenerator
 
 from .base_test_case import BaseTestCase
@@ -27,7 +26,6 @@ class PayConsumerProductTests(BaseTestCase):
         self.pay_consumer_product = self.injector.get(PayConsumerProduct)
         self.entity_storage = self.injector.get(EntityStorage)
         self.buyer = self.member_generator.create_member_entity()
-        self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
         self.update_plans_and_payout = self.injector.get(UpdatePlansAndPayout)
         self.query_member_purchases = self.injector.get(
             query_member_purchases.QueryMemberPurchases

--- a/tests/use_cases/test_query_member_purchases.py
+++ b/tests/use_cases/test_query_member_purchases.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from arbeitszeit.use_cases.query_member_purchases import QueryMemberPurchases
-from tests.control_thresholds import ControlThresholdsTestImpl
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -9,7 +8,6 @@ class TestQueryMemberPurchases(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.query_purchases = self.injector.get(QueryMemberPurchases)
-        self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
         self.control_thresholds.set_allowed_overdraw_of_member_account(10000)
 
     def test_that_no_purchase_is_returned_when_searching_an_empty_repo(self) -> None:


### PR DESCRIPTION
This change reworks the tests for the
ShowPRDAccountDetailsUseCase. The basic idea of this change was to remove all explicit references to the transaction generator and the transaction repository. Instead the creation of the test fixtures is done by invoking the proper use cases for for "buying" products from a company. This should make the tests more robust in the face of changes to the DB structure.

Plan-ID: 8c5dfb71-affb-4def-b850-aafa86b2c8fd