### PR TITLE
DatabaseGateway: Refactor update logic for email addresses

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -255,15 +255,7 @@ class MemberResult(QueryResult[Member], Protocol):
     def joined_with_email_address(self) -> QueryResult[Tuple[Member, EmailAddress]]:
         ...
 
-    def update(self) -> MemberUpdate:
-        """Prepare an update for all selected members."""
-
     def that_are_confirmed(self) -> MemberResult:
-        ...
-
-
-class MemberUpdate(DatabaseUpdate, Protocol):
-    def set_confirmation_timestamp(self, timestamp: datetime) -> MemberUpdate:
         ...
 
 
@@ -323,14 +315,6 @@ class CompanyResult(QueryResult[Company], Protocol):
         ...
 
     def joined_with_email_address(self) -> QueryResult[Tuple[Company, EmailAddress]]:
-        ...
-
-    def update(self) -> CompanyUpdate:
-        ...
-
-
-class CompanyUpdate(DatabaseUpdate, Protocol):
-    def set_confirmation_timestamp(self, timestamp: datetime) -> Self:
         ...
 
 
@@ -414,7 +398,16 @@ class CompanyWorkInviteResult(QueryResult[CompanyWorkInvite], Protocol):
 
 
 class EmailAddressResult(QueryResult[EmailAddress], Protocol):
-    ...
+    def with_address(self, *addresses: str) -> Self:
+        ...
+
+    def update(self) -> EmailAddressUpdate:
+        ...
+
+
+class EmailAddressUpdate(DatabaseUpdate, Protocol):
+    def set_confirmation_timestamp(self, timestamp: Optional[datetime]) -> Self:
+        ...
 
 
 class AccountRepository(ABC):
@@ -575,4 +568,12 @@ class DatabaseGateway(Protocol):
         ...
 
     def get_accountants(self) -> AccountantResult:
+        ...
+
+    def create_email_address(
+        self, *, address: str, confirmed_on: Optional[datetime]
+    ) -> EmailAddress:
+        ...
+
+    def get_email_addresses(self) -> EmailAddressResult:
         ...

--- a/arbeitszeit/use_cases/confirm_company.py
+++ b/arbeitszeit/use_cases/confirm_company.py
@@ -36,7 +36,7 @@ class ConfirmCompanyUseCase:
             )
         company, email = record
         if email.confirmed_on is None:
-            self.database.get_companies().with_email_address(
+            self.database.get_email_addresses().with_address(
                 request.email_address
             ).update().set_confirmation_timestamp(self.datetime_service.now()).perform()
             return self.Response(is_confirmed=True, user_id=company.id)

--- a/arbeitszeit/use_cases/confirm_member.py
+++ b/arbeitszeit/use_cases/confirm_member.py
@@ -26,7 +26,9 @@ class ConfirmMemberUseCase:
         if members.that_are_confirmed():
             pass
         else:
-            members.update().set_confirmation_timestamp(datetime.min).perform()
+            self.database.get_email_addresses().with_address(
+                request.email_address
+            ).update().set_confirmation_timestamp(datetime.min).perform()
             member = members.first()
             assert member
             return self.Response(is_confirmed=True, member=member.id)

--- a/arbeitszeit/use_cases/register_company.py
+++ b/arbeitszeit/use_cases/register_company.py
@@ -59,6 +59,8 @@ class RegisterCompany:
         labour_account = self.account_repository.create_account()
         products_account = self.account_repository.create_account()
         registered_on = self.datetime_service.now()
+        if not self.database.get_email_addresses().with_address(request.email):
+            self.database.create_email_address(address=request.email, confirmed_on=None)
         company = self.database.create_company(
             email=request.email,
             name=request.name,

--- a/arbeitszeit/use_cases/register_member.py
+++ b/arbeitszeit/use_cases/register_member.py
@@ -65,6 +65,8 @@ class RegisterMemberUseCase:
 
         member_account = self.account_repository.create_account()
         registered_on = self.datetime_service.now()
+        if not self.database.get_email_addresses().with_address(request.email):
+            self.database.create_email_address(address=request.email, confirmed_on=None)
         member = self.database.create_member(
             email=request.email,
             name=request.name,

--- a/tests/flask_integration/database_gateway_impl/test_email_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_email_result.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from ..flask import FlaskTestCase
+
+
+class EmailResultTests(FlaskTestCase):
+    def test_cannot_create_same_email_address_twice(self) -> None:
+        address = "test@test.test"
+        self.database_gateway.create_email_address(address=address, confirmed_on=None)
+        with pytest.raises(IntegrityError):
+            self.database_gateway.create_email_address(
+                address=address, confirmed_on=datetime.min
+            )

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -118,7 +118,7 @@ class ViewTestCase(FlaskTestCase):
 
     def login_company(
         self,
-        company: Optional[Company] = None,
+        company: Optional[UUID] = None,
         password: Optional[str] = None,
         email: Optional[str] = None,
         confirm_company: bool = True,
@@ -128,8 +128,8 @@ class ViewTestCase(FlaskTestCase):
         if email is None:
             email = self.email_generator.get_random_email()
         if company is None:
-            company = self.company_generator.create_company_entity(
-                password=password, email=email
+            company = self.company_generator.create_company(
+                password=password, email=email, confirmed=False
             )
         response = self.client.post(
             "/company/login",

--- a/tests/use_cases/test_list_workers.py
+++ b/tests/use_cases/test_list_workers.py
@@ -51,7 +51,7 @@ def test_list_workers_response_includes_single_company_worker(
     member_generator: MemberGenerator,
 ):
     worker: Member = member_generator.create_member_entity()
-    company: Company = company_generator.create_company_entity(workers=[worker])
+    company: Company = company_generator.create_company_entity(workers=[worker.id])
     response: ListWorkersResponse = list_workers(make_request(company=company.id))
     assert worker_in_results(worker, response)
 
@@ -65,7 +65,7 @@ def test_list_workers_response_includes_multiple_company_workers(
     worker1: Member = member_generator.create_member_entity()
     worker2: Member = member_generator.create_member_entity()
     company: Company = company_generator.create_company_entity(
-        workers=[worker1, worker2]
+        workers=[worker1.id, worker2.id]
     )
     response: ListWorkersResponse = list_workers(make_request(company=company.id))
     assert worker_in_results(worker1, response) and worker_in_results(worker2, response)

--- a/tests/use_cases/test_show_a_account_details.py
+++ b/tests/use_cases/test_show_a_account_details.py
@@ -186,7 +186,7 @@ def test_that_plotting_info_is_generated_after_transfer_of_work_certificates(
     transaction_generator: TransactionGenerator,
 ):
     worker = member_generator.create_member_entity()
-    own_company = company_generator.create_company_entity(workers=[worker])
+    own_company = company_generator.create_company_entity(workers=[worker.id])
 
     transaction_generator.create_transaction(
         sending_account=own_company.work_account,
@@ -209,7 +209,9 @@ def test_that_correct_plotting_info_is_generated_after_transferring_of_work_cert
 ):
     worker1 = member_generator.create_member_entity()
     worker2 = member_generator.create_member_entity()
-    own_company = company_generator.create_company_entity(workers=[worker1, worker2])
+    own_company = company_generator.create_company_entity(
+        workers=[worker1.id, worker2.id]
+    )
 
     trans1 = transaction_generator.create_transaction(
         sending_account=own_company.work_account,
@@ -249,7 +251,7 @@ def test_that_plotting_info_is_generated_in_the_correct_order_after_transfer_of_
     worker2 = member_generator.create_member_entity()
     worker3 = member_generator.create_member_entity()
     own_company = company_generator.create_company_entity(
-        workers=[worker1, worker2, worker3]
+        workers=[worker1.id, worker2.id, worker3.id]
     )
 
     trans1 = transaction_generator.create_transaction(


### PR DESCRIPTION
This change moves the update logic for email addresses in the DB to the newly created EmailAddressUpdate interface. All use cases were updated accordingly.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (3x)