### PR TITLE
Implement new route ("Review registered consumption") and fix typo

### DIFF
--- a/arbeitszeit/use_cases/review_registered_consumptions.py
+++ b/arbeitszeit/use_cases/review_registered_consumptions.py
@@ -18,7 +18,7 @@ class RegisteredConsumption:
 
 
 @dataclass
-class RewiewRegisteredConsumptionsUseCase:
+class ReviewRegisteredConsumptionsUseCase:
     @dataclass
     class Request:
         providing_company: UUID

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -72,6 +72,9 @@ from arbeitszeit_flask.views.register_productive_consumption import (
 from arbeitszeit_flask.views.request_coordination_transfer_view import (
     RequestCoordinationTransferView,
 )
+from arbeitszeit_flask.views.review_registered_consumptions_view import (
+    ReviewRegisteredConsumptionsView,
+)
 from arbeitszeit_flask.views.show_coordination_transfer_request_view import (
     ShowCoordinationTransferRequestView,
 )
@@ -538,4 +541,10 @@ class invite_worker_to_company(InviteWorkerToCompanyView):
 @CompanyRoute("/company/end_cooperation")
 @as_flask_view()
 class end_cooperation(EndCooperationView):
+    ...
+
+
+@CompanyRoute("/company/review_registered_consumptions")
+@as_flask_view()
+class review_registered_consumptions(ReviewRegisteredConsumptionsView):
     ...

--- a/arbeitszeit_flask/templates/company/review_registered_consumptions.html
+++ b/arbeitszeit_flask/templates/company/review_registered_consumptions.html
@@ -1,0 +1,3 @@
+<div>
+    TODO
+</div>

--- a/arbeitszeit_flask/views/review_registered_consumptions_view.py
+++ b/arbeitszeit_flask/views/review_registered_consumptions_view.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+import flask
+
+from arbeitszeit.use_cases.review_registered_consumptions import (
+    ReviewRegisteredConsumptionsUseCase,
+)
+from arbeitszeit_flask import types
+from arbeitszeit_web.www.controllers.review_registered_consumptions_controller import (
+    InvalidRequest,
+    ReviewRegisteredConsumptionsController,
+)
+from arbeitszeit_web.www.presenters.review_registered_consumptions_presenter import (
+    ReviewRegisteredConsumptionsPresenter,
+)
+
+
+@dataclass
+class ReviewRegisteredConsumptionsView:
+    controller: ReviewRegisteredConsumptionsController
+    use_case: ReviewRegisteredConsumptionsUseCase
+    presenter: ReviewRegisteredConsumptionsPresenter
+
+    def GET(self) -> types.Response:
+        use_case_request = self.controller.create_use_case_request()
+        match use_case_request:
+            case InvalidRequest(status_code=status_code):
+                return flask.Response(status=status_code)
+        use_case_response = self.use_case.review_registered_consumptions(
+            use_case_request
+        )
+        view_model = self.presenter.present(use_case_response)
+        return flask.Response(
+            flask.render_template(
+                "company/review_registered_consumptions.html",
+                view_model=view_model,
+            )
+        )

--- a/arbeitszeit_web/www/controllers/review_registered_consumptions_controller.py
+++ b/arbeitszeit_web/www/controllers/review_registered_consumptions_controller.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase,
+    ReviewRegisteredConsumptionsUseCase,
 )
 from arbeitszeit_web.session import Session, UserRole
 
@@ -13,13 +13,13 @@ class ReviewRegisteredConsumptionsController:
 
     def create_use_case_request(
         self,
-    ) -> Optional[RewiewRegisteredConsumptionsUseCase.Request]:
+    ) -> Optional[ReviewRegisteredConsumptionsUseCase.Request]:
         user_role = self.session.get_user_role()
         if user_role != UserRole.company:
             return None
         providing_company = self.session.get_current_user()
         if not providing_company:
             return None
-        return RewiewRegisteredConsumptionsUseCase.Request(
+        return ReviewRegisteredConsumptionsUseCase.Request(
             providing_company=providing_company
         )

--- a/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
@@ -4,7 +4,7 @@ from typing import Optional
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.review_registered_consumptions import RegisteredConsumption
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.url_index import UrlIndex

--- a/tests/flask_integration/test_review_registered_consumptions_view.py
+++ b/tests/flask_integration/test_review_registered_consumptions_view.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from parameterized import parameterized
+
+from tests.flask_integration.flask import LogInUser, ViewTestCase
+
+
+class UserAccessTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "company/review_registered_consumptions"
+
+    @parameterized.expand(
+        [
+            (LogInUser.accountant, 302),
+            (None, 302),
+            (LogInUser.company, 200),
+            (LogInUser.member, 302),
+        ]
+    )
+    def test_correct_status_codes_on_get_requests(
+        self, login: Optional[LogInUser], expected_code: int
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=self.url,
+            method="get",
+            login=login,
+            expected_code=expected_code,
+        )

--- a/tests/use_cases/test_review_registered_consumptions.py
+++ b/tests/use_cases/test_review_registered_consumptions.py
@@ -4,7 +4,7 @@ from math import isclose
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from tests.use_cases.base_test_case import BaseTestCase
 

--- a/tests/www/controllers/test_review_registered_consumptions_controller.py
+++ b/tests/www/controllers/test_review_registered_consumptions_controller.py
@@ -1,4 +1,5 @@
 from arbeitszeit_web.www.controllers.review_registered_consumptions_controller import (
+    InvalidRequest,
     ReviewRegisteredConsumptionsController,
 )
 from tests.www.base_test_case import BaseTestCase
@@ -9,23 +10,25 @@ class ReviewRegisteredConsumptionsControllerTests(BaseTestCase):
         super().setUp()
         self.controller = self.injector.get(ReviewRegisteredConsumptionsController)
 
-    def test_none_is_returned_if_no_user_is_logged_in(self):
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_none_is_returned_if_user_is_a_member(self):
-        self.session.login_member(self.member_generator.create_member())
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_none_is_returned_if_user_is_an_accountant(self):
-        self.session.login_accountant(self.accountant_generator.create_accountant())
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_use_case_request_is_created_if_user_is_a_company(self):
-        self.session.login_company(self.company_generator.create_company())
-        self.assertIsNotNone(self.controller.create_use_case_request())
-
-    def test_use_case_request_contains_providing_company(self):
-        company = self.company_generator.create_company()
-        self.session.login_company(company)
+    def test_401_is_returned_if_no_user_is_logged_in(self):
         request = self.controller.create_use_case_request()
-        self.assertEqual(request.providing_company, company)
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 401
+
+    def test_403_is_returned_if_user_is_a_member(self):
+        self.session.login_member(self.member_generator.create_member())
+        request = self.controller.create_use_case_request()
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 403
+
+    def test_403_is_returned_if_user_is_an_accountant(self):
+        self.session.login_accountant(self.accountant_generator.create_accountant())
+        request = self.controller.create_use_case_request()
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 403
+
+    def test_use_case_request_contains_currently_logged_in_company_id(self):
+        expected_company_id = self.company_generator.create_company()
+        self.session.login_company(expected_company_id)
+        request = self.controller.create_use_case_request()
+        assert request.providing_company == expected_company_id

--- a/tests/www/presenters/test_review_registered_consumptions_presenter.py
+++ b/tests/www/presenters/test_review_registered_consumptions_presenter.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.review_registered_consumptions import RegisteredConsumption
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.review_registered_consumptions_presenter import (


### PR DESCRIPTION
**Fix typo in class definition: Rewiew -> Review**

**Implement ReviewRegisteredConsumptionsView** 

This commit adds a company route ("/company/review_registered_consumptions") which leads to the `ReviewRegisteredConsumptionsView`. The corresponding controller has been refactored in order to return the correct status codes (401, 403).

There is still no content in the html file and there is no place in the app that links to the new route. This will be implemented in one of the upcoming PRs. 

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c