### PR TITLE
Add strict undefined behavior for Jinja2 environment

### DIFF
--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from flask import Flask, session
 from flask_migrate import upgrade
 from flask_talisman import Talisman
+from jinja2 import StrictUndefined
 
 import arbeitszeit_flask.extensions
 from arbeitszeit_flask.babel import initialize_babel
@@ -50,6 +51,7 @@ def create_app(config: Any = None, db: Any = None, template_folder: Any = None) 
     app = Flask(
         __name__, instance_relative_config=False, template_folder=template_folder
     )
+    app.jinja_env.undefined = StrictUndefined
 
     load_configuration(app=app, configuration=config)
 

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -51,7 +51,6 @@ def create_app(config: Any = None, db: Any = None, template_folder: Any = None) 
     app = Flask(
         __name__, instance_relative_config=False, template_folder=template_folder
     )
-    app.jinja_env.undefined = StrictUndefined
 
     load_configuration(app=app, configuration=config)
 
@@ -62,8 +61,10 @@ def create_app(config: Any = None, db: Any = None, template_folder: Any = None) 
     # view without being logged in.
     login_manager.login_view = "auth.start"
 
-    # Init Flask-Talisman
-    if not app.config["DEBUG"]:
+    if app.config["DEBUG"]:
+        app.jinja_env.undefined = StrictUndefined
+    else:
+        # Init Flask-Talisman
         csp = {"default-src": ["'self'", "'unsafe-inline'", "*.fontawesome.com"]}
         Talisman(
             app, content_security_policy=csp, force_https=app.config["FORCE_HTTPS"]

--- a/arbeitszeit_flask/configuration_base.py
+++ b/arbeitszeit_flask/configuration_base.py
@@ -24,3 +24,10 @@ FLASK_PROFILER = {
 
 RESTX_MASK_SWAGGER = False
 ARBEITSZEIT_PASSWORD_HASHER = "arbeitszeit_flask.password_hasher:PasswordHasherImpl"
+
+# swagger placeholders are necessary until fix of bug in flask-restx:
+# https://github.com/python-restx/flask-restx/issues/565
+SWAGGER_UI_OAUTH_CLIENT_ID = "placeholder"
+SWAGGER_VALIDATOR_URL = "placeholder"
+SWAGGER_UI_OAUTH_REALM = "placeholder"
+SWAGGER_UI_OAUTH_APP_NAME = "placeholder"

--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -22,13 +22,13 @@
 </head>
 
 <body>
-  {% if session['user_type'] == 'company' %}
+  {% if session['user_type'] is defined and (session['user_type'] == 'company') %}
   {% set user_navigation = company_navigation %}
 
-  {% elif session['user_type'] == 'member' %}
+  {% elif session['user_type'] is defined and (session['user_type'] == 'member') %}
   {% set user_navigation = member_navigation %}
 
-  {% elif session['user_type'] == 'accountant' %}
+  {% elif session['user_type'] is defined and (session['user_type'] == 'accountant') %}
   {% set user_navigation = accountant_navigation %}
 
   {% else %}

--- a/arbeitszeit_flask/templates/user/request_email_address_change.html
+++ b/arbeitszeit_flask/templates/user/request_email_address_change.html
@@ -9,9 +9,11 @@
       <div class="control">
         {{ form.new_email() }}
       </div>
+      {% if form.new_email.errors is defined and form.new_email.errors %}
       {% for error in form.errors['new_email'] %}
       <p class="help is-danger">{{ error }}</p>
       {% endfor %}
+      {% endif %}
     </div>
     <div class="field">
       <div class="control">

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -13,6 +13,7 @@ from arbeitszeit_flask.token import FlaskTokenService
 from tests.data_generators import (
     AccountantGenerator,
     CompanyGenerator,
+    ConsumptionGenerator,
     CooperationGenerator,
     CoordinationTransferRequestGenerator,
     EmailGenerator,
@@ -69,6 +70,7 @@ class ViewTestCase(FlaskTestCase):
         self.coordination_transfer_request_generator = self.injector.get(
             CoordinationTransferRequestGenerator
         )
+        self.consumption_generator = self.injector.get(ConsumptionGenerator)
 
     def login_member(
         self,

--- a/tests/flask_integration/test_private_consumptions_view.py
+++ b/tests/flask_integration/test_private_consumptions_view.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import jinja2
+import pytest
 from parameterized import parameterized
 
 from tests.flask_integration.flask import LogInUser, ViewTestCase
@@ -27,6 +29,17 @@ class UserAccessTests(ViewTestCase):
             login=login,
             expected_code=expected_code,
         )
+
+    @pytest.mark.xfail(
+        raises=jinja2.exceptions.UndefinedError,
+        reason="expected to fail until resolution of issue #921",
+        strict=True,
+    )
+    def test_logged_in_member_gets_200_after_consuming_something(self) -> None:
+        member = self.login_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
 
 
 class AnonymousUserTest(ViewTestCase):

--- a/tests/flask_integration/test_private_consumptions_view.py
+++ b/tests/flask_integration/test_private_consumptions_view.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import jinja2
-import pytest
 from parameterized import parameterized
 
 from tests.flask_integration.flask import LogInUser, ViewTestCase
@@ -30,11 +28,6 @@ class UserAccessTests(ViewTestCase):
             expected_code=expected_code,
         )
 
-    @pytest.mark.xfail(
-        raises=jinja2.exceptions.UndefinedError,
-        reason="expected to fail until resolution of issue #921",
-        strict=True,
-    )
     def test_logged_in_member_gets_200_after_consuming_something(self) -> None:
         member = self.login_member()
         self.consumption_generator.create_private_consumption(consumer=member)


### PR DESCRIPTION
In the past our app did crash or behave unexpectedly because of errors in our jinja templates. For example when we would loop over undefined variables or used a mistyped variable in a template.  A current example is described in issue #921.

In order to be able to catch these errors in our tests we set the `undefined` paramter of the jinja environment of this app to `StrictUndefined` https://jinja.palletsprojects.com/en/3.0.x/api/#undefined-types

We also fix the places where the new configuration raises errors. In the `configuration_base.py` we have to insert four dummy config entries until a bug in flask-restx is fixed.

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c (4x)