### PR TITLE
Fix bug in QueryPlansView

### DIFF
--- a/arbeitszeit_flask/views/query_plans.py
+++ b/arbeitszeit_flask/views/query_plans.py
@@ -22,7 +22,7 @@ class QueryPlansView:
     request: FlaskRequest
 
     def GET(self) -> Response:
-        form = PlanSearchForm(request.form)
+        form = PlanSearchForm(request.args)
         if not form.validate():
             return self._get_invalid_form_response(form=form)
         use_case_request = self.controller.import_form_data(form, self.request)

--- a/tests/flask_integration/test_query_companies_view.py
+++ b/tests/flask_integration/test_query_companies_view.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+from uuid import uuid4
 
 from parameterized import parameterized
 
@@ -68,3 +69,17 @@ class QueryCompanyViewTests(ViewTestCase):
             expected_code=400,
             data=data,
         )
+
+    def test_that_one_company_name_appears_in_html_when_there_are_two_companies_but_only_one_is_searched_for(
+        self,
+    ) -> None:
+        self.login_member()
+        EXPECTED_COMPANY_NAME = f"One-{uuid4()}"
+        UNEXPECTED_COMPANY_NAME = f"Two-{uuid4()}"
+        self.company_generator.create_company(name=EXPECTED_COMPANY_NAME)
+        self.company_generator.create_company(name=UNEXPECTED_COMPANY_NAME)
+        response = self.client.get(
+            URL, query_string={"select": "Name", "search": EXPECTED_COMPANY_NAME}
+        )
+        assert EXPECTED_COMPANY_NAME in response.text
+        assert UNEXPECTED_COMPANY_NAME not in response.text

--- a/tests/flask_integration/test_query_plans_view.py
+++ b/tests/flask_integration/test_query_plans_view.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import uuid4
 
 from parameterized import parameterized
 
@@ -56,3 +57,19 @@ class UserAccessTests(ViewTestCase):
             login=None,
             expected_code=302,
         )
+
+
+class QueryPlansTests(ViewTestCase):
+    def test_that_one_plan_name_appears_in_html_when_there_are_two_plans_but_only_one_is_searched_for(
+        self,
+    ) -> None:
+        self.login_member()
+        EXPECTED_PLAN_NAME = f"One-{uuid4()}"
+        UNEXPECTED_PLAN_NAME = f"Two-{uuid4()}"
+        self.plan_generator.create_plan(product_name=EXPECTED_PLAN_NAME)
+        self.plan_generator.create_plan(product_name=UNEXPECTED_PLAN_NAME)
+        response = self.client.get(
+            URL, query_string={"select": "Produktname", "search": EXPECTED_PLAN_NAME}
+        )
+        assert EXPECTED_PLAN_NAME in response.text
+        assert UNEXPECTED_PLAN_NAME not in response.text


### PR DESCRIPTION
In the QueryPlansView we were passing `request.form` instead of `request.args` to the PlanSearchForm. This was incorrect because we are dealing with a GET request and key word arguments.

The bug has been fixed and integration tests have been added.

Plan: b05bef9c-4dbf-4cd1-9e99-59219dfa9c4b (2x)