### PR TITLE
Run github CI workflow on pull requests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,10 @@
 name: Arbeitszeitapp CI Tests
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   static-code-analysis:


### PR DESCRIPTION
This change should fix the problem that our CI pipeline wouldn't run on pull requests from forks.

Details: https://docs.github.com/de/actions/using-workflows/events-that-trigger-workflows#pull_request