### PR TITLE
Implement member account details view

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -60,6 +60,10 @@ class Member:
     def is_member(self) -> bool:
         return True
 
+    @property
+    def email_address(self) -> str:
+        return self.email
+
 
 @dataclass
 class Company:
@@ -101,6 +105,10 @@ class Company:
 
     def is_member(self) -> bool:
         return False
+
+    @property
+    def email_address(self) -> str:
+        return self.email
 
 
 class AccountTypes(Enum):

--- a/arbeitszeit/use_cases/get_user_account_details.py
+++ b/arbeitszeit/use_cases/get_user_account_details.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+from uuid import UUID
+
+from arbeitszeit import entities
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class GetUserAccountDetailsUseCase:
+    database: DatabaseGateway
+
+    def get_user_account_details(self, request: Request) -> Response:
+        user: Union[entities.Member, entities.Company, entities.Accountant, None] = (
+            self.database.get_members().with_id(request.user_id).first()
+            or self.database.get_companies().with_id(request.user_id).first()
+            or self.database.get_accountants().with_id(request.user_id).first()
+        )
+        return Response(
+            user_info=UserInfo(id=user.id, email_address=user.email_address)
+            if user
+            else None
+        )
+
+
+@dataclass
+class Request:
+    user_id: UUID
+
+
+@dataclass
+class Response:
+    user_info: Optional[UserInfo]
+
+
+@dataclass
+class UserInfo:
+    id: UUID
+    email_address: str

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -9,6 +9,7 @@ from flask_login import current_user
 from arbeitszeit import use_cases
 from arbeitszeit.use_cases.get_company_summary import GetCompanySummary
 from arbeitszeit.use_cases.get_plan_summary import GetPlanSummaryUseCase
+from arbeitszeit.use_cases.get_user_account_details import GetUserAccountDetailsUseCase
 from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.forms import (
@@ -26,6 +27,9 @@ from arbeitszeit_flask.views import (
     QueryCompaniesView,
     QueryPlansView,
 )
+from arbeitszeit_web.controllers.get_member_account_details_controller import (
+    GetMemberAccountDetailsController,
+)
 from arbeitszeit_web.controllers.query_companies_controller import (
     QueryCompaniesController,
 )
@@ -33,6 +37,9 @@ from arbeitszeit_web.get_company_summary import GetCompanySummarySuccessPresente
 from arbeitszeit_web.get_coop_summary import GetCoopSummarySuccessPresenter
 from arbeitszeit_web.get_plan_summary_member import GetPlanSummaryMemberMemberPresenter
 from arbeitszeit_web.get_statistics import GetStatisticsPresenter
+from arbeitszeit_web.presenters.get_member_account_details_presenter import (
+    GetMemberAccountDetailsPresenter,
+)
 from arbeitszeit_web.presenters.get_member_account_presenter import (
     GetMemberAccountPresenter,
 )
@@ -236,3 +243,21 @@ def show_company_work_invite(invite_id: UUID, view: CompanyWorkInviteView):
         return view.respond_to_post(form, invite_id)
     else:
         return view.respond_to_get(invite_id)
+
+
+@MemberRoute("/member/account")
+def get_member_account_details(
+    controller: GetMemberAccountDetailsController,
+    presenter: GetMemberAccountDetailsPresenter,
+    use_case: GetUserAccountDetailsUseCase,
+    template_renderer: UserTemplateRenderer,
+):
+    uc_request = controller.parse_web_request()
+    uc_response = use_case.get_user_account_details(uc_request)
+    view_model = presenter.render_member_account_details(uc_response)
+    return FlaskResponse(
+        template_renderer.render_template(
+            "member/get_member_account_details.html", dict(view_model=view_model)
+        ),
+        status=200,
+    )

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -4,13 +4,22 @@
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
-      {% if current_user.is_authenticated %}
-      <span class="icon"><i class="fas fa-user"></i></span>&nbsp;
-      {{ current_user.name|truncate(20, True) }}
-      {% else %}
-      <span class="icon"><i class="fas fa-user"></i></span>&nbsp;
-      {{ gettext("Member view") }}
-      {% endif %}
+      <a
+        href="{{ url_for('main_member.get_member_account_details') }}"
+        class="navbar-item"
+        >
+        {% if current_user.is_authenticated %}
+        <span class="icon">
+          <i class="fas fa-user"></i>
+        </span>&nbsp;
+        {{ current_user.name|truncate(20, True) }}
+        {% else %}
+        <span class="icon">
+          <i class="fas fa-user"></i>
+        </span>&nbsp;
+        {{ gettext("Member view") }}
+        {% endif %}
+      </a>
     </div>
 
     <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"

--- a/arbeitszeit_flask/templates/member/get_member_account_details.html
+++ b/arbeitszeit_flask/templates/member/get_member_account_details.html
@@ -1,0 +1,14 @@
+{% extends "base_member.html" %}
+{% block content %}
+<div class="section has-text-centered">
+  <h1 class="title">{{ gettext('User Account Data') }}</h1>
+  <div>
+    <p>
+      {{ gettext("Account ID:") }} {{ view_model.user_id}}
+    </p>
+    <p>
+      {{ gettext("Email address:") }} {{ view_model.email_address }}
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/arbeitszeit_web/controllers/get_member_account_details_controller.py
+++ b/arbeitszeit_web/controllers/get_member_account_details_controller.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class GetMemberAccountDetailsController:
+    session: Session
+
+    def parse_web_request(self) -> use_case.Request:
+        role = self.session.get_user_role()
+        if role == UserRole.member:
+            user_id = self.session.get_current_user()
+            assert user_id
+            return use_case.Request(
+                user_id=user_id,
+            )
+        else:
+            raise Exception()

--- a/arbeitszeit_web/presenters/get_member_account_details_presenter.py
+++ b/arbeitszeit_web/presenters/get_member_account_details_presenter.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+
+
+@dataclass
+class ViewModel:
+    user_id: str
+    email_address: str
+
+
+class GetMemberAccountDetailsPresenter:
+    def render_member_account_details(self, response: use_case.Response) -> ViewModel:
+        assert response.user_info
+        return ViewModel(
+            user_id=str(response.user_info.id),
+            email_address=response.user_info.email_address,
+        )

--- a/tests/controllers/test_get_member_account_details_controller.py
+++ b/tests/controllers/test_get_member_account_details_controller.py
@@ -1,0 +1,43 @@
+from uuid import uuid4
+
+import pytest
+
+from arbeitszeit_web.controllers import (
+    get_member_account_details_controller as controller,
+)
+from tests.session import FakeSession
+
+from .base_test_case import BaseTestCase
+
+
+class GetMemberAccountDetailsControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(
+            controller.GetMemberAccountDetailsController
+        )
+        self.session = self.injector.get(FakeSession)
+
+    def test_that_controller_raises_if_user_is_not_logged_in(self) -> None:
+        self.session.logout()
+        with pytest.raises(Exception):
+            self.controller.parse_web_request()
+
+    def test_that_controller_does_not_raise_if_user_is_logged_in_as_member(
+        self,
+    ) -> None:
+        self.session.login_member(uuid4())
+        self.controller.parse_web_request()
+
+    def test_that_controller_raises_if_user_is_logged_in_as_company(self) -> None:
+        self.session.login_company(uuid4())
+        with pytest.raises(Exception):
+            self.controller.parse_web_request()
+
+    def test_that_request_generated_by_controller_contains_current_user_id(
+        self,
+    ) -> None:
+        user_id = uuid4()
+        self.session.login_member(user_id)
+        request = self.controller.parse_web_request()
+        assert request.user_id

--- a/tests/flask_integration/test_get_member_account_details_view.py
+++ b/tests/flask_integration/test_get_member_account_details_view.py
@@ -1,0 +1,17 @@
+from .flask import ViewTestCase
+
+
+class GetMemberAccountDetailsViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/member/account"
+
+    def test_that_logged_in_member_receives_200(self) -> None:
+        self.login_member()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_that_response_contains_user_id(self) -> None:
+        member = str(self.login_member().id)
+        response = self.client.get(self.url)
+        assert member in response.text

--- a/tests/presenters/test_get_member_account_details_presenter.py
+++ b/tests/presenters/test_get_member_account_details_presenter.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+from arbeitszeit_web.presenters import get_member_account_details_presenter as presenter
+
+from .base_test_case import BaseTestCase
+
+
+class GetMemberAccountDetailsPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(presenter.GetMemberAccountDetailsPresenter)
+
+    def test_that_user_id_is_rendered_into_string_representation_of_itself(
+        self,
+    ) -> None:
+        user_id = uuid4()
+        response = use_case.Response(
+            user_info=use_case.UserInfo(id=user_id, email_address="test@test.test")
+        )
+        view_model = self.presenter.render_member_account_details(response)
+        assert view_model.user_id == str(user_id)
+
+    def test_that_user_email_address_is_rendered_as_is(self) -> None:
+        expected_email_address = "test@test.test"
+        response = use_case.Response(
+            user_info=use_case.UserInfo(
+                id=uuid4(), email_address=expected_email_address
+            )
+        )
+        view_model = self.presenter.render_member_account_details(response)
+        assert view_model.email_address == expected_email_address

--- a/tests/use_cases/test_get_user_account_details.py
+++ b/tests/use_cases/test_get_user_account_details.py
@@ -1,0 +1,52 @@
+from uuid import uuid4
+
+from arbeitszeit.use_cases import get_user_account_details
+
+from .base_test_case import BaseTestCase
+
+
+class GetUserAccountDetailsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(
+            get_user_account_details.GetUserAccountDetailsUseCase
+        )
+
+    def test_that_no_user_info_is_returned_if_requested_user_id_is_not_registered(
+        self,
+    ) -> None:
+        request = get_user_account_details.Request(user_id=uuid4())
+        response = self.use_case.get_user_account_details(request)
+        assert response.user_info is None
+
+    def test_that_returned_user_id_is_equal_to_member_id_requested(self) -> None:
+        member = self.member_generator.create_member()
+        request = get_user_account_details.Request(user_id=member)
+        response = self.use_case.get_user_account_details(request)
+        assert response.user_info
+        assert response.user_info.id == member
+
+    def test_that_returned_user_id_is_equal_to_company_id_requested(self) -> None:
+        company = self.company_generator.create_company()
+        request = get_user_account_details.Request(user_id=company)
+        response = self.use_case.get_user_account_details(request)
+        assert response.user_info
+        assert response.user_info.id == company
+
+    def test_that_returned_user_id_is_equal_to_accountant_id_requested(self) -> None:
+        accountant = self.accountant_generator.create_accountant()
+        request = get_user_account_details.Request(user_id=accountant)
+        response = self.use_case.get_user_account_details(request)
+        assert response.user_info
+        assert response.user_info.id == accountant
+
+    def test_that_users_email_address_is_shown(self) -> None:
+        for expected_email_address in [
+            "testmail@test.test",
+            "other@test.mail",
+        ]:
+            member = self.member_generator.create_member(email=expected_email_address)
+            request = get_user_account_details.Request(user_id=member)
+            response = self.use_case.get_user_account_details(request)
+            assert response.user_info
+            assert response.user_info.email_address == expected_email_address


### PR DESCRIPTION
The goal of this PR is to create the conditions for implementing functionality that lets the user change their email address and password. To this end I implemented a basic minimal "account settings" view. The layout of this view is super minimal and should be polished in future changes.

Here is a preview of this new view:

![image](https://github.com/arbeitszeit/arbeitszeitapp/assets/4805746/10177f87-a853-4a3d-ba79-ed8bb6becc6a)

It can be accessed by clicking on the user name that is displayed in the top left corner at all times.

Here are the commit messages of the 2 commits included in this PR:

### arbeitszeit: Implement GetUserAccountDetailsUseCase

The implemented use case class is supposed to show basic account
information to the user. In this first iteration the information
returned is limited to the users ID and email address.

### Implement get_member_account_details view

With this change a new view is introduced. This view allows users
logged in as a member to check their basic account data. For now this
is limited to their user id and their email address. As it stands
right now this view is pretty useless since the same information is
also present on the member dashboard view. The newly introduced view
can serve as a basis for implementing new functionality to change a
users password and email address.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)
