### PR TITLE
Non-colored balances of company accounts

### DIFF
--- a/arbeitszeit_flask/templates/user/company_account_a.html
+++ b/arbeitszeit_flask/templates/user/company_account_a.html
@@ -22,7 +22,7 @@
         </div>
         <p>{{ gettext("Balance:") }}</p>
         <p
-            class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+            class="has-text-weight-bold">
             {{ view_model.account_balance }}
         </p>
         <div>

--- a/arbeitszeit_flask/templates/user/company_account_p.html
+++ b/arbeitszeit_flask/templates/user/company_account_p.html
@@ -22,7 +22,7 @@
             </div>
             <p>{{ gettext("Balance:") }}</p>
             <p
-                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+                class="has-text-weight-bold">
                 {{ view_model.account_balance }}
             </p>
         <div>

--- a/arbeitszeit_flask/templates/user/company_account_prd.html
+++ b/arbeitszeit_flask/templates/user/company_account_prd.html
@@ -21,7 +21,7 @@
             </div>
             <p>{{ gettext("Balance:") }}</p>
             <p
-                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
+                class="has-text-weight-bold">
                 {{ view_model.account_balance }}</p>
         
             <div>

--- a/arbeitszeit_flask/templates/user/company_account_r.html
+++ b/arbeitszeit_flask/templates/user/company_account_r.html
@@ -22,7 +22,7 @@
         </div>
         <p>{{ gettext("Balance:") }}</p>
         <p
-            class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+            class="has-text-weight-bold">
             {{ view_model.account_balance }}
         </p>
         <div>

--- a/arbeitszeit_flask/templates/user/company_accounts.html
+++ b/arbeitszeit_flask/templates/user/company_accounts.html
@@ -35,7 +35,7 @@
                         <td class="is-italic">{{ gettext("Account for fixed means of production") }}
                         </td>
                         <td
-                            class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
+                            class="py-2 has-text-right has-text-weight-bold">
                             {{ view_model.balance_fixed }}</td>
                     </tr>
                     <tr>
@@ -46,7 +46,7 @@
                         <td class="is-italic">{{ gettext("Account for liquid means of production")}}
                         </td>
                         <td
-                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
+                            class="py-2 has-text-right has-text-weight-bold">
                             {{ view_model.balance_liquid }}</td>
                     </tr>
                     <tr>
@@ -57,7 +57,7 @@
                         <td class="is-italic">{{ gettext("Account for work certificates (wages)") }}
                         </td>
                         <td
-                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
+                            class="py-2 has-text-right has-text-weight-bold">
                             {{ view_model.balance_work }}</td>
                     </tr>
                     <tr>
@@ -67,7 +67,7 @@
                         <td class="is-italic">{{ gettext("Account for product transfers (sales)") }}
                         </td>
                         <td
-                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
+                            class="py-2 has-text-right has-text-weight-bold">
                             {{ view_model.balance_product }}</td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Before this commit balances of company accounts p, r, a and prd were shown green when value was >= 0 and red when <0. This was misleading, because it potentially shows a "green light" for misplanning (less consumption of means of production, less worked hours, more product delivered than originally planned, etc.). The real goal of planning is to be near zero. 

The company balances are now always non-colored. Green and red coloring has been maintained for transactions (it's easier in order to distinguish between positive and negative numbers) and for the member account (here it is more probable that it is problematic if a worker consumes more than the amount of available work certificates).

Plan: b05bef9c-4dbf-4cd1-9e99-59219dfa9c4b