### PR TITLE
fix bug in flask-restx nix packaging directive

### DIFF
--- a/nix/pythonPackages/flask-restx.nix
+++ b/nix/pythonPackages/flask-restx.nix
@@ -1,15 +1,11 @@
 { lib, buildPythonPackage, fetchPypi, flask, aniso8601, jsonschema, pytz
 , werkzeug }:
-
-buildPythonPackage rec {
-  pname = "flask-restx";
-  version = "1.1.0";
+let pypiSource = (builtins.fromJSON (builtins.readFile ./flask-restx.json));
+in buildPythonPackage rec {
+  pname = pypiSource.pname;
+  version = pypiSource.version;
   format = "setuptools";
-
-  src = fetchPypi (builtins.fromJSON (builtins.readFile ./flask-restx.json));
-
+  src = fetchPypi pypiSource;
   propagatedBuildInputs = [ flask aniso8601 jsonschema pytz werkzeug ];
-
   doCheck = false;
-
 }


### PR DESCRIPTION
We used to have the package name and the version of `flask-restx` hardcoded in our nix package directives. With this change the correct metadata is read from the json file `flask-restx.json` that also serves as the source definition for fetchPypi.

No certs required.

Thank @Amittai-Aviram for catching a similar bug with `is_safe_url`. Your discovery gave me the idea to check `flask-restx` as well.