### PR TITLE
HTML for RviewRegisteredConsumptions

### DIFF
--- a/arbeitszeit/use_cases/review_registered_consumptions.py
+++ b/arbeitszeit/use_cases/review_registered_consumptions.py
@@ -18,7 +18,7 @@ class RegisteredConsumption:
 
 
 @dataclass
-class RewiewRegisteredConsumptionsUseCase:
+class ReviewRegisteredConsumptionsUseCase:
     @dataclass
     class Request:
         providing_company: UUID

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -72,6 +72,9 @@ from arbeitszeit_flask.views.register_productive_consumption import (
 from arbeitszeit_flask.views.request_coordination_transfer_view import (
     RequestCoordinationTransferView,
 )
+from arbeitszeit_flask.views.review_registered_consumptions_view import (
+    ReviewRegisteredConsumptionsView,
+)
 from arbeitszeit_flask.views.show_coordination_transfer_request_view import (
     ShowCoordinationTransferRequestView,
 )
@@ -538,4 +541,10 @@ class invite_worker_to_company(InviteWorkerToCompanyView):
 @CompanyRoute("/company/end_cooperation")
 @as_flask_view()
 class end_cooperation(EndCooperationView):
+    ...
+
+
+@CompanyRoute("/company/review_registered_consumptions")
+@as_flask_view()
+class review_registered_consumptions(ReviewRegisteredConsumptionsView):
     ...

--- a/arbeitszeit_flask/templates/company/dashboard.html
+++ b/arbeitszeit_flask/templates/company/dashboard.html
@@ -32,15 +32,15 @@
             <h1 class="title is-3">{{ gettext("Frequent actions") }}</h1>
         </div>
         <div class="tile is-ancestor">
-          <a class="tile is-parent" href="{{ url_for('main_company.create_draft') }}">
-            <div class="tile is-child box has-background-danger-light">
-              <h1 class="title is-5">
-                <span class="icon"><i class="fa-solid fa-file-circle-plus"></i></span>
-                {{ gettext("Create new plan") }}
-              </h1>
-              <div class="subtitle"></div>
-            </div>
-          </a>
+            <a class="tile is-parent" href="{{ url_for('main_company.create_draft') }}">
+                <div class="tile is-child box has-background-danger-light">
+                    <h1 class="title is-5">
+                        <span class="icon"><i class="fa-solid fa-file-circle-plus"></i></span>
+                        {{ gettext("Create new plan") }}
+                    </h1>
+                    <div class="subtitle"></div>
+                </div>
+            </a>
             <a class="tile is-parent" href="{{ url_for('main_company.register_productive_consumption') }}">
                 <div class="tile is-child box has-background-danger-light">
                     <h1 class="title is-5"><span class="icon"><i class="fa-regular fa-credit-card"></i></span>
@@ -101,6 +101,16 @@
                     <div class="subtitle is-6">{{ gettext("Your consumptions") }}</div>
                 </div>
             </a>
+            <a class="tile is-parent" href="{{ url_for('main_company.review_registered_consumptions') }}">
+                <div class="tile is-child box has-background-primary-light">
+                    <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-exchange"></i></span> {{
+                        gettext("Product transfers") }}
+                    </h1>
+                    <div class="subtitle is-6">{{ gettext("Your product transfers") }}</div>
+                </div>
+            </a>
+        </div>
+        <div class="tile is-ancestor">
             <a class="tile is-parent" href="{{ url_for('main_company.invite_worker_to_company') }}">
                 <div class="tile is-child box has-background-primary-light">
                     <h1 class="title is-5"><span class="icon"><i class="fa-solid fa-users"></i></span> {{
@@ -108,6 +118,8 @@
                     <div class="subtitle is-6">{{ gettext("Members of your collective") }}</div>
                 </div>
             </a>
+            <div class="tile is-parent"></div>
+            <div class="tile is-parent"></div>
         </div>
         <div class="has-text-centered py-5">
             <h1 class="title is-3">{{ gettext("Public accounting") }}</h1>

--- a/arbeitszeit_flask/templates/company/review_registered_consumptions.html
+++ b/arbeitszeit_flask/templates/company/review_registered_consumptions.html
@@ -1,0 +1,3 @@
+<div>
+    TODO
+</div>

--- a/arbeitszeit_flask/templates/company/review_registered_consumptions.html
+++ b/arbeitszeit_flask/templates/company/review_registered_consumptions.html
@@ -1,3 +1,49 @@
-<div>
-    TODO
-</div>
+{% extends "base.html" %}
+
+{% block navbar_start %}
+<div class="navbar-item">{{ gettext("My product transfers") }}</div>
+{% endblock %}
+
+{% block content %}
+
+<section class="section has-text-centered pb-0">
+    <h1 class="title">{{ gettext("My product transfers (sales)") }}</h1>
+</section>
+
+<section class="section columns has-text-centered">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <div class="section has-text-left">
+            {% for c in view_model.consumptions %}          
+            <article class="media">
+                <div class="media-left">
+                    <p class="pt-1">
+                        <small class="has-text-weight-semibold">{{ c.date }}</small><br>
+                    </p>
+                </div>
+                <div class="media-content">
+                    <div class="content">
+                        <p>
+                            <span class="icon"><i class='{{ c.consumer_type_icon }}'></i></span>
+                            {% if c.consumer_url is none %}
+                            <span>{{ c.consumer_name }}</span>
+                            {% else %}
+                            <span><a href="{{ c.consumer_url }}">{{ c.consumer_name }}</a></span>
+                            {% endif %}
+                            <br>
+                            <small><a href="{{ c.plan_url }}">{{ c.product_name }}</a></small>
+                        </p>
+                    </div>
+                </div>
+                <div class="media-right">
+                    <p class="is-size-5 pt-1 has-text-success">
+                        {{ c.labour_hours_consumed }}
+                    </p>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+    </div>
+    <div class="column"></div>
+</section>
+{% endblock %}

--- a/arbeitszeit_flask/views/review_registered_consumptions_view.py
+++ b/arbeitszeit_flask/views/review_registered_consumptions_view.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+import flask
+
+from arbeitszeit.use_cases.review_registered_consumptions import (
+    ReviewRegisteredConsumptionsUseCase,
+)
+from arbeitszeit_flask import types
+from arbeitszeit_web.www.controllers.review_registered_consumptions_controller import (
+    InvalidRequest,
+    ReviewRegisteredConsumptionsController,
+)
+from arbeitszeit_web.www.presenters.review_registered_consumptions_presenter import (
+    ReviewRegisteredConsumptionsPresenter,
+)
+
+
+@dataclass
+class ReviewRegisteredConsumptionsView:
+    controller: ReviewRegisteredConsumptionsController
+    use_case: ReviewRegisteredConsumptionsUseCase
+    presenter: ReviewRegisteredConsumptionsPresenter
+
+    def GET(self) -> types.Response:
+        use_case_request = self.controller.create_use_case_request()
+        match use_case_request:
+            case InvalidRequest(status_code=status_code):
+                return flask.Response(status=status_code)
+        use_case_response = self.use_case.review_registered_consumptions(
+            use_case_request
+        )
+        view_model = self.presenter.present(use_case_response)
+        return flask.Response(
+            flask.render_template(
+                "company/review_registered_consumptions.html",
+                view_model=view_model,
+            )
+        )

--- a/arbeitszeit_web/www/controllers/review_registered_consumptions_controller.py
+++ b/arbeitszeit_web/www/controllers/review_registered_consumptions_controller.py
@@ -1,10 +1,14 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase,
+    ReviewRegisteredConsumptionsUseCase,
 )
 from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class InvalidRequest:
+    status_code: int
 
 
 @dataclass
@@ -13,13 +17,13 @@ class ReviewRegisteredConsumptionsController:
 
     def create_use_case_request(
         self,
-    ) -> Optional[RewiewRegisteredConsumptionsUseCase.Request]:
-        user_role = self.session.get_user_role()
-        if user_role != UserRole.company:
-            return None
-        providing_company = self.session.get_current_user()
-        if not providing_company:
-            return None
-        return RewiewRegisteredConsumptionsUseCase.Request(
-            providing_company=providing_company
-        )
+    ) -> ReviewRegisteredConsumptionsUseCase.Request | InvalidRequest:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            return InvalidRequest(status_code=401)
+        match self.session.get_user_role():
+            case UserRole.company:
+                return ReviewRegisteredConsumptionsUseCase.Request(
+                    providing_company=user_id
+                )
+        return InvalidRequest(status_code=403)

--- a/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
@@ -4,7 +4,7 @@ from typing import Optional
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.review_registered_consumptions import RegisteredConsumption
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.url_index import UrlIndex

--- a/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timedelta
+
+from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
+from tests.control_thresholds import ControlThresholdsTestImpl
+from tests.data_generators import (
+    CompanyGenerator,
+    ConsumptionGenerator,
+    MemberGenerator,
+    PlanGenerator,
+)
+from tests.datetime_service import FakeDatetimeService
+from tests.flask_integration.flask import FlaskTestCase
+
+
+class PrivateConsumptionTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.database_gateway = self.injector.get(DatabaseGatewayImpl)
+        self.consumption_generator = self.injector.get(ConsumptionGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.member_generator = self.injector.get(MemberGenerator)
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.datetime_service = self.injector.get(FakeDatetimeService)
+        self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(1000)
+
+    def test_that_by_default_no_private_consumptions_are_in_db(self) -> None:
+        assert not self.database_gateway.get_private_consumptions()
+
+    def test_that_there_are_some_private_consumptions_in_db_after_one_was_created(
+        self,
+    ) -> None:
+        self.consumption_generator.create_private_consumption()
+        assert self.database_gateway.get_private_consumptions()
+
+    def test_that_retrieved_consumption_contains_specified_plan_id(self) -> None:
+        plan = self.plan_generator.create_plan()
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        assert consumption.plan_id == plan.id
+
+    def test_that_transaction_id_retrieved_is_the_same_twice_in_a_row(self) -> None:
+        self.consumption_generator.create_private_consumption()
+        consumption_1 = self.database_gateway.get_private_consumptions().first()
+        consumption_2 = self.database_gateway.get_private_consumptions().first()
+        assert consumption_1
+        assert consumption_2
+        assert consumption_1.transaction_id == consumption_2.transaction_id
+
+    def test_that_transaction_id_for_two_different_consumptions_is_also_different(
+        self,
+    ) -> None:
+        self.consumption_generator.create_private_consumption()
+        self.consumption_generator.create_private_consumption()
+        consumption_1, consumption_2 = list(
+            self.database_gateway.get_private_consumptions()
+        )
+        assert consumption_1.transaction_id != consumption_2.transaction_id
+
+    def test_that_amount_is_retrieved_with_the_same_value_as_specified_when_creating_the_consumption(
+        self,
+    ) -> None:
+        expected_amount = 123
+        self.consumption_generator.create_private_consumption(amount=expected_amount)
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        assert consumption.amount == expected_amount
+
+    def test_can_filter_consumptions_by_member(self) -> None:
+        member = self.member_generator.create_member()
+        other_member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        consumptions = self.database_gateway.get_private_consumptions()
+        assert consumptions.where_consumer_is_member(member)
+        assert not consumptions.where_consumer_is_member(other_member)
+
+    def test_that_plans_can_be_ordered_by_creation_date(self) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        plan_1 = self.plan_generator.create_plan()
+        self.consumption_generator.create_private_consumption(plan=plan_1.id)
+        self.datetime_service.advance_time(timedelta(days=1))
+        plan_2 = self.plan_generator.create_plan()
+        self.consumption_generator.create_private_consumption(plan=plan_2.id)
+        consumption_1, consumption_2 = list(
+            self.database_gateway.get_private_consumptions().ordered_by_creation_date(
+                ascending=True
+            )
+        )
+        assert consumption_1.plan_id == plan_1.id
+        assert consumption_2.plan_id == plan_2.id
+        consumption_2, consumption_1 = list(
+            self.database_gateway.get_private_consumptions().ordered_by_creation_date(
+                ascending=False
+            )
+        )
+        assert consumption_1.plan_id == plan_1.id
+        assert consumption_2.plan_id == plan_2.id
+
+    def test_can_retrieve_plan_and_transaction_with_consumption(self) -> None:
+        self.consumption_generator.create_private_consumption()
+        result = (
+            self.database_gateway.get_private_consumptions()
+            .joined_with_transactions_and_plan()
+            .first()
+        )
+        assert result
+        consumption, transaction, plan = result
+        assert consumption.transaction_id == transaction.id
+        assert consumption.plan_id == plan.id
+
+    def test_can_combine_filtering_and_joining_of_consumptions_with_transactions_and_plans(
+        self,
+    ) -> None:
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        assert (
+            self.database_gateway.get_private_consumptions()
+            .ordered_by_creation_date()
+            .where_consumer_is_member(member)
+            .joined_with_transactions_and_plan()
+        )
+
+    def test_can_filter_consumptions_by_providing_company(self) -> None:
+        provider = self.company_generator.create_company()
+        other_company = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=provider)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        consumptions = self.database_gateway.get_private_consumptions()
+        assert consumptions.where_provider_is_company(provider)
+        assert not consumptions.where_provider_is_company(other_company)
+
+    def test_can_retrieve_plan_and_transaction_and_consumer_with_consumption(
+        self,
+    ) -> None:
+        expected_consumer = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(
+            consumer=expected_consumer
+        )
+        result = (
+            self.database_gateway.get_private_consumptions()
+            .joined_with_transaction_and_plan_and_consumer()
+            .first()
+        )
+        assert result
+        consumption, transaction, plan, consumer = result
+        assert consumption.transaction_id == transaction.id
+        assert consumption.plan_id == plan.id
+        assert consumer.id == expected_consumer

--- a/tests/use_cases/test_review_registered_consumptions.py
+++ b/tests/use_cases/test_review_registered_consumptions.py
@@ -4,7 +4,7 @@ from math import isclose
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from tests.use_cases.base_test_case import BaseTestCase
 

--- a/tests/www/controllers/test_review_registered_consumptions_controller.py
+++ b/tests/www/controllers/test_review_registered_consumptions_controller.py
@@ -1,4 +1,5 @@
 from arbeitszeit_web.www.controllers.review_registered_consumptions_controller import (
+    InvalidRequest,
     ReviewRegisteredConsumptionsController,
 )
 from tests.www.base_test_case import BaseTestCase
@@ -9,23 +10,25 @@ class ReviewRegisteredConsumptionsControllerTests(BaseTestCase):
         super().setUp()
         self.controller = self.injector.get(ReviewRegisteredConsumptionsController)
 
-    def test_none_is_returned_if_no_user_is_logged_in(self):
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_none_is_returned_if_user_is_a_member(self):
-        self.session.login_member(self.member_generator.create_member())
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_none_is_returned_if_user_is_an_accountant(self):
-        self.session.login_accountant(self.accountant_generator.create_accountant())
-        self.assertIsNone(self.controller.create_use_case_request())
-
-    def test_use_case_request_is_created_if_user_is_a_company(self):
-        self.session.login_company(self.company_generator.create_company())
-        self.assertIsNotNone(self.controller.create_use_case_request())
-
-    def test_use_case_request_contains_providing_company(self):
-        company = self.company_generator.create_company()
-        self.session.login_company(company)
+    def test_401_is_returned_if_no_user_is_logged_in(self):
         request = self.controller.create_use_case_request()
-        self.assertEqual(request.providing_company, company)
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 401
+
+    def test_403_is_returned_if_user_is_a_member(self):
+        self.session.login_member(self.member_generator.create_member())
+        request = self.controller.create_use_case_request()
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 403
+
+    def test_403_is_returned_if_user_is_an_accountant(self):
+        self.session.login_accountant(self.accountant_generator.create_accountant())
+        request = self.controller.create_use_case_request()
+        assert isinstance(request, InvalidRequest)
+        assert request.status_code == 403
+
+    def test_use_case_request_contains_currently_logged_in_company_id(self):
+        expected_company_id = self.company_generator.create_company()
+        self.session.login_company(expected_company_id)
+        request = self.controller.create_use_case_request()
+        assert request.providing_company == expected_company_id

--- a/tests/www/presenters/test_review_registered_consumptions_presenter.py
+++ b/tests/www/presenters/test_review_registered_consumptions_presenter.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.review_registered_consumptions import RegisteredConsumption
 from arbeitszeit.use_cases.review_registered_consumptions import (
-    RewiewRegisteredConsumptionsUseCase as UseCase,
+    ReviewRegisteredConsumptionsUseCase as UseCase,
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.review_registered_consumptions_presenter import (


### PR DESCRIPTION
This commit adds the html layer for the company's review consumptions feature. This view allows companies to see a list of their "sales", with the buyer's non-anonymized data. If the consumer is a member, only the user's name is shown - in the long run this might not be detailed enough and we probably will have to identify the member with a link to their profile (currently there are no member profile pages that can be accessed by other users) or the member's ID number.

Builds on #926 and #927

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c