### PR TITLE
tests: Refactor test_get_company_transactions.py

### DIFF
--- a/tests/use_cases/test_get_company_transactions.py
+++ b/tests/use_cases/test_get_company_transactions.py
@@ -1,274 +1,193 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-from arbeitszeit.entities import AccountTypes, SocialAccounting
+from arbeitszeit.entities import AccountTypes, ProductionCosts
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.get_company_transactions import GetCompanyTransactions
-from tests.data_generators import (
-    CompanyGenerator,
-    FakeDatetimeService,
-    MemberGenerator,
-    TransactionGenerator,
-)
+from arbeitszeit.use_cases.update_plans_and_payout import UpdatePlansAndPayout
 
-from .dependency_injection import injection_test
+from .base_test_case import BaseTestCase
 
 
-@injection_test
-def test_that_no_info_is_generated_when_no_transaction_took_place(
-    get_company_transactions: GetCompanyTransactions,
-    member_generator: MemberGenerator,
-    company_generator: CompanyGenerator,
-):
-    member_generator.create_member()
-    company = company_generator.create_company_entity()
+class GetCompanyTransactionsUseCase(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.get_company_transactions = self.injector.get(GetCompanyTransactions)
+        self.update_plans_and_payout = self.injector.get(UpdatePlansAndPayout)
 
-    info = get_company_transactions(company.id)
-    assert not info.transactions
+    def test_that_no_info_is_generated_when_no_transaction_took_place(self) -> None:
+        company = self.company_generator.create_company()
+        info = self.get_company_transactions(company)
+        assert not info.transactions
 
+    def test_that_correct_info_is_generated_after_transaction_of_member_buying_consumer_product(
+        self,
+    ) -> None:
+        self.control_thresholds.set_allowed_overdraw_of_member_account(10)
+        company = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            planner=company,
+            costs=ProductionCosts(
+                labour_cost=Decimal(1),
+                resource_cost=Decimal(1),
+                means_cost=Decimal(1),
+            ),
+            amount=1,
+        )
+        info_company = self.get_company_transactions(company)
+        transactions_before = len(info_company.transactions)
+        self.purchase_generator.create_purchase_by_member(plan=plan.id, amount=1)
+        info_company = self.get_company_transactions(company)
+        assert len(info_company.transactions) == transactions_before + 1
+        transaction = info_company.transactions[0]
+        assert type(transaction.date) == datetime
+        assert transaction.transaction_type == TransactionTypes.sale_of_consumer_product
+        assert transaction.transaction_volume == Decimal(3)
+        assert transaction.account_type == AccountTypes.prd
 
-@injection_test
-def test_that_correct_info_is_generated_after_transaction_of_member_buying_consumer_product(
-    get_company_transactions: GetCompanyTransactions,
-    member_generator: MemberGenerator,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-):
-    member = member_generator.create_member_entity()
-    company = company_generator.create_company_entity()
+    def test_that_correct_info_for_sender_is_generated_after_transaction_of_company_buying_p(
+        self,
+    ) -> None:
+        company1 = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            amount=1,
+            costs=ProductionCosts(
+                labour_cost=Decimal(12),
+                resource_cost=Decimal(0),
+                means_cost=Decimal(0),
+            ),
+        )
+        self.purchase_generator.create_fixed_means_purchase(
+            buyer=company1, plan=plan.id
+        )
+        info_sender = self.get_company_transactions(company1)
+        transaction = info_sender.transactions[0]
+        assert transaction.transaction_type == TransactionTypes.payment_of_fixed_means
+        assert transaction.transaction_volume == Decimal(-12)
+        assert transaction.account_type == AccountTypes.p
 
-    transaction_generator.create_transaction(
-        sending_account=member.account,
-        receiving_account=company.product_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
+    def test_that_correct_info_for_receiver_is_generated_after_transaction_of_company_buying_p(
+        self,
+    ) -> None:
+        company1 = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            planner=company1,
+            costs=ProductionCosts(
+                labour_cost=Decimal("12.5"),
+                means_cost=Decimal(0),
+                resource_cost=Decimal(0),
+            ),
+            amount=1,
+        )
+        self.purchase_generator.create_fixed_means_purchase(plan=plan.id)
+        info_receiver = self.get_company_transactions(company1)
+        transaction = info_receiver.transactions[0]
+        assert transaction.transaction_type == TransactionTypes.sale_of_fixed_means
+        assert transaction.transaction_volume == Decimal("12.5")
+        assert transaction.account_type == AccountTypes.prd
 
-    info_company = get_company_transactions(company.id)
-    assert len(info_company.transactions) == 1
-    transaction = info_company.transactions[0]
-    assert type(transaction.date) == datetime
-    assert transaction.transaction_type == TransactionTypes.sale_of_consumer_product
-    assert transaction.transaction_volume == Decimal(8.5)
-    assert transaction.account_type == AccountTypes.prd
+    def test_that_correct_info_for_company_is_generated_after_transaction_where_credit_for_p_is_granted(
+        self,
+    ) -> None:
+        expected_p_amount = Decimal(4)
+        expected_r_amount = Decimal(7)
+        expected_prd_amount = Decimal(-15)
+        company = self.company_generator.create_company()
+        self.plan_generator.create_plan(
+            planner=company,
+            costs=ProductionCosts(
+                means_cost=expected_p_amount,
+                resource_cost=expected_r_amount,
+                labour_cost=Decimal(4),
+            ),
+        )
+        info_receiver = self.get_company_transactions(company)
+        assert len(info_receiver.transactions) == 3
+        transaction_volumes = [t.transaction_volume for t in info_receiver.transactions]
+        assert expected_p_amount in transaction_volumes
+        assert expected_r_amount in transaction_volumes
+        assert expected_prd_amount in transaction_volumes
+        transaction_purposes = [t.transaction_type for t in info_receiver.transactions]
+        assert TransactionTypes.credit_for_fixed_means in transaction_purposes
+        assert TransactionTypes.credit_for_liquid_means in transaction_purposes
+        assert TransactionTypes.expected_sales in transaction_purposes
 
+    def test_that_correct_info_for_company_is_generated_after_transaction_where_credit_for_a_is_granted(
+        self,
+    ) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        company = self.company_generator.create_company()
+        self.plan_generator.create_plan(
+            planner=company,
+            costs=ProductionCosts(
+                labour_cost=Decimal(10),
+                means_cost=Decimal(0),
+                resource_cost=Decimal(0),
+            ),
+            timeframe=1,
+        )
+        self.datetime_service.advance_time(timedelta(days=1))
+        self.update_plans_and_payout()
+        info_receiver = self.get_company_transactions(company)
+        assert info_receiver.transactions[0].transaction_volume == Decimal(10)
+        assert (
+            info_receiver.transactions[0].transaction_type
+            == TransactionTypes.credit_for_wages
+        )
 
-@injection_test
-def test_that_correct_info_for_sender_is_generated_after_transaction_of_company_buying_p(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-):
-    company1 = company_generator.create_company_entity()
-    company2 = company_generator.create_company_entity()
+    def test_correct_info_is_generated_after_several_transactions_where_companies_buy_each_others_product(
+        self,
+    ) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        company1 = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=company1)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_fixed_means_purchase(
+            buyer=company1,
+        )
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_fixed_means_purchase(
+            plan=plan.id,
+        )
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_resource_purchase_by_company(
+            buyer=company1,
+        )
+        self.datetime_service.advance_time(timedelta(hours=1))
+        info_company1 = self.get_company_transactions(company1)
+        trans1 = info_company1.transactions[2]
+        assert trans1.transaction_type == TransactionTypes.payment_of_fixed_means
+        trans2 = info_company1.transactions[1]
+        assert trans2.transaction_type == TransactionTypes.sale_of_fixed_means
+        trans3 = info_company1.transactions[0]
+        assert trans3.transaction_type == TransactionTypes.payment_of_liquid_means
 
-    trans = transaction_generator.create_transaction(
-        sending_account=company1.means_account,
-        receiving_account=company2.product_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    info_sender = get_company_transactions(company1.id)
-    transaction = info_sender.transactions[0]
-    assert transaction.transaction_type == TransactionTypes.payment_of_fixed_means
-    assert transaction.transaction_volume == -trans.amount_sent
-    assert transaction.account_type == AccountTypes.p
-
-
-@injection_test
-def test_that_correct_info_for_receiver_is_generated_after_transaction_of_company_buying_p(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-):
-    company1 = company_generator.create_company_entity()
-    company2 = company_generator.create_company_entity()
-
-    trans = transaction_generator.create_transaction(
-        sending_account=company1.means_account,
-        receiving_account=company2.product_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    info_receiver = get_company_transactions(company2.id)
-    transaction = info_receiver.transactions[0]
-    assert transaction.transaction_type == TransactionTypes.sale_of_fixed_means
-    assert transaction.transaction_volume == trans.amount_received
-    assert transaction.account_type == AccountTypes.prd
-
-
-@injection_test
-def test_that_correct_info_for_company_is_generated_after_transaction_where_credit_for_p_is_granted(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
-):
-    company = company_generator.create_company_entity()
-
-    trans = transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.means_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    info_receiver = get_company_transactions(company.id)
-    assert info_receiver.transactions[0].transaction_volume == trans.amount_received
-    assert (
-        info_receiver.transactions[0].transaction_type
-        == TransactionTypes.credit_for_fixed_means
-    )
-
-
-@injection_test
-def test_that_correct_info_for_company_is_generated_after_transaction_where_credit_for_r_is_granted(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
-):
-    company = company_generator.create_company_entity()
-
-    trans = transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.raw_material_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    info_receiver = get_company_transactions(company.id)
-    assert info_receiver.transactions[0].transaction_volume == trans.amount_received
-    assert (
-        info_receiver.transactions[0].transaction_type
-        == TransactionTypes.credit_for_liquid_means
-    )
-
-
-@injection_test
-def test_that_correct_info_for_company_is_generated_after_transaction_where_credit_for_a_is_granted(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
-):
-    company = company_generator.create_company_entity()
-
-    trans = transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.work_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    info_receiver = get_company_transactions(company.id)
-    assert info_receiver.transactions[0].transaction_volume == trans.amount_received
-    assert (
-        info_receiver.transactions[0].transaction_type
-        == TransactionTypes.credit_for_wages
-    )
-
-
-@injection_test
-def test_correct_info_is_generated_after_several_transactions_where_companies_buy_each_others_product(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    datetime_service: FakeDatetimeService,
-):
-    company1 = company_generator.create_company_entity()
-    company2 = company_generator.create_company_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=company1.means_account,
-        receiving_account=company2.product_account,
-        date=datetime_service.now() - timedelta(hours=3),
-    )
-    transaction_generator.create_transaction(
-        sending_account=company2.means_account,
-        receiving_account=company1.product_account,
-        date=datetime_service.now() - timedelta(hours=2),
-    )
-    transaction_generator.create_transaction(
-        sending_account=company1.raw_material_account,
-        receiving_account=company2.product_account,
-        date=datetime_service.now() - timedelta(hours=1),
-    )
-
-    info_company1 = get_company_transactions(company1.id)
-    assert len(info_company1.transactions) == 3
-
-    trans1 = info_company1.transactions.pop()
-    assert trans1.transaction_type == TransactionTypes.payment_of_fixed_means
-
-    trans2 = info_company1.transactions.pop()
-    assert trans2.transaction_type == TransactionTypes.sale_of_fixed_means
-
-    trans3 = info_company1.transactions.pop()
-    assert trans3.transaction_type == TransactionTypes.payment_of_liquid_means
-
-
-@injection_test
-def test_that_correct_info_for_company_is_generated_in_correct_order_after_several_transactions_of_different_kind(
-    get_company_transactions: GetCompanyTransactions,
-    company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    member_generator: MemberGenerator,
-    social_accounting: SocialAccounting,
-    datetime_service: FakeDatetimeService,
-):
-    company1 = company_generator.create_company_entity()
-    company2 = company_generator.create_company_entity()
-    member = member_generator.create_member_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=company1.means_account,
-        receiving_account=company2.product_account,
-        date=datetime_service.now() - timedelta(hours=5),
-    )
-    transaction_generator.create_transaction(
-        sending_account=company2.means_account,
-        receiving_account=company1.product_account,
-        date=datetime_service.now() - timedelta(hours=4),
-    )
-    transaction_generator.create_transaction(
-        sending_account=company1.raw_material_account,
-        receiving_account=company2.product_account,
-        date=datetime_service.now() - timedelta(hours=3),
-    )
-    transaction_generator.create_transaction(
-        sending_account=member.account,
-        receiving_account=company1.product_account,
-        date=datetime_service.now() - timedelta(hours=2),
-    )
-    expected_trans5 = transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company1.product_account,
-        date=datetime_service.now() - timedelta(hours=1),
-    )
-
-    info = get_company_transactions(company1.id)
-    assert len(info.transactions) == 5
-
-    # trans1
-    trans1 = info.transactions.pop()
-    assert trans1.transaction_type == TransactionTypes.payment_of_fixed_means
-
-    # trans2
-    trans2 = info.transactions.pop()
-    assert trans2.transaction_type == TransactionTypes.sale_of_fixed_means
-
-    # trans3
-    trans3 = info.transactions.pop()
-    assert trans3.transaction_type == TransactionTypes.payment_of_liquid_means
-
-    # trans4
-    trans4 = info.transactions.pop()
-    assert trans4.transaction_type == TransactionTypes.sale_of_consumer_product
-
-    # trans5
-    trans5 = info.transactions.pop()
-    assert trans5.transaction_type == TransactionTypes.expected_sales
-    assert trans5.transaction_volume == expected_trans5.amount_received
+    def test_that_correct_info_for_company_is_generated_in_correct_order_after_several_transactions_of_different_kind(
+        self,
+    ) -> None:
+        self.control_thresholds.set_allowed_overdraw_of_member_account(100)
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        company1 = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=company1)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_fixed_means_purchase(buyer=company1)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_fixed_means_purchase(plan=plan.id)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_resource_purchase_by_company(buyer=company1)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        self.purchase_generator.create_purchase_by_member(plan=plan.id)
+        self.datetime_service.advance_time(timedelta(hours=1))
+        info = self.get_company_transactions(company1)
+        # trans1
+        trans1 = info.transactions[3]
+        assert trans1.transaction_type == TransactionTypes.payment_of_fixed_means
+        # trans2
+        trans2 = info.transactions[2]
+        assert trans2.transaction_type == TransactionTypes.sale_of_fixed_means
+        # trans3
+        trans3 = info.transactions[1]
+        assert trans3.transaction_type == TransactionTypes.payment_of_liquid_means
+        # trans4
+        trans4 = info.transactions[0]
+        assert trans4.transaction_type == TransactionTypes.sale_of_consumer_product


### PR DESCRIPTION
The use case tests for GetCompanyTransactions were not conforming to our standard test suite layout. Current development standards require tests to be based on the pythons unittest.TestCase class. The tests in tests/use_cases/test_get_company_transactions.py were instead based on pytests function based approach. Now they are class based.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf