### PR TITLE
Add placeholders in plan draft creation forms

### DIFF
--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -262,20 +262,24 @@ class CreateDraftForm(Form):
     )
     description = TextAreaField(validators=[validators.InputRequired()])
     timeframe = IntegerField(
-        validators=[validators.InputRequired(), validators.NumberRange(min=1, max=365)]
+        validators=[validators.InputRequired(), validators.NumberRange(min=1, max=365)],
+        render_kw={"placeholder": trans.lazy_gettext("Days")},
     )
     prd_unit = StringField(validators=[validators.InputRequired()])
     prd_amount = IntegerField(
         validators=[validators.InputRequired(), validators.NumberRange(min=1)]
     )
     costs_p = DecimalField(
-        validators=[validators.InputRequired(), validators.NumberRange(min=0)]
+        validators=[validators.InputRequired(), validators.NumberRange(min=0)],
+        render_kw={"placeholder": trans.lazy_gettext("Hours")},
     )
     costs_r = DecimalField(
-        validators=[validators.InputRequired(), validators.NumberRange(min=0)]
+        validators=[validators.InputRequired(), validators.NumberRange(min=0)],
+        render_kw={"placeholder": trans.lazy_gettext("Hours")},
     )
     costs_a = DecimalField(
-        validators=[validators.InputRequired(), validators.NumberRange(min=0)]
+        validators=[validators.InputRequired(), validators.NumberRange(min=0)],
+        render_kw={"placeholder": trans.lazy_gettext("Hours")},
     )
     productive_or_public = BooleanField(
         trans.lazy_gettext("This plan is a public service")

--- a/arbeitszeit_flask/templates/macros/draft_form.html
+++ b/arbeitszeit_flask/templates/macros/draft_form.html
@@ -31,7 +31,7 @@ token field and buttons to submit. -->
     <span class="icon"><i class="fa-solid fa-circle-question"></i></span>
   </div>
   <div class="field">
-    <label class="label">{{ gettext("Planning timeframe (days)")}}</label>
+    <label class="label">{{ gettext("Planning timeframe")}}</label>
     <div class="control">
       {{ form.timeframe(class_="input is-large") }}
     </div>

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -30,7 +30,6 @@ class CreateDraftView:
 
     @commit_changes
     def POST(self) -> Response:
-        """either cancel plan creation, save draft or file draft."""
         form = CreateDraftForm(request.form)
         user_action = self.request.get_form("action")
         if user_action == "save_draft":


### PR DESCRIPTION
This commit adds placeholders to the `CreateDraftForm`. The text "Days" appear in the field "planning timeframe" and the text "Hours" appear in fields "cost_p", "cost_r" and "cost_a".

No registration needed.

![image](https://github.com/arbeitszeit/arbeitszeitapp/assets/61537351/31a304de-2381-441d-a397-15691e4de3ba)
![image](https://github.com/arbeitszeit/arbeitszeitapp/assets/61537351/1b25f184-9698-4fce-ae32-354823fe6f57)
