### PR TITLE
Implement account details view for companies

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -26,6 +26,7 @@ from arbeitszeit.use_cases.file_plan_with_accounting import FilePlanWithAccounti
 from arbeitszeit.use_cases.get_company_summary import GetCompanySummary
 from arbeitszeit.use_cases.get_draft_summary import GetDraftSummary
 from arbeitszeit.use_cases.get_plan_summary import GetPlanSummaryUseCase
+from arbeitszeit.use_cases.get_user_account_details import GetUserAccountDetailsUseCase
 from arbeitszeit.use_cases.hide_plan import HidePlan
 from arbeitszeit.use_cases.list_active_plans_of_company import ListActivePlansOfCompany
 from arbeitszeit.use_cases.list_all_cooperations import ListAllCooperations
@@ -86,6 +87,9 @@ from arbeitszeit_web.www.controllers.delete_draft_controller import (
 from arbeitszeit_web.www.controllers.file_plan_with_accounting_controller import (
     FilePlanWithAccountingController,
 )
+from arbeitszeit_web.www.controllers.get_company_account_details_controller import (
+    GetCompanyAccountDetailsController,
+)
 from arbeitszeit_web.www.controllers.query_companies_controller import (
     QueryCompaniesController,
 )
@@ -102,6 +106,9 @@ from arbeitszeit_web.www.presenters.create_draft_presenter import (
 from arbeitszeit_web.www.presenters.delete_draft_presenter import DeleteDraftPresenter
 from arbeitszeit_web.www.presenters.file_plan_with_accounting_presenter import (
     FilePlanWithAccountingPresenter,
+)
+from arbeitszeit_web.www.presenters.get_company_account_details_presenter import (
+    GetCompanyAccountDetailsPresenter,
 )
 from arbeitszeit_web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
@@ -694,3 +701,21 @@ def end_cooperation(
     view: EndCooperationView,
 ) -> Response:
     return view.respond_to_get()
+
+
+@CompanyRoute("/company/account")
+def get_company_account_details(
+    controller: GetCompanyAccountDetailsController,
+    use_case: GetUserAccountDetailsUseCase,
+    presenter: GetCompanyAccountDetailsPresenter,
+    template_renderer: UserTemplateRenderer,
+) -> Response:
+    uc_request = controller.parse_web_request()
+    uc_response = use_case.get_user_account_details(uc_request)
+    view_model = presenter.render_company_account_details(uc_response)
+    return FlaskResponse(
+        template_renderer.render_template(
+            "company/get_company_account_details.html", dict(view_model=view_model)
+        ),
+        status=200,
+    )

--- a/arbeitszeit_flask/templates/base_company.html
+++ b/arbeitszeit_flask/templates/base_company.html
@@ -4,13 +4,17 @@
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
-      {% if current_user.is_authenticated %}
-      <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
-      {{ current_user.name|truncate(20, True) }}
-      {% else %}
-      <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
-      {{ gettext("Company view") }}
-      {% endif %}
+      <a href="{{ url_for('main_company.get_company_account_details') }}"
+         class="navbar-item"
+         >
+        {% if current_user.is_authenticated %}
+        <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
+        {{ current_user.name|truncate(20, True) }}
+        {% else %}
+        <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
+        {{ gettext("Company view") }}
+        {% endif %}
+      </a>
     </div>
 
     <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -4,10 +4,9 @@
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
-      <a
-        href="{{ url_for('main_member.get_member_account_details') }}"
-        class="navbar-item"
-        >
+      <a href="{{ url_for('main_member.get_member_account_details') }}"
+         class="navbar-item"
+         >
         {% if current_user.is_authenticated %}
         <span class="icon">
           <i class="fas fa-user"></i>

--- a/arbeitszeit_flask/templates/company/get_company_account_details.html
+++ b/arbeitszeit_flask/templates/company/get_company_account_details.html
@@ -1,0 +1,14 @@
+{% extends "base_company.html" %}
+{% block content %}
+<div class="section has-text-centered">
+  <h1 class="title">{{ gettext('User Account Data') }}</h1>
+  <div>
+    <p>
+      {{ gettext("Account ID:") }} {{ view_model.user_id}}
+    </p>
+    <p>
+      {{ gettext("Email address:") }} {{ view_model.email_address }}
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/arbeitszeit_web/www/controllers/get_company_account_details_controller.py
+++ b/arbeitszeit_web/www/controllers/get_company_account_details_controller.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class GetCompanyAccountDetailsController:
+    session: Session
+
+    def parse_web_request(self) -> use_case.Request:
+        user_id = self.session.get_current_user()
+        if self.session.get_user_role() != UserRole.company or not user_id:
+            raise Exception()
+        return use_case.Request(user_id=user_id)

--- a/arbeitszeit_web/www/presenters/get_company_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_account_details_presenter.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+
+
+@dataclass
+class ViewModel:
+    email_address: str
+    user_id: str
+
+
+class GetCompanyAccountDetailsPresenter:
+    def render_company_account_details(self, response: use_case.Response) -> ViewModel:
+        assert response.user_info
+        return ViewModel(
+            email_address=response.user_info.email_address,
+            user_id=str(response.user_info.id),
+        )

--- a/tests/controllers/test_get_company_account_details_controller.py
+++ b/tests/controllers/test_get_company_account_details_controller.py
@@ -1,0 +1,41 @@
+from uuid import uuid4
+
+import pytest
+
+from arbeitszeit_web.www.controllers.get_company_account_details_controller import (
+    GetCompanyAccountDetailsController,
+)
+from tests.session import FakeSession
+
+from .base_test_case import BaseTestCase
+
+
+class GetCompanyAccountDetailsControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.session = self.injector.get(FakeSession)
+        self.controller = self.injector.get(GetCompanyAccountDetailsController)
+
+    def test_that_exception_is_raised_when_user_is_not_logged_in(self) -> None:
+        self.session.logout()
+        with pytest.raises(Exception):
+            self.controller.parse_web_request()
+
+    def test_that_no_exception_is_raised_when_user_is_logged_in_as_company(
+        self,
+    ) -> None:
+        self.session.login_company(uuid4())
+        self.controller.parse_web_request()
+
+    def test_an_exception_is_raised_when_user_is_logged_in_as_member(self) -> None:
+        self.session.login_member(uuid4())
+        with pytest.raises(Exception):
+            self.controller.parse_web_request()
+
+    def test_resulting_request_contains_id_of_current_user(
+        self,
+    ) -> None:
+        expected_user_id = uuid4()
+        self.session.login_company(expected_user_id)
+        request = self.controller.parse_web_request()
+        assert request.user_id == expected_user_id

--- a/tests/flask_integration/test_get_company_account_details_view.py
+++ b/tests/flask_integration/test_get_company_account_details_view.py
@@ -1,0 +1,17 @@
+from .flask import ViewTestCase
+
+
+class GetCompanyAccountDetailsViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/company/account"
+
+    def test_that_logged_in_company_receives_200(self) -> None:
+        self.login_company()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_that_response_contains_user_id(self) -> None:
+        company = str(self.login_company().id)
+        response = self.client.get(self.url)
+        assert company in response.text

--- a/tests/presenters/test_get_company_account_details_presenter.py
+++ b/tests/presenters/test_get_company_account_details_presenter.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+from arbeitszeit.use_cases import get_user_account_details as use_case
+from arbeitszeit_web.www.presenters.get_company_account_details_presenter import (
+    GetCompanyAccountDetailsPresenter,
+)
+
+from .base_test_case import BaseTestCase
+
+
+class GetCompanyAccountDetailsPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(GetCompanyAccountDetailsPresenter)
+
+    def test_that_email_address_from_response_is_rendered_as_is(self) -> None:
+        expected_email_address = "test@test.test"
+        response = use_case.Response(
+            user_info=use_case.UserInfo(
+                id=uuid4(), email_address=expected_email_address
+            )
+        )
+        view_model = self.presenter.render_company_account_details(response)
+        assert view_model.email_address == expected_email_address
+
+    def test_that_user_id_is_rendered_as_string(self) -> None:
+        user_id = uuid4()
+        response = use_case.Response(
+            user_info=use_case.UserInfo(id=user_id, email_address="test@test.test")
+        )
+        view_model = self.presenter.render_company_account_details(response)
+        assert view_model.user_id == str(user_id)


### PR DESCRIPTION
This change implements a web view where companies can see their user id and email address. The added code implements the adapter logic for the get_user_account_details use case.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)