### PR TITLE
Remove PlanDraftRespository

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -424,27 +424,6 @@ class AccountRepository(ABC):
         pass
 
 
-class PlanDraftRepository(ABC):
-    @abstractmethod
-    def create_plan_draft(
-        self,
-        planner: UUID,
-        product_name: str,
-        description: str,
-        costs: ProductionCosts,
-        production_unit: str,
-        amount: int,
-        timeframe_in_days: int,
-        is_public_service: bool,
-        creation_timestamp: datetime,
-    ) -> PlanDraft:
-        pass
-
-    @abstractmethod
-    def get_plan_drafts(self) -> PlanDraftResult:
-        pass
-
-
 class LanguageRepository(Protocol):
     def get_available_language_codes(self) -> Iterable[str]:
         ...
@@ -576,4 +555,21 @@ class DatabaseGateway(Protocol):
         ...
 
     def get_email_addresses(self) -> EmailAddressResult:
+        ...
+
+    def create_plan_draft(
+        self,
+        planner: UUID,
+        product_name: str,
+        description: str,
+        costs: ProductionCosts,
+        production_unit: str,
+        amount: int,
+        timeframe_in_days: int,
+        is_public_service: bool,
+        creation_timestamp: datetime,
+    ) -> PlanDraft:
+        ...
+
+    def get_plan_drafts(self) -> PlanDraftResult:
         ...

--- a/arbeitszeit/use_cases/create_plan_draft.py
+++ b/arbeitszeit/use_cases/create_plan_draft.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.repositories import DatabaseGateway, PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -36,7 +36,6 @@ class CreatePlanDraftResponse:
 
 @dataclass
 class CreatePlanDraft:
-    plan_draft_repository: PlanDraftRepository
     database: DatabaseGateway
     datetime_service: DatetimeService
 
@@ -58,7 +57,7 @@ class CreatePlanDraft:
                 rejection_reason=CreatePlanDraftResponse.RejectionReason.planner_does_not_exist,
             )
 
-        draft = self.plan_draft_repository.create_plan_draft(
+        draft = self.database.create_plan_draft(
             planner=request.planner,
             costs=request.costs,
             product_name=request.product_name,

--- a/arbeitszeit/use_cases/delete_draft.py
+++ b/arbeitszeit/use_cases/delete_draft.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from arbeitszeit.repositories import DatabaseGateway, PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -19,11 +19,10 @@ class DeleteDraftUseCase:
         pass
 
     database: DatabaseGateway
-    draft_repository: PlanDraftRepository
 
     def delete_draft(self, request: Request) -> Response:
         deleter = self.database.get_companies().with_id(request.deleter).first()
-        draft_query = self.draft_repository.get_plan_drafts().with_id(request.draft)
+        draft_query = self.database.get_plan_drafts().with_id(request.draft)
         draft = draft_query.first()
         if not draft or not deleter:
             raise self.Failure()

--- a/arbeitszeit/use_cases/edit_draft.py
+++ b/arbeitszeit/use_cases/edit_draft.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from arbeitszeit.repositories import PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -26,20 +26,14 @@ class EditDraftUseCase:
     class Response:
         is_success: bool
 
-    draft_repository: PlanDraftRepository
+    database: DatabaseGateway
 
     def edit_draft(self, request: Request) -> Response:
         if (
-            (
-                draft := self.draft_repository.get_plan_drafts()
-                .with_id(request.draft)
-                .first()
-            )
+            (draft := self.database.get_plan_drafts().with_id(request.draft).first())
             is not None
         ) and draft.planner == request.editor:
-            update = (
-                self.draft_repository.get_plan_drafts().with_id(request.draft).update()
-            )
+            update = self.database.get_plan_drafts().with_id(request.draft).update()
             if request.product_name is not None:
                 update = update.set_product_name(request.product_name)
             if request.amount is not None:

--- a/arbeitszeit/use_cases/file_plan_with_accounting.py
+++ b/arbeitszeit/use_cases/file_plan_with_accounting.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from arbeitszeit.accountant_notifications import AccountantNotifier
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.repositories import DatabaseGateway, PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -21,13 +21,12 @@ class FilePlanWithAccounting:
         is_plan_successfully_filed: bool
         plan_id: Optional[UUID]
 
-    draft_repository: PlanDraftRepository
     database_gateway: DatabaseGateway
     datetime_service: DatetimeService
     accountant_notifier: AccountantNotifier
 
     def file_plan_with_accounting(self, request: Request) -> Response:
-        draft_query = self.draft_repository.get_plan_drafts().with_id(request.draft_id)
+        draft_query = self.database_gateway.get_plan_drafts().with_id(request.draft_id)
         draft = draft_query.first()
         if draft is not None and draft.planner == request.filing_company:
             plan = self.database_gateway.create_plan(

--- a/arbeitszeit/use_cases/get_draft_summary.py
+++ b/arbeitszeit/use_cases/get_draft_summary.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from arbeitszeit.repositories import PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -26,10 +26,10 @@ DraftSummaryResponse = Optional[DraftSummarySuccess]
 
 @dataclass
 class GetDraftSummary:
-    draft_repository: PlanDraftRepository
+    database: DatabaseGateway
 
     def __call__(self, draft_id: UUID) -> DraftSummaryResponse:
-        draft = self.draft_repository.get_plan_drafts().with_id(draft_id).first()
+        draft = self.database.get_plan_drafts().with_id(draft_id).first()
         if draft is None:
             return None
         return DraftSummarySuccess(

--- a/arbeitszeit/use_cases/show_my_plans.py
+++ b/arbeitszeit/use_cases/show_my_plans.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import Plan, PlanDraft
 from arbeitszeit.price_calculator import PriceCalculator
-from arbeitszeit.repositories import DatabaseGateway, PlanDraftRepository
+from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
@@ -41,7 +41,6 @@ class ShowMyPlansResponse:
 @dataclass
 class ShowMyPlansUseCase:
     database_gateway: DatabaseGateway
-    draft_repository: PlanDraftRepository
     price_calculator: PriceCalculator
     datetime_service: DatetimeService
 
@@ -56,7 +55,7 @@ class ShowMyPlansUseCase:
         drafts = list(
             map(
                 self._create_plan_info_from_draft,
-                self.draft_repository.get_plan_drafts().planned_by(request.company_id),
+                self.database_gateway.get_plan_drafts().planned_by(request.company_id),
             )
         )
         drafts.sort(key=lambda x: x.plan_creation_date, reverse=True)

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -1151,66 +1151,6 @@ class AccountingRepository:
 
 
 @dataclass
-class PlanDraftRepository(repositories.PlanDraftRepository):
-    db: SQLAlchemy
-
-    def create_plan_draft(
-        self,
-        planner: UUID,
-        product_name: str,
-        description: str,
-        costs: entities.ProductionCosts,
-        production_unit: str,
-        amount: int,
-        timeframe_in_days: int,
-        is_public_service: bool,
-        creation_timestamp: datetime,
-    ) -> entities.PlanDraft:
-        orm = PlanDraft(
-            id=str(uuid4()),
-            plan_creation_date=creation_timestamp,
-            planner=str(planner),
-            costs_p=costs.means_cost,
-            costs_r=costs.resource_cost,
-            costs_a=costs.labour_cost,
-            prd_name=product_name,
-            prd_unit=production_unit,
-            prd_amount=amount,
-            description=description,
-            timeframe=timeframe_in_days,
-            is_public_service=is_public_service,
-        )
-        self.db.session.add(orm)
-        return self.plan_draft_from_orm(orm)
-
-    def get_plan_drafts(self) -> PlanDraftResult:
-        return PlanDraftResult(
-            db=self.db,
-            query=models.PlanDraft.query,
-            mapper=self.plan_draft_from_orm,
-        )
-
-    @classmethod
-    def plan_draft_from_orm(cls, orm: models.PlanDraft) -> entities.PlanDraft:
-        return entities.PlanDraft(
-            id=orm.id,
-            creation_date=orm.plan_creation_date,
-            planner=UUID(orm.planner),
-            production_costs=entities.ProductionCosts(
-                labour_cost=orm.costs_a,
-                resource_cost=orm.costs_r,
-                means_cost=orm.costs_p,
-            ),
-            product_name=orm.prd_name,
-            unit_of_distribution=orm.prd_unit,
-            amount_produced=orm.prd_amount,
-            description=orm.description,
-            timeframe=int(orm.timeframe),
-            is_public_service=orm.is_public_service,
-        )
-
-
-@dataclass
 class DatabaseGatewayImpl:
     db: SQLAlchemy
 
@@ -1654,3 +1594,58 @@ class DatabaseGatewayImpl:
         self.db.session.add(orm)
         self.db.session.flush()
         return self.email_address_from_orm(orm)
+
+    def create_plan_draft(
+        self,
+        planner: UUID,
+        product_name: str,
+        description: str,
+        costs: entities.ProductionCosts,
+        production_unit: str,
+        amount: int,
+        timeframe_in_days: int,
+        is_public_service: bool,
+        creation_timestamp: datetime,
+    ) -> entities.PlanDraft:
+        orm = PlanDraft(
+            id=str(uuid4()),
+            plan_creation_date=creation_timestamp,
+            planner=str(planner),
+            costs_p=costs.means_cost,
+            costs_r=costs.resource_cost,
+            costs_a=costs.labour_cost,
+            prd_name=product_name,
+            prd_unit=production_unit,
+            prd_amount=amount,
+            description=description,
+            timeframe=timeframe_in_days,
+            is_public_service=is_public_service,
+        )
+        self.db.session.add(orm)
+        return self.plan_draft_from_orm(orm)
+
+    def get_plan_drafts(self) -> PlanDraftResult:
+        return PlanDraftResult(
+            db=self.db,
+            query=models.PlanDraft.query,
+            mapper=self.plan_draft_from_orm,
+        )
+
+    @classmethod
+    def plan_draft_from_orm(cls, orm: models.PlanDraft) -> entities.PlanDraft:
+        return entities.PlanDraft(
+            id=orm.id,
+            creation_date=orm.plan_creation_date,
+            planner=UUID(orm.planner),
+            production_costs=entities.ProductionCosts(
+                labour_cost=orm.costs_a,
+                resource_cost=orm.costs_r,
+                means_cost=orm.costs_p,
+            ),
+            product_name=orm.prd_name,
+            unit_of_distribution=orm.prd_unit,
+            amount_produced=orm.prd_amount,
+            description=orm.description,
+            timeframe=int(orm.timeframe),
+            is_public_service=orm.is_public_service,
+        )

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -26,7 +26,6 @@ from arbeitszeit_flask.database import get_social_accounting
 from arbeitszeit_flask.database.repositories import (
     AccountRepository,
     DatabaseGatewayImpl,
-    PlanDraftRepository,
     UserAddressBookImpl,
 )
 from arbeitszeit_flask.datetime import RealtimeDatetimeService
@@ -119,10 +118,6 @@ class FlaskModule(Module):
         binder.bind(
             interfaces.AccountRepository,  # type: ignore
             to=AliasProvider(AccountRepository),
-        )
-        binder.bind(
-            interfaces.PlanDraftRepository,  # type: ignore
-            to=AliasProvider(PlanDraftRepository),
         )
         binder.bind(
             DatetimeService,  # type: ignore

--- a/tests/flask_integration/database_gateway_impl/test_plan_draft_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_draft_result.py
@@ -4,11 +4,10 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from arbeitszeit.entities import PlanDraft, ProductionCosts
-from arbeitszeit_flask.database.repositories import PlanDraftRepository
 from tests.data_generators import CompanyGenerator
 from tests.datetime_service import FakeDatetimeService
 
-from .flask import FlaskTestCase
+from ..flask import FlaskTestCase
 
 DEFAULT_COST = ProductionCosts(
     labour_cost=Decimal(1),
@@ -20,7 +19,6 @@ DEFAULT_COST = ProductionCosts(
 class PlanDraftRepositoryBaseTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.repo = self.injector.get(PlanDraftRepository)
         self.company_generator = self.injector.get(CompanyGenerator)
         self.planner = self.company_generator.create_company_entity()
         self.datetime_service = self.injector.get(FakeDatetimeService)
@@ -41,7 +39,7 @@ class PlanDraftRepositoryBaseTests(FlaskTestCase):
             planner = self.planner.id
         if creation_timestamp is None:
             creation_timestamp = self.datetime_service.now()
-        return self.repo.create_plan_draft(
+        return self.database_gateway.create_plan_draft(
             planner=planner,
             product_name=product_name,
             description=description,
@@ -56,14 +54,14 @@ class PlanDraftRepositoryBaseTests(FlaskTestCase):
 
 class PlanDraftRepositoryTests(PlanDraftRepositoryBaseTests):
     def test_plan_draft_repository(self) -> None:
-        draft = self.repo.get_plan_drafts().with_id(uuid4()).first()
+        draft = self.database_gateway.get_plan_drafts().with_id(uuid4()).first()
         assert draft is None
 
     def test_created_drafts_can_be_retrieved_by_their_id(self) -> None:
         expected_draft = self.create_plan_draft()
         self.assertEqual(
             expected_draft,
-            self.repo.get_plan_drafts().with_id(expected_draft.id).first(),
+            self.database_gateway.get_plan_drafts().with_id(expected_draft.id).first(),
         )
 
     def test_created_draft_name_specified_on_creation(self) -> None:
@@ -116,37 +114,39 @@ class PlanDraftRepositoryTests(PlanDraftRepositoryBaseTests):
 
     def test_deleted_drafts_cannot_be_retrieved_anymore(self) -> None:
         draft = self.create_plan_draft()
-        self.repo.get_plan_drafts().with_id(draft.id).delete()
-        self.assertIsNone(self.repo.get_plan_drafts().with_id(draft.id).first())
+        self.database_gateway.get_plan_drafts().with_id(draft.id).delete()
+        self.assertIsNone(
+            self.database_gateway.get_plan_drafts().with_id(draft.id).first()
+        )
 
     def test_that_deletion_of_one_plan_returns_1_if_plan_existed(self) -> None:
         draft = self.create_plan_draft()
-        assert self.repo.get_plan_drafts().with_id(draft.id).delete() == 1
+        assert self.database_gateway.get_plan_drafts().with_id(draft.id).delete() == 1
 
     def test_that_deletion_of_non_existing_plan_returns_0(self) -> None:
-        assert self.repo.get_plan_drafts().with_id(uuid4()).delete() == 0
+        assert self.database_gateway.get_plan_drafts().with_id(uuid4()).delete() == 0
 
     def test_all_drafts_can_be_retrieved(self) -> None:
         expected_draft1 = self.create_plan_draft()
         expected_draft2 = self.create_plan_draft()
-        drafts = self.repo.get_plan_drafts().planned_by(self.planner.id)
+        drafts = self.database_gateway.get_plan_drafts().planned_by(self.planner.id)
         self.assertIn(expected_draft1, drafts)
         self.assertIn(expected_draft2, drafts)
 
     def test_that_nothing_is_returned_when_repo_is_empty_and_querying_all_drafts(
         self,
     ) -> None:
-        assert not self.repo.get_plan_drafts().planned_by(self.planner.id)
+        assert not self.database_gateway.get_plan_drafts().planned_by(self.planner.id)
 
 
 class PlanDraftUpdateTests(PlanDraftRepositoryBaseTests):
     def test_can_change_the_product_name(self) -> None:
         self.create_plan_draft()
         expected_product_name = "test product name new"
-        self.repo.get_plan_drafts().update().set_product_name(
+        self.database_gateway.get_plan_drafts().update().set_product_name(
             expected_product_name
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.product_name == expected_product_name
 
@@ -156,10 +156,10 @@ class PlanDraftUpdateTests(PlanDraftRepositoryBaseTests):
         draft = self.create_plan_draft()
         expected_product_name = "product_name_of_other_draft"
         other_draft = self.create_plan_draft(product_name=expected_product_name)
-        self.repo.get_plan_drafts().with_id(draft.id).update().set_product_name(
-            "changed product name"
-        ).perform()
-        other_draft = self.repo.get_plan_drafts().with_id(other_draft.id).first()  # type: ignore
+        self.database_gateway.get_plan_drafts().with_id(
+            draft.id
+        ).update().set_product_name("changed product name").perform()
+        other_draft = self.database_gateway.get_plan_drafts().with_id(other_draft.id).first()  # type: ignore
         assert other_draft.product_name == expected_product_name
 
     def test_that_product_name_is_not_changed_without_calling_perform(
@@ -167,8 +167,10 @@ class PlanDraftUpdateTests(PlanDraftRepositoryBaseTests):
     ) -> None:
         expected_product_name = "test product name new"
         self.create_plan_draft(product_name=expected_product_name)
-        self.repo.get_plan_drafts().update().set_product_name("changed product name")
-        changed_draft = self.repo.get_plan_drafts().first()
+        self.database_gateway.get_plan_drafts().update().set_product_name(
+            "changed product name"
+        )
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.product_name == expected_product_name
 
@@ -177,15 +179,17 @@ class PlanDraftUpdateTests(PlanDraftRepositoryBaseTests):
     ) -> None:
         self.create_plan_draft()
         expected_product_name = "test product name new"
-        update = self.repo.get_plan_drafts().update()
+        update = self.database_gateway.get_plan_drafts().update()
         update.set_product_name(expected_product_name)
         update.perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.product_name != expected_product_name
 
     def test_that_affected_rows_are_returned(self) -> None:
-        update = self.repo.get_plan_drafts().update().set_product_name("bla")
+        update = (
+            self.database_gateway.get_plan_drafts().update().set_product_name("bla")
+        )
         assert update.perform() == 0
         self.create_plan_draft()
         assert update.perform() == 1
@@ -193,75 +197,79 @@ class PlanDraftUpdateTests(PlanDraftRepositoryBaseTests):
     def test_can_update_amount(self) -> None:
         self.create_plan_draft()
         expected_amount = 1234
-        self.repo.get_plan_drafts().update().set_amount(expected_amount).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        self.database_gateway.get_plan_drafts().update().set_amount(
+            expected_amount
+        ).perform()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.amount_produced == expected_amount
 
     def test_can_update_description(self) -> None:
         self.create_plan_draft()
         expected_description = "bla bla bla"
-        self.repo.get_plan_drafts().update().set_description(
+        self.database_gateway.get_plan_drafts().update().set_description(
             expected_description
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.description == expected_description
 
     def test_can_update_labour_cost(self) -> None:
         self.create_plan_draft()
         expected_labour_cost = Decimal("1.234")
-        self.repo.get_plan_drafts().update().set_labour_cost(
+        self.database_gateway.get_plan_drafts().update().set_labour_cost(
             expected_labour_cost
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.production_costs.labour_cost == expected_labour_cost
 
     def test_can_update_means_cost(self) -> None:
         self.create_plan_draft()
         expected_means_cost = Decimal("1.234")
-        self.repo.get_plan_drafts().update().set_means_cost(
+        self.database_gateway.get_plan_drafts().update().set_means_cost(
             expected_means_cost
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.production_costs.means_cost == expected_means_cost
 
     def test_can_update_resource_cost(self) -> None:
         self.create_plan_draft()
         expected_resource_cost = Decimal("1.234")
-        self.repo.get_plan_drafts().update().set_resource_cost(
+        self.database_gateway.get_plan_drafts().update().set_resource_cost(
             expected_resource_cost
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.production_costs.resource_cost == expected_resource_cost
 
     def test_can_update_is_public_service(self) -> None:
         self.create_plan_draft(is_public_service=True)
         expected_is_public_service = False
-        self.repo.get_plan_drafts().update().set_is_public_service(
+        self.database_gateway.get_plan_drafts().update().set_is_public_service(
             expected_is_public_service
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.is_public_service == expected_is_public_service
 
     def test_can_update_timeframe(self) -> None:
         self.create_plan_draft()
         expected_timeframe = 43
-        self.repo.get_plan_drafts().update().set_timeframe(expected_timeframe).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        self.database_gateway.get_plan_drafts().update().set_timeframe(
+            expected_timeframe
+        ).perform()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.timeframe == expected_timeframe
 
     def test_can_update_unit_of_distribution(self) -> None:
         self.create_plan_draft()
         expected_unit_of_distribution = "bla unit bla"
-        self.repo.get_plan_drafts().update().set_unit_of_distribution(
+        self.database_gateway.get_plan_drafts().update().set_unit_of_distribution(
             expected_unit_of_distribution
         ).perform()
-        changed_draft = self.repo.get_plan_drafts().first()
+        changed_draft = self.database_gateway.get_plan_drafts().first()
         assert changed_draft
         assert changed_draft.unit_of_distribution == expected_unit_of_distribution

--- a/tests/flask_integration/test_create_draft_view.py
+++ b/tests/flask_integration/test_create_draft_view.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Dict
 
-from arbeitszeit.repositories import PlanDraftRepository
+from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
 from tests.data_generators import PlanGenerator
 from tests.request import FakeRequest
 
@@ -34,9 +34,9 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.plan_generator = self.injector.get(PlanGenerator)
-        self.plan_draft_repository = self.injector.get(PlanDraftRepository)  # type: ignore
         self.form = self.injector.get(FakeRequest)
         self.company = self.login_company()
+        self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
 
     def test_post_user_canceling_leads_to_302_and_no_draft_gets_created(self) -> None:
         test_data = self._create_form_data()
@@ -69,6 +69,6 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
         )
 
     def _count_drafts_of_company(self) -> int:
-        return len(
-            self.plan_draft_repository.get_plan_drafts().planned_by(self.company.id)
-        )
+        request = ShowMyPlansRequest(company_id=self.company.id)
+        response = self.show_my_plans.show_company_plans(request)
+        return len(response.drafts)

--- a/tests/flask_integration/test_delete_draft_view.py
+++ b/tests/flask_integration/test_delete_draft_view.py
@@ -13,7 +13,7 @@ class DeleteDraftViewTests(ViewTestCase):
     def test_get_405_when_getting_url_as_company(self) -> None:
         company = self.login_company()
         draft = self.plan_generator.draft_plan(planner=company.id)
-        response = self.client.get(self.get_url(draft.id))
+        response = self.client.get(self.get_url(draft))
         self.assertEqual(response.status_code, 405)
 
     def test_get_404_when_posting_url_as_company_for_non_existing_draft(self) -> None:
@@ -24,14 +24,14 @@ class DeleteDraftViewTests(ViewTestCase):
     def test_get_302_when_posting_url_as_company_for_existing_draft(self) -> None:
         company = self.login_company()
         draft = self.plan_generator.draft_plan(planner=company.id)
-        response = self.client.post(self.get_url(draft.id))
+        response = self.client.post(self.get_url(draft))
         self.assertEqual(response.status_code, 302)
 
     def test_get_404_when_posting_draft_twice_as_company(self) -> None:
         company = self.login_company()
         draft = self.plan_generator.draft_plan(planner=company.id)
-        self.client.post(self.get_url(draft.id))
-        response = self.client.post(self.get_url(draft.id))
+        self.client.post(self.get_url(draft))
+        response = self.client.post(self.get_url(draft))
         self.assertEqual(response.status_code, 404)
 
     def get_url(self, draft_id: UUID) -> str:

--- a/tests/flask_integration/test_get_draft_summary_view.py
+++ b/tests/flask_integration/test_get_draft_summary_view.py
@@ -13,7 +13,7 @@ class ViewTests(ViewTestCase):
 
     def test_get_proper_response_code_with_correct_draft_id(self) -> None:
         draft = self.plan_generator.draft_plan(planner=self.company.id)
-        response = self.client.get(self.get_url(draft.id))
+        response = self.client.get(self.get_url(draft))
         self.assertEqual(response.status_code, 200)
 
     def test_get_404_with_random_uuid(self) -> None:

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -157,7 +157,7 @@ class GeneralUrlIndexTests(ViewTestCase):
     ) -> None:
         company = self.login_company()
         draft = self.plan_generator.draft_plan(planner=company.id)
-        url = self.url_index.get_draft_summary_url(draft_id=draft.id)
+        url = self.url_index.get_draft_summary_url(draft_id=draft)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -48,9 +48,6 @@ class InMemoryModule(Module):
         binder[interfaces.AccountRepository] = AliasProvider(  # type: ignore
             repositories.AccountRepository
         )
-        binder[interfaces.PlanDraftRepository] = AliasProvider(  # type: ignore
-            repositories.PlanDraftRepository
-        )
         binder.bind(
             interfaces.DatabaseGateway,  # type: ignore
             to=AliasProvider(repositories.EntityStorage),

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -979,45 +979,6 @@ class AccountRepository(interfaces.AccountRepository):
 
 
 @singleton
-class PlanDraftRepository(interfaces.PlanDraftRepository):
-    def __init__(self, entities: EntityStorage) -> None:
-        self.entities = entities
-
-    def create_plan_draft(
-        self,
-        planner: UUID,
-        product_name: str,
-        description: str,
-        costs: ProductionCosts,
-        production_unit: str,
-        amount: int,
-        timeframe_in_days: int,
-        is_public_service: bool,
-        creation_timestamp: datetime,
-    ) -> PlanDraft:
-        draft = PlanDraft(
-            id=uuid4(),
-            creation_date=creation_timestamp,
-            planner=planner,
-            product_name=product_name,
-            production_costs=costs,
-            unit_of_distribution=production_unit,
-            amount_produced=amount,
-            description=description,
-            timeframe=timeframe_in_days,
-            is_public_service=is_public_service,
-        )
-        self.entities.drafts[draft.id] = draft
-        return draft
-
-    def get_plan_drafts(self) -> PlanDraftResult:
-        return PlanDraftResult(
-            items=lambda: self.entities.drafts.values(),
-            entities=self.entities,
-        )
-
-
-@singleton
 class FakeLanguageRepository:
     def __init__(self) -> None:
         self._language_codes: Set[str] = set()
@@ -1347,4 +1308,37 @@ class EntityStorage:
         return EmailAddressResult(
             entities=self,
             items=lambda: self.email_addresses.values(),
+        )
+
+    def create_plan_draft(
+        self,
+        planner: UUID,
+        product_name: str,
+        description: str,
+        costs: ProductionCosts,
+        production_unit: str,
+        amount: int,
+        timeframe_in_days: int,
+        is_public_service: bool,
+        creation_timestamp: datetime,
+    ) -> PlanDraft:
+        draft = PlanDraft(
+            id=uuid4(),
+            creation_date=creation_timestamp,
+            planner=planner,
+            product_name=product_name,
+            production_costs=costs,
+            unit_of_distribution=production_unit,
+            amount_produced=amount,
+            description=description,
+            timeframe=timeframe_in_days,
+            is_public_service=is_public_service,
+        )
+        self.drafts[draft.id] = draft
+        return draft
+
+    def get_plan_drafts(self) -> PlanDraftResult:
+        return PlanDraftResult(
+            items=lambda: self.drafts.values(),
+            entities=self,
         )

--- a/tests/use_cases/test_approve_plan.py
+++ b/tests/use_cases/test_approve_plan.py
@@ -23,7 +23,6 @@ from arbeitszeit.use_cases.query_plans import (
 )
 
 from .base_test_case import BaseTestCase
-from .repositories import PlanDraftRepository
 
 
 class UseCaseTests(BaseTestCase):
@@ -32,7 +31,6 @@ class UseCaseTests(BaseTestCase):
         self.use_case = self.injector.get(ApprovePlanUseCase)
         self.get_company_summary = self.injector.get(GetCompanySummary)
         self.query_plans = self.injector.get(QueryPlans)
-        self.draft_repository = self.injector.get(PlanDraftRepository)
         self.pay_means_of_production = self.injector.get(PayMeansOfProduction)
         self.get_company_transactions_use_case = self.injector.get(
             GetCompanyTransactions

--- a/tests/use_cases/test_delete_draft.py
+++ b/tests/use_cases/test_delete_draft.py
@@ -23,7 +23,7 @@ class UseCaseTests(BaseTestCase):
     def test_that_no_failure_is_raised_if_draft_is_deleted_by_its_owner(self) -> None:
         planner = self.company_generator.create_company()
         draft = self.plan_generator.draft_plan(planner=planner)
-        self.use_case.delete_draft(self.create_request(deleter=planner, draft=draft.id))
+        self.use_case.delete_draft(self.create_request(deleter=planner, draft=draft))
 
     def test_that_failure_is_raised_if_draft_does_not_exist(self) -> None:
         planner = self.company_generator.create_company()
@@ -36,14 +36,14 @@ class UseCaseTests(BaseTestCase):
         draft = self.plan_generator.draft_plan()
         with self.assertRaises(DeleteDraftUseCase.Failure):
             self.use_case.delete_draft(
-                self.create_request(deleter=uuid4(), draft=draft.id),
+                self.create_request(deleter=uuid4(), draft=draft),
             )
 
     def test_that_after_deleting_draft_summary_is_not_available_anymore(self) -> None:
         planner = self.company_generator.create_company()
         draft = self.plan_generator.draft_plan(planner=planner)
-        self.use_case.delete_draft(self.create_request(deleter=planner, draft=draft.id))
-        response = self.get_draft_summary(draft_id=draft.id)
+        self.use_case.delete_draft(self.create_request(deleter=planner, draft=draft))
+        response = self.get_draft_summary(draft_id=draft)
         self.assertIsNone(response)
 
     def test_that_plan_is_not_deleted_if_deleter_is_not_planner(self) -> None:
@@ -51,9 +51,9 @@ class UseCaseTests(BaseTestCase):
         draft = self.plan_generator.draft_plan()
         with self.assertRaises(DeleteDraftUseCase.Failure):
             self.use_case.delete_draft(
-                self.create_request(deleter=company.id, draft=draft.id)
+                self.create_request(deleter=company.id, draft=draft)
             )
-        response = self.get_draft_summary(draft_id=draft.id)
+        response = self.get_draft_summary(draft_id=draft)
         self.assertIsNotNone(response)
 
     def test_failure_is_raised_if_deleter_is_not_planner(self) -> None:
@@ -61,7 +61,7 @@ class UseCaseTests(BaseTestCase):
         draft = self.plan_generator.draft_plan()
         with self.assertRaises(DeleteDraftUseCase.Failure):
             self.use_case.delete_draft(
-                self.create_request(deleter=company.id, draft=draft.id)
+                self.create_request(deleter=company.id, draft=draft)
             )
 
     def test_show_draft_name_in_successful_deletion_response(self) -> None:
@@ -71,7 +71,7 @@ class UseCaseTests(BaseTestCase):
             planner=planner, product_name=expected_name
         )
         response = self.use_case.delete_draft(
-            self.create_request(deleter=planner, draft=draft.id)
+            self.create_request(deleter=planner, draft=draft)
         )
         self.assertEqual(response.product_name, expected_name)
 

--- a/tests/use_cases/test_edit_draft.py
+++ b/tests/use_cases/test_edit_draft.py
@@ -27,14 +27,14 @@ class UseCaseTests(TestCase):
     def test_planner_can_edit_successfully_an_existing_draft(self) -> None:
         planner = self.company_generator.create_company()
         draft = self.plan_generator.draft_plan(planner=planner)
-        request = self.create_request(draft=draft.id, editor=planner)
+        request = self.create_request(draft=draft, editor=planner)
         response = self.use_case.edit_draft(request)
         self.assertTrue(response.is_success)
 
     def test_non_planner_cannot_edit_draft_successfully(self) -> None:
         other_company = self.company_generator.create_company()
         draft = self.plan_generator.draft_plan()
-        request = self.create_request(draft=draft.id, editor=other_company)
+        request = self.create_request(draft=draft, editor=other_company)
         response = self.use_case.edit_draft(request)
         self.assertFalse(response.is_success)
 
@@ -44,11 +44,11 @@ class UseCaseTests(TestCase):
             planner=planner, product_name="original name"
         )
         request = self.create_request(
-            draft=draft.id, editor=planner, product_name="new name"
+            draft=draft, editor=planner, product_name="new name"
         )
         self.use_case.edit_draft(request)
         self.assertDraft(
-            draft.id,
+            draft,
             lambda d: d.product_name == "new name",
         )
 
@@ -63,11 +63,11 @@ class UseCaseTests(TestCase):
             ),
         )
         request = self.create_request(
-            draft=draft.id, editor=planner, labour_cost=Decimal(2)
+            draft=draft, editor=planner, labour_cost=Decimal(2)
         )
         self.use_case.edit_draft(request)
         self.assertDraft(
-            draft.id,
+            draft,
             lambda d: d.labour_cost == Decimal(2),
         )
 
@@ -82,11 +82,11 @@ class UseCaseTests(TestCase):
             ),
         )
         request = self.create_request(
-            draft=draft.id, editor=planner, means_cost=Decimal(2)
+            draft=draft, editor=planner, means_cost=Decimal(2)
         )
         self.use_case.edit_draft(request)
         self.assertDraft(
-            draft.id,
+            draft,
             lambda d: d.means_cost == Decimal(2),
         )
 
@@ -101,11 +101,11 @@ class UseCaseTests(TestCase):
             ),
         )
         request = self.create_request(
-            draft=draft.id, editor=planner, resource_cost=Decimal(2)
+            draft=draft, editor=planner, resource_cost=Decimal(2)
         )
         self.use_case.edit_draft(request)
         self.assertDraft(
-            draft.id,
+            draft,
             lambda d: d.resources_cost == Decimal(2),
         )
 
@@ -116,11 +116,11 @@ class UseCaseTests(TestCase):
             description="old description",
         )
         request = self.create_request(
-            draft=draft.id, editor=planner, description="new description"
+            draft=draft, editor=planner, description="new description"
         )
         self.use_case.edit_draft(request)
         self.assertDraft(
-            draft.id,
+            draft,
             lambda d: d.description == "new description",
         )
 
@@ -131,12 +131,12 @@ class UseCaseTests(TestCase):
             is_public_service=True,
         )
         request = self.create_request(
-            draft=draft.id,
+            draft=draft,
             editor=planner,
             is_public_service=False,
         )
         self.use_case.edit_draft(request)
-        self.assertDraft(draft.id, lambda d: not d.is_public_service)
+        self.assertDraft(draft, lambda d: not d.is_public_service)
 
     def test_can_edit_timeframe(self) -> None:
         planner = self.company_generator.create_company()
@@ -145,12 +145,12 @@ class UseCaseTests(TestCase):
             timeframe=1,
         )
         request = self.create_request(
-            draft=draft.id,
+            draft=draft,
             editor=planner,
             timeframe=2,
         )
         self.use_case.edit_draft(request)
-        self.assertDraft(draft.id, lambda d: d.timeframe == 2)
+        self.assertDraft(draft, lambda d: d.timeframe == 2)
 
     def test_can_change_unit_of_distribution(self) -> None:
         planner = self.company_generator.create_company()
@@ -159,12 +159,12 @@ class UseCaseTests(TestCase):
             production_unit="old unit",
         )
         request = self.create_request(
-            draft=draft.id,
+            draft=draft,
             editor=planner,
             unit_of_distribution="new unit",
         )
         self.use_case.edit_draft(request)
-        self.assertDraft(draft.id, lambda d: d.production_unit == "new unit")
+        self.assertDraft(draft, lambda d: d.production_unit == "new unit")
 
     def assertDraft(
         self, draft_id: UUID, condition: Callable[[DraftSummarySuccess], bool]

--- a/tests/use_cases/test_file_plan_with_accounting.py
+++ b/tests/use_cases/test_file_plan_with_accounting.py
@@ -54,7 +54,7 @@ class BaseUseCaseTestCase(BaseTestCase):
             timeframe=timeframe,
             planner=self.planner,
         )
-        return draft.id
+        return draft
 
     def create_request(
         self,

--- a/tests/use_cases/test_get_draft_summary.py
+++ b/tests/use_cases/test_get_draft_summary.py
@@ -21,7 +21,7 @@ def test_that_correct_planner_id_is_returned(
 ):
     planner = company_generator.create_company()
     draft = plan_generator.draft_plan(planner=planner)
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.planner_id == planner)
 
 
@@ -37,7 +37,7 @@ def test_that_correct_production_costs_are_shown(
             resource_cost=Decimal(3),
         )
     )
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(
         summary,
         lambda s: all(
@@ -56,7 +56,7 @@ def test_that_correct_product_name_is_shown(
     get_draft_summary: GetDraftSummary,
 ):
     draft = plan_generator.draft_plan(product_name="test product")
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.product_name == "test product")
 
 
@@ -66,7 +66,7 @@ def test_that_correct_product_description_is_shown(
     get_draft_summary: GetDraftSummary,
 ):
     draft = plan_generator.draft_plan(description="test description")
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.description == "test description")
 
 
@@ -76,7 +76,7 @@ def test_that_correct_product_unit_is_shown(
     get_draft_summary: GetDraftSummary,
 ):
     draft = plan_generator.draft_plan(production_unit="test unit")
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.production_unit == "test unit")
 
 
@@ -86,7 +86,7 @@ def test_that_correct_amount_is_shown(
     get_draft_summary: GetDraftSummary,
 ):
     draft = plan_generator.draft_plan(amount=123)
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.amount == 123)
 
 
@@ -96,7 +96,7 @@ def test_that_correct_public_service_is_shown(
     get_draft_summary: GetDraftSummary,
 ):
     draft = plan_generator.draft_plan(is_public_service=True)
-    summary = get_draft_summary(draft.id)
+    summary = get_draft_summary(draft)
     assert_success(summary, lambda s: s.is_public_service == True)
 
 

--- a/tests/use_cases/test_list_plans_with_pending_review.py
+++ b/tests/use_cases/test_list_plans_with_pending_review.py
@@ -79,9 +79,7 @@ class UseCaseTests(BaseTestCase):
         draft = self.plan_generator.draft_plan(
             product_name=product_name, planner=planner
         )
-        request = FilePlanWithAccounting.Request(
-            draft_id=draft.id, filing_company=draft.planner
-        )
+        request = FilePlanWithAccounting.Request(draft_id=draft, filing_company=planner)
         response = self.file_plan_with_accounting_use_case.file_plan_with_accounting(
             request
         )

--- a/tests/use_cases/test_show_my_plans.py
+++ b/tests/use_cases/test_show_my_plans.py
@@ -67,6 +67,6 @@ class UseCaseTests(BaseTestCase):
         response = self.use_case.show_company_plans(
             request=ShowMyPlansRequest(company_id=company)
         )
-        self.assertEqual(response.drafts[0].id, expected_first_plan.id)
-        self.assertEqual(response.drafts[1].id, expected_second_plan.id)
-        self.assertEqual(response.drafts[2].id, expected_third_plan.id)
+        self.assertEqual(response.drafts[0].id, expected_first_plan)
+        self.assertEqual(response.drafts[1].id, expected_second_plan)
+        self.assertEqual(response.drafts[2].id, expected_third_plan)


### PR DESCRIPTION
This change removes the PlanDraftRepository interface and its implementations in favor of moving all the associated functionality to DatabaseGateway and its implementations.

Futher the PlanGenerator was changed slightly such that draft_plan no longer returns a Plan entity object but a UUID instead.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf