### PR TITLE
New API endpoint `consumptions`

### DIFF
--- a/arbeitszeit/use_cases/register_productive_consumption.py
+++ b/arbeitszeit/use_cases/register_productive_consumption.py
@@ -48,7 +48,7 @@ class RegisterProductiveConsumption:
             plan, consumer, purpose = self._validate_request(request)
         except RegisterProductiveConsumptionResponse.RejectionReason as reason:
             return RegisterProductiveConsumptionResponse(rejection_reason=reason)
-        self.create_transaction(
+        self._create_transaction(
             consumer=consumer,
             plan=plan,
             amount=request.amount,
@@ -98,7 +98,7 @@ class RegisterProductiveConsumption:
             raise RegisterProductiveConsumptionResponse.RejectionReason.invalid_consumption_type
         return request.consumption_type
 
-    def create_transaction(
+    def _create_transaction(
         self,
         amount: int,
         consumption_type: ConsumptionType,

--- a/arbeitszeit_flask/api/__init__.py
+++ b/arbeitszeit_flask/api/__init__.py
@@ -5,6 +5,7 @@ from arbeitszeit_flask.extensions import csrf_protect
 
 from .auth import namespace as auth_ns
 from .companies import namespace as companies_ns
+from .consumptions import namespace as consumptions_ns
 from .plans import namespace as plans_ns
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
@@ -28,6 +29,8 @@ api_extension = Api(
     decorators=[csrf_protect.exempt],
 )
 
-api_extension.add_namespace(plans_ns)
-api_extension.add_namespace(companies_ns)
+# the ordering of these calls determines the order of the endpoints in the swagger UI
 api_extension.add_namespace(auth_ns)
+api_extension.add_namespace(companies_ns)
+api_extension.add_namespace(plans_ns)
+api_extension.add_namespace(consumptions_ns)

--- a/arbeitszeit_flask/api/companies.py
+++ b/arbeitszeit_flask/api/companies.py
@@ -14,7 +14,7 @@ from arbeitszeit_web.api.controllers.query_companies_api_controller import (
 from arbeitszeit_web.api.presenters.query_companies_api_presenter import (
     QueryCompaniesApiPresenter,
 )
-from arbeitszeit_web.api.response_errors import BadRequest
+from arbeitszeit_web.api.response_errors import BadRequest, Unauthorized
 
 namespace = Namespace("companies", "Companies related endpoints.")
 
@@ -31,7 +31,9 @@ model = SchemaConverter(namespace).json_schema_to_flaskx(
 class QueryCompanies(Resource):
     @namespace.expect(input_documentation)
     @namespace.marshal_with(model, skip_none=True)
-    @error_response_handling(error_responses=[BadRequest], namespace=namespace)
+    @error_response_handling(
+        error_responses=[BadRequest, Unauthorized], namespace=namespace
+    )
     @authentication_check
     @with_injection()
     def get(

--- a/arbeitszeit_flask/api/consumptions.py
+++ b/arbeitszeit_flask/api/consumptions.py
@@ -1,0 +1,58 @@
+from flask_restx import Namespace, Resource
+
+from arbeitszeit.use_cases.register_productive_consumption import (
+    RegisterProductiveConsumption,
+)
+from arbeitszeit_flask.api.authentication import authentication_check
+from arbeitszeit_flask.api.input_documentation import generate_input_documentation
+from arbeitszeit_flask.api.response_handling import error_response_handling
+from arbeitszeit_flask.api.schema_converter import SchemaConverter
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_web.api.controllers.liquid_means_consumption_controller import (
+    LiquidMeansConsumptionController,
+)
+from arbeitszeit_web.api.presenters.liquid_means_consumption_presenter import (
+    LiquidMeansConsumptionPresenter,
+)
+from arbeitszeit_web.api.response_errors import (
+    BadRequest,
+    Forbidden,
+    NotFound,
+    Unauthorized,
+)
+
+namespace = Namespace("consumptions", "Consumptions related endpoints.")
+
+input_documentation = generate_input_documentation(
+    LiquidMeansConsumptionController.create_expected_inputs()
+)
+
+model = SchemaConverter(namespace).json_schema_to_flaskx(
+    schema=LiquidMeansConsumptionPresenter().get_schema()
+)
+
+
+@namespace.route("/liquid_means_of_production")
+class LiquidMeansOfProduction(Resource):
+    @namespace.expect(input_documentation)
+    @namespace.marshal_with(model, skip_none=True)
+    @error_response_handling(
+        error_responses=[Unauthorized, BadRequest, NotFound, Forbidden],
+        namespace=namespace,
+    )
+    @authentication_check
+    @with_injection()
+    @commit_changes
+    def post(
+        self,
+        controller: LiquidMeansConsumptionController,
+        register_productive_consumption: RegisterProductiveConsumption,
+        presenter: LiquidMeansConsumptionPresenter,
+    ):
+        """
+        Register consumption of liquid means of production.
+        """
+        use_case_request = controller.create_request()
+        use_case_response = register_productive_consumption(use_case_request)
+        return presenter.create_view_model(use_case_response)

--- a/arbeitszeit_flask/api/input_documentation.py
+++ b/arbeitszeit_flask/api/input_documentation.py
@@ -6,15 +6,6 @@ from arbeitszeit_web.api.controllers.expected_input import InputLocation
 from arbeitszeit_web.api.controllers.query_plans_api_controller import ExpectedInput
 
 
-def _generate_location(location: InputLocation) -> str:
-    if location == InputLocation.query:
-        return "query"
-    elif location == InputLocation.form:
-        return "form"
-    else:
-        return "path"
-
-
 def generate_input_documentation(
     expected_inputs: List[ExpectedInput],
 ) -> RequestParser:
@@ -29,3 +20,15 @@ def generate_input_documentation(
             required=input.required,
         )
     return parser
+
+
+def _generate_location(location: InputLocation) -> str:
+    match location:
+        case InputLocation.query:
+            return "query"
+        case InputLocation.form:
+            return "form"
+        case InputLocation.path:
+            return "path"
+        case _:
+            raise ValueError(f"Unknown location: {location}")

--- a/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
+++ b/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.use_cases.register_productive_consumption import (
+    RegisterProductiveConsumptionRequest as UseCaseRequest,
+)
+from arbeitszeit_web.api.controllers.expected_input import ExpectedInput, InputLocation
+from arbeitszeit_web.api.response_errors import BadRequest, Unauthorized
+from arbeitszeit_web.request import Request
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class LiquidMeansConsumptionController:
+    @classmethod
+    def create_expected_inputs(cls) -> list[ExpectedInput]:
+        return [
+            ExpectedInput(
+                name="plan_id",
+                type=str,
+                description="The plan to consume.",
+                default=None,
+                location=InputLocation.form,
+                required=True,
+            ),
+            ExpectedInput(
+                name="amount",
+                type=int,
+                description="The amount of product to consume.",
+                default=None,
+                location=InputLocation.form,
+                required=True,
+            ),
+        ]
+
+    request: Request
+    session: Session
+
+    def create_request(self) -> UseCaseRequest:
+        company = self._validate_current_user()
+        return UseCaseRequest(
+            consumer=company,
+            plan=self._parse_plan_id(),
+            amount=self._parse_amount(),
+            consumption_type=ConsumptionType.raw_materials,
+        )
+
+    def _validate_current_user(self) -> UUID:
+        current_user = self.session.get_current_user()
+        if current_user is None:
+            raise Unauthorized(
+                message="You have to authenticate before using this service."
+            )
+        user_role = self.session.get_user_role()
+        if user_role != UserRole.company:
+            raise Unauthorized(
+                message="You must authenticate as a company to register consumption of means of production."
+            )
+        return current_user
+
+    def _parse_plan_id(self) -> UUID:
+        plan_id = self.request.get_form("plan_id")
+        if not plan_id:
+            raise BadRequest(message="Plan id missing.")
+        try:
+            plan_uuid = UUID(plan_id)
+        except ValueError:
+            raise BadRequest(f"Plan id must be in UUID format, got {plan_id}.")
+        return plan_uuid
+
+    def _parse_amount(self) -> int:
+        amount = self.request.get_form("amount")
+        if not amount:
+            raise BadRequest(message="Amount missing.")
+        try:
+            amount_int = int(amount)
+        except ValueError:
+            raise BadRequest(message=f"Amount must be an integer, got {amount}.")
+        if amount_int < 1:
+            raise BadRequest(
+                message=f"Amount must be a positive integer, got {amount}."
+            )
+        return amount_int

--- a/arbeitszeit_web/api/controllers/query_companies_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_companies_api_controller.py
@@ -17,14 +17,14 @@ class QueryCompaniesApiController:
         return [
             ExpectedInput(
                 name="offset",
-                type=str,
+                type=int,
                 description="The query offset.",
                 default=DEFAULT_OFFSET,
                 location=InputLocation.query,
             ),
             ExpectedInput(
                 name="limit",
-                type=str,
+                type=int,
                 description="The query limit.",
                 default=DEFAULT_LIMIT,
                 location=InputLocation.query,

--- a/arbeitszeit_web/api/controllers/query_plans_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_plans_api_controller.py
@@ -17,14 +17,14 @@ class QueryPlansApiController:
         return [
             ExpectedInput(
                 name="offset",
-                type=str,
+                type=int,
                 description="The query offset.",
                 default=DEFAULT_OFFSET,
                 location=InputLocation.query,
             ),
             ExpectedInput(
                 name="limit",
-                type=str,
+                type=int,
                 description="The query limit.",
                 default=DEFAULT_LIMIT,
                 location=InputLocation.query,

--- a/arbeitszeit_web/api/presenters/liquid_means_consumption_presenter.py
+++ b/arbeitszeit_web/api/presenters/liquid_means_consumption_presenter.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.register_productive_consumption import (
+    RegisterProductiveConsumptionResponse as UseCaseResponse,
+)
+from arbeitszeit_web.api.presenters.interfaces import JsonBoolean, JsonObject, JsonValue
+from arbeitszeit_web.api.response_errors import Forbidden, NotFound
+
+
+@dataclass
+class LiquidMeansConsumptionPresenter:
+    @dataclass
+    class ViewModel:
+        success: bool
+
+    @classmethod
+    def get_schema(cls) -> JsonValue:
+        return JsonObject(
+            members=dict(success=JsonBoolean()),
+            name="LiquidMeansConsumptionResponse",
+        )
+
+    def create_view_model(self, response: UseCaseResponse) -> ViewModel:
+        if not response.is_rejected:
+            return self.ViewModel(success=True)
+        match response.rejection_reason:
+            case UseCaseResponse.RejectionReason.plan_not_found:
+                raise NotFound(message="Plan does not exist.")
+            case UseCaseResponse.RejectionReason.plan_is_not_active:
+                raise NotFound(message="The specified plan has expired.")
+            case UseCaseResponse.RejectionReason.cannot_consume_public_service:
+                raise Forbidden(message="Companies cannot acquire public products.")
+            case UseCaseResponse.RejectionReason.consumer_is_planner:
+                raise Forbidden(message="Companies cannot acquire their own products.")
+            case _:
+                raise NotFound(message="Unknown error.")

--- a/arbeitszeit_web/api/response_errors.py
+++ b/arbeitszeit_web/api/response_errors.py
@@ -1,3 +1,7 @@
+"""
+The exceptions in this module are ordered by their HTTP status code.
+"""
+
 from typing import Protocol
 
 from arbeitszeit_web.api.presenters.interfaces import JsonObject, JsonString, JsonValue
@@ -30,6 +34,18 @@ error_response_schema = JsonObject(
 )
 
 
+class BadRequest(Exception):
+    code = 400
+    description = "Bad Request"
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    @classmethod
+    def get_schema(cls) -> JsonValue:
+        return error_response_schema
+
+
 class Unauthorized(Exception):
     code = 401
     description = "Unauthorized"
@@ -42,9 +58,9 @@ class Unauthorized(Exception):
         return error_response_schema
 
 
-class BadRequest(Exception):
-    code = 400
-    description = "Bad Request"
+class Forbidden(Exception):
+    code = 403
+    description = "Forbidden"
 
     def __init__(self, message: str) -> None:
         self.message = message

--- a/tests/api/controllers/test_liquid_means_consumption_controller.py
+++ b/tests/api/controllers/test_liquid_means_consumption_controller.py
@@ -1,0 +1,185 @@
+from uuid import uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit_web.api.controllers.expected_input import InputLocation
+from arbeitszeit_web.api.controllers.liquid_means_consumption_controller import (
+    LiquidMeansConsumptionController,
+)
+from arbeitszeit_web.api.response_errors import BadRequest, Unauthorized
+from tests.request import FakeRequest
+from tests.www.base_test_case import BaseTestCase
+
+
+class ControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(LiquidMeansConsumptionController)
+        self.request = self.injector.get(FakeRequest)
+
+    def test_controller_raises_unauthorized_for_anonymous_user(self) -> None:
+        with self.assertRaises(Unauthorized):
+            self.controller.create_request()
+
+    def test_controller_raises_unauthorized_for_member(self) -> None:
+        member = self.member_generator.create_member()
+        self.session.login_member(member)
+        with self.assertRaises(Unauthorized):
+            self.controller.create_request()
+
+    def test_controller_raises_unauthorized_for_accountant(self) -> None:
+        accountant = self.accountant_generator.create_accountant()
+        self.session.login_accountant(accountant)
+        with self.assertRaises(Unauthorized):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_plan_id_and_amount_are_missing(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_plan_id_is_missing(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("amount", "10")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_amount_is_missing(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_plan_id_is_not_in_uuid_format(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", "invalid_uuid")
+        self.request.set_form("amount", "10")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_amount_is_a_character(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "invalid_amount")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_amount_is_a_floating_number(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "10.5")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_amount_is_zero(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "0")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_raises_bad_request_when_amount_is_negative(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "-10")
+        with self.assertRaises(BadRequest):
+            self.controller.create_request()
+
+    def test_controller_creates_request_with_consumer_set_to_currently_logged_in_company(
+        self,
+    ) -> None:
+        expected_company = self.company_generator.create_company()
+        self.session.login_company(expected_company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "10")
+        request = self.controller.create_request()
+        self.assertEqual(request.consumer, expected_company)
+
+    def test_controller_creates_request_with_plan_as_specified_in_post_body(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        expected_plan_id = uuid4()
+        self.request.set_form("plan_id", str(expected_plan_id))
+        self.request.set_form("amount", "10")
+        request = self.controller.create_request()
+        self.assertEqual(request.plan, expected_plan_id)
+
+    @parameterized.expand(
+        [
+            (1,),
+            (101,),
+            (1000,),
+        ]
+    )
+    def test_controller_creates_request_with_amount_as_specified_in_post_body(
+        self, expected_amount: int
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", str(expected_amount))
+        request = self.controller.create_request()
+        self.assertEqual(request.amount, expected_amount)
+
+    def test_controller_creates_request_with_consumption_type_set_to_raw_materials(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company)
+        self.request.set_form("plan_id", str(uuid4()))
+        self.request.set_form("amount", "10")
+        request = self.controller.create_request()
+        self.assertEqual(request.consumption_type, ConsumptionType.raw_materials)
+
+
+class ExpectedInputsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(LiquidMeansConsumptionController)
+        self.inputs = self.controller.create_expected_inputs()
+
+    def test_controller_has_two_expected_inputs(self):
+        self.assertEqual(len(self.inputs), 2)
+
+    def test_first_expected_input_is_plan_id(self):
+        input = self.inputs[0]
+        self.assertEqual(input.name, "plan_id")
+
+    def test_input_plan_id_has_correct_parameters(self):
+        input = self.inputs[0]
+        self.assertEqual(input.name, "plan_id")
+        self.assertEqual(input.type, str)
+        self.assertEqual(input.description, "The plan to consume.")
+        self.assertEqual(input.default, None)
+        self.assertEqual(input.location, InputLocation.form)
+        self.assertEqual(input.required, True)
+
+    def test_second_expected_input_is_amount(self):
+        input = self.inputs[1]
+        self.assertEqual(input.name, "amount")
+
+    def test_input_amount_has_correct_parameters(self):
+        input = self.inputs[1]
+        self.assertEqual(input.name, "amount")
+        self.assertEqual(input.type, int)
+        self.assertEqual(input.description, "The amount of product to consume.")
+        self.assertEqual(input.default, None)
+        self.assertEqual(input.location, InputLocation.form)
+        self.assertEqual(input.required, True)

--- a/tests/api/controllers/test_query_companies_api_controller.py
+++ b/tests/api/controllers/test_query_companies_api_controller.py
@@ -118,7 +118,7 @@ class ExpectedInputsTests(BaseTestCase):
     def test_input_offset_has_correct_parameters(self) -> None:
         input = self.inputs[0]
         self.assertEqual(input.name, "offset")
-        self.assertEqual(input.type, str)
+        self.assertEqual(input.type, int)
         self.assertEqual(input.description, "The query offset.")
         self.assertEqual(input.default, 0)
         self.assertEqual(input.location, InputLocation.query)
@@ -131,7 +131,7 @@ class ExpectedInputsTests(BaseTestCase):
     def test_input_limit_has_correct_parameters(self) -> None:
         input = self.inputs[1]
         self.assertEqual(input.name, "limit")
-        self.assertEqual(input.type, str)
+        self.assertEqual(input.type, int)
         self.assertEqual(input.description, "The query limit.")
         self.assertEqual(input.default, 30)
         self.assertEqual(input.location, InputLocation.query)

--- a/tests/api/integration/base_test_case.py
+++ b/tests/api/integration/base_test_case.py
@@ -38,14 +38,11 @@ class ApiTestCase(FlaskTestCase):
         self.company_generator.create_company(
             password=password, email=email, confirmed=True
         )
-        # login via webapp, not api
-        # because api endpoint has not been implemented yet
         response = self.client.post(
-            "/company/login",
+            self.url_prefix + "/auth/login_company",
             data=dict(
                 email=email,
                 password=password,
             ),
-            follow_redirects=True,
         )
         assert response.status_code < 400

--- a/tests/api/integration/test_liquid_means_consumption.py
+++ b/tests/api/integration/test_liquid_means_consumption.py
@@ -1,0 +1,51 @@
+from tests.api.integration.base_test_case import ApiTestCase
+
+
+class AnonymousUserTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = self.url_prefix + "/consumptions/liquid_means_of_production"
+
+    def test_get_request_of_anonymous_user_returns_method_not_allowed_error(
+        self,
+    ) -> None:
+        response = self.client.get(self.url)
+        assert response.status_code == 405
+
+    def test_post_request_of_anonymous_user_returns_unauthorized_error(self) -> None:
+        response = self.client.post(self.url)
+        assert response.status_code == 401
+
+
+class AuthenticatedCompanyTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = self.url_prefix + "/consumptions/liquid_means_of_production"
+        self.login_company()
+
+    def test_post_request_of_authenticated_company_returns_ok_with_valid_input(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.post(self.url, data={"plan_id": plan, "amount": 10})
+        assert response.status_code == 200
+
+    def test_post_request_of_authenticated_company_returns_bad_request_with_invalid_input(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.post(self.url, data={"plan_id": plan})
+        assert response.status_code == 400
+
+
+class AuthenticatedMemberTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = self.url_prefix + "/consumptions/liquid_means_of_production"
+        self.login_member()
+
+    def test_post_request_of_authenticated_member_returns_unauthorized(
+        self,
+    ) -> None:
+        response = self.client.post(self.url)
+        assert response.status_code == 401

--- a/tests/api/integration/test_list_active_plans_api.py
+++ b/tests/api/integration/test_list_active_plans_api.py
@@ -1,63 +1,105 @@
+from parameterized import parameterized
+
 from tests.api.integration.base_test_case import ApiTestCase
 
 
-class UnauthentificatedUserTests(ApiTestCase):
+class AnonymousUserTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = self.url_prefix + "/plans/active"
 
-    def test_unauthenticated_user_gets_401(self):
+    def test_anonymous_user_gets_status_code_401_on_get_request(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
 
-    def test_unauthenticated_user_gets_corrrect_error_message(self):
+    def test_anonymous_user_gets_corrrect_error_message_on_get_request(self):
         expected_message = "You have to authenticate before using this service."
         response = self.client.get(self.url)
         self.assertEqual(response.json["message"], expected_message)
 
-    def test_unauthenticated_user_gets_mimetype_application_json(self):
+    def test_anonymous_user_gets_mimetype_application_json_on_get_request(self):
         response = self.client.get(self.url)
         self.assertEqual(response.mimetype, "application/json")
 
 
-class AuthentificatedCompanyTests(ApiTestCase):
+class AuthenticatedCompanyTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = self.url_prefix + "/plans/active"
         self.login_company()
 
-    def test_authenticated_company_can_get_plan_and_gets_200(self):
+    def test_company_gets_status_code_200_on_get_request(self):
         response = self.client.get(self.url)
         self.assertEqual(response.mimetype, "application/json")
         self.assertEqual(response.status_code, 200)
 
 
-class AuthentificatedMemberTests(ApiTestCase):
+class AuthenticatedMemberTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = self.url_prefix + "/plans/active"
         self.login_member()
 
-    def test_authenticated_member_can_get_plans_and_gets_200(self):
+    def test_member_gets_status_code_200_on_get_request(self):
         response = self.client.get(self.url)
         self.assertEqual(response.mimetype, "application/json")
         self.assertEqual(response.status_code, 200)
 
-    def test_get_returns_200_with_correct_offset_param(self):
-        response = self.client.get(self.url + "?offset=1")
+    @parameterized.expand(
+        [
+            (0,),
+            (75,),
+        ]
+    )
+    def test_member_gets_status_code_200_when_query_parameter_offset_is_a_positive_number(
+        self,
+        offset: int,
+    ):
+        response = self.client.get(self.url, query_string={"offset": offset})
         self.assertEqual(response.status_code, 200)
 
-    def test_get_returns_200_with_correct_offset_and_limit_params(self):
-        response = self.client.get(self.url + "?offset=1&limit=1")
-        self.assertEqual(response.status_code, 200)
-
-    def test_get_returns_400_when_letters_are_in_offset_param(
+    def test_member_gets_status_code_400_when_query_parameter_offset_is_a_negative_number(
         self,
     ):
-        response = self.client.get(self.url + "?offset=abc")
+        response = self.client.get(self.url, query_string={"offset": -1})
         self.assertEqual(response.status_code, 400)
 
-    def test_post_returns_405(self):
+    @parameterized.expand(
+        [
+            (0,),
+            (75,),
+        ]
+    )
+    def test_member_gets_status_code_200_when_query_parameter_limit_is_a_positive_number(
+        self,
+        offset: int,
+    ):
+        response = self.client.get(self.url, query_string={"limit": offset})
+        self.assertEqual(response.status_code, 200)
+
+    @parameterized.expand(
+        [
+            (3, 7),
+            (100, 5),
+        ]
+    )
+    def test_member_gets_status_code_200_with_offset_and_limit_set_to_positive_numbers(
+        self,
+        offset: int,
+        limit: int,
+    ):
+        response = self.client.get(
+            self.url, query_string={"offset": offset, "limit": limit}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_member_gets_status_code_400_when_letters_are_in_offset_param(
+        self,
+    ):
+        response = self.client.get(self.url, query_string={"offset": "abc"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_member_gets_status_code_405_on_post_request(self):
         response = self.client.post(self.url)
         self.assertEqual(response.mimetype, "application/json")
         self.assertEqual(response.status_code, 405)

--- a/tests/api/integration/test_query_companies_api.py
+++ b/tests/api/integration/test_query_companies_api.py
@@ -1,14 +1,19 @@
 from tests.api.integration.base_test_case import ApiTestCase
 
 
-class UnauthenticatedUsersTests(ApiTestCase):
+class AnonymousUsersTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = self.url_prefix + "/companies"
 
-    def test_unauthenticated_user_gets_401(self):
+    def test_anonymous_user_gets_status_code_401_on_get_request(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
+
+    def test_anonymous_user_gets_corrrect_error_message_on_get_request(self):
+        expected_message = "You have to authenticate before using this service."
+        response = self.client.get(self.url)
+        self.assertEqual(response.json["message"], expected_message)
 
 
 class AuthenticatedCompanyTests(ApiTestCase):

--- a/tests/api/presenters/test_liquid_means_consumption_presenter.py
+++ b/tests/api/presenters/test_liquid_means_consumption_presenter.py
@@ -1,0 +1,130 @@
+from arbeitszeit.use_cases.register_productive_consumption import (
+    RegisterProductiveConsumptionResponse as UseCaseResponse,
+)
+from arbeitszeit_web.api.presenters.interfaces import JsonBoolean, JsonObject
+from arbeitszeit_web.api.presenters.liquid_means_consumption_presenter import (
+    LiquidMeansConsumptionPresenter,
+)
+from arbeitszeit_web.api.response_errors import Forbidden, NotFound
+from tests.api.presenters.base_test_case import BaseTestCase
+
+
+class TestViewModelCreation(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(LiquidMeansConsumptionPresenter)
+
+    def test_view_model_returns_success_is_true_if_use_case_was_successful(
+        self,
+    ) -> None:
+        response = UseCaseResponse(rejection_reason=None)
+        view_model = self.presenter.create_view_model(response)
+        assert view_model.success
+
+    def test_view_model_raises_not_found_if_plan_was_not_found(self) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.plan_not_found
+        )
+        with self.assertRaises(NotFound):
+            self.presenter.create_view_model(response)
+
+    def test_view_model_shows_error_message_if_plan_was_not_found(self) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.plan_not_found
+        )
+        with self.assertRaises(NotFound) as err:
+            self.presenter.create_view_model(response)
+        assert err.exception.message == "Plan does not exist."
+
+    def test_view_model_raises_not_found_if_plan_has_expired(self) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.plan_is_not_active
+        )
+        with self.assertRaises(NotFound):
+            self.presenter.create_view_model(response)
+
+    def test_view_model_shows_error_message_if_plan_has_expired(self) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.plan_is_not_active
+        )
+        with self.assertRaises(NotFound) as err:
+            self.presenter.create_view_model(response)
+        assert err.exception.message == "The specified plan has expired."
+
+    def test_view_model_raises_forbidden_if_company_tries_to_acquire_public_product(
+        self,
+    ) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.cannot_consume_public_service
+        )
+        with self.assertRaises(Forbidden):
+            self.presenter.create_view_model(response)
+
+    def test_view_model_shows_error_message_if_company_tries_to_acquire_public_product(
+        self,
+    ) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.cannot_consume_public_service
+        )
+        with self.assertRaises(Forbidden) as err:
+            self.presenter.create_view_model(response)
+        assert err.exception.message == "Companies cannot acquire public products."
+
+    def test_view_model_raises_forbidden_if_company_tries_to_acquire_its_own_product(
+        self,
+    ) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.consumer_is_planner
+        )
+        with self.assertRaises(Forbidden):
+            self.presenter.create_view_model(response)
+
+    def test_view_model_shows_error_message_if_company_tries_to_acquire_its_own_product(
+        self,
+    ) -> None:
+        response = UseCaseResponse(
+            rejection_reason=UseCaseResponse.RejectionReason.consumer_is_planner
+        )
+        with self.assertRaises(Forbidden) as err:
+            self.presenter.create_view_model(response)
+        assert err.exception.message == "Companies cannot acquire their own products."
+
+
+class TestSchema(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(LiquidMeansConsumptionPresenter)
+        self.schema = self.presenter.get_schema()
+
+    def test_schema_is_of_type_object(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+
+    def test_schema_is_not_shown_as_list(self) -> None:
+        assert not self.schema.as_list
+
+    def test_schema_is_required(self) -> None:
+        assert self.schema.required
+
+    def test_schema_name_is_as_expected(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert self.schema.name == "LiquidMeansConsumptionResponse"
+
+    def test_schema_has_one_top_level_member(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert len(self.schema.members) == 1
+
+    def test_member_has_name_success(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert "success" in self.schema.members
+
+    def test_member_is_of_type_boolean(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert isinstance(self.schema.members["success"], JsonBoolean)
+
+    def test_member_success_is_required(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert self.schema.members["success"].required
+
+    def test_member_success_is_not_shown_as_list(self) -> None:
+        assert isinstance(self.schema, JsonObject)
+        assert not self.schema.members["success"].as_list


### PR DESCRIPTION
**API: Add missing documentation and some tests** 

The get route for companies was missing the documentation of the 401 error. Also tests for offset and limit parameters were added. The automatically generated OpenAPI documentation for the input parameters "offset" and "limit"
was changed in order to show that we expect integers.


**New API endpoint consumptions** 

This commit creates a new endpoint for our RestAPI, `/consumptions`, and implements also a route for this endpoint, `/consumptions/liquid_means_of_production`. This route accepts only POST requests and can be used by authenticated companies to register consumption of liquid means of production ("raw materials").

For this POST method we are using the existing `RegisterProductiveConsumption` use case from the business logic layer as well as the database implementation from the arbeitszeit_flask layer. On the other hand, new API-specific presenter and controller have been created.

The OpenAPI 2.0 documentation at `/api/v1/doc/` will be generated automatically.

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c (7x)

![image](https://github.com/arbeitszeit/arbeitszeitapp/assets/61537351/15b4d275-c9ff-4c2b-802d-bcc3ad29e1df)
