### PR TITLE
Fix plan_details macro after bulma update

### DIFF
--- a/arbeitszeit_flask/templates/macros/plan_details.html
+++ b/arbeitszeit_flask/templates/macros/plan_details.html
@@ -6,11 +6,11 @@
             {{ gettext("Plan information") }}
         </h1>
         <div class="box">
-            <div class="tile is-ancestor">
+            <div class="grid">
                 <div class="tile is-vertical is-8">
                     <div class="tile">
-                        <div class="tile is-parent is-vertical">
-                            <article class="tile is-child notification">
+                        <div class="cell is-vertical">
+                            <article class="box notification">
                                 <div class="has-text-right has-text-info-dark">
                                     {{ info_tooltip(id="id_plan_id", text=gettext("This plan ID identifies your plan. It is used to account for labour time by workers and companies that work on, or respectively consume, the planned product or service.")) }}
                                 </div>
@@ -26,14 +26,14 @@
                                 </p>
                             </article>
                             <div class="tile">
-                                <div class="tile is-parent">
-                                    <article class="tile is-child notification">
+                                <div class="cell">
+                                    <article class="box notification">
                                         <p class="title is-4">{{ view_model.details.product_name[0] }}</p>
                                         <p class="subtitle">{{ view_model.details.product_name[1] }}</p>
                                     </article>
                                 </div>
-                                <div class="tile is-parent">
-                                    <article class="tile is-child notification">
+                                <div class="cell">
+                                    <article class="box notification">
                                         <p class="title is-4">{{ view_model.details.planner[0] }}</p>
                                         <p class="subtitle"><a href="{{ view_model.details.planner[2] }}">{{
                                         view_model.details.planner[3] }}</a></p>
@@ -43,8 +43,8 @@
                         </div>
                     </div>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child notification has-background-primary-light">
+                <div class="cell">
+                    <article class="box notification has-background-primary-light">
                         <div class="content">
                             <p class="title is-4">{{ view_model.details.description[0] }}</p>
                             <div class="content">
@@ -58,10 +58,10 @@
         </div>
 
         <div class="box">
-            <div class="tile is-ancestor">
+            <div class="grid">
                 <div class="tile is-4">
-                    <div class="tile is-parent">
-                        <article class="tile is-child notification has-background-warning-light">
+                    <div class="cell">
+                        <article class="box notification has-background-warning-light">
                             <div class="has-text-right has-text-info-dark">
                                 {{ info_tooltip(id="id_plan_status", text=gettext("Status can be \"Active\", i.e. plan was approved and current date is within planning timeframe, or \"Inactive\", i.e. plan is not yet approved or it is expired.")) }}
                             </div>
@@ -70,8 +70,8 @@
                         </article>
                     </div>
                 </div>
-                <div class="tile is-parent">
-                    <div class="tile is-child notification">
+                <div class="cell">
+                    <div class="box notification">
                         <p class="title is-4">{{ view_model.details.timeframe[0] }}</p>
                         <p class="subtitle">({{ view_model.details.active_days}} / {{ view_model.details.timeframe[1]
                             }})</p>
@@ -80,9 +80,9 @@
                     </div>
                 </div>
             </div>
-            <div class="tile is-ancestor">
-                <div class="tile is-parent">
-                    <article class="tile is-child notification">
+            <div class="grid">
+                <div class="cell">
+                    <article class="box notification">
                         <div class="columns subtitle is-italic">
                             <div class="column"><span
                                     class="has-text-weight-semibold">{{  gettext("Plan creation") }}</span>
@@ -100,18 +100,18 @@
         </div>
 
         <div class="box">
-            <div class="tile is-ancestor">
+            <div class="grid">
                 <div class="tile is-vertical">
                     <div class="tile">
-                        <div class="tile is-parent is-vertical">
-                            <article class="tile is-child notification">
+                        <div class="cell is-vertical">
+                            <article class="box notification">
                                 <div class="has-text-right has-text-info-dark">
                                     {{ info_tooltip(id="id_amount", text=gettext("This is the amount you plan to deliver.")) }}
                                 </div>
                                 <p class="title is-4">{{ view_model.details.amount[0] }}</p>
                                 <p class="subtitle">{{ view_model.details.amount[1] }}</p>
                             </article>
-                            <article class="tile is-child notification">
+                            <article class="box notification">
                                 <p class="title is-4">{{ view_model.details.production_unit[0] }}</p>
                                 <p class="subtitle">{{ view_model.details.production_unit[1] }}</p>
                             </article>
@@ -120,22 +120,22 @@
                 </div>
                 <div class="tile is-vertical is-8">
                     <div class="tile">
-                        <div class="tile is-parent is-vertical">
-                            <article class="tile is-child notification has-background-danger-light">
+                        <div class="cell is-vertical">
+                            <article class="box notification has-background-danger-light">
                                 <div class="has-text-right has-text-info-dark">
                                     {{ info_tooltip(id="id_fixed_means", text=gettext("This field is mainly to account for wear and tear of machines. E.g. if you plan to use a machine that cost 10000 hours to produce, for 10 years, and you have ten one-year-plans, then for this fixed mean of production, the value would be 1000.")) }}
                                 </div>
                                 <p class="title is-4">{{ view_model.details.means_cost[0] }}</p>
                                 <p class="subtitle">{{ view_model.details.means_cost[1] }}</p>
                             </article>
-                            <article class="tile is-child notification has-background-danger-light">
+                            <article class="box notification has-background-danger-light">
                                 <div class="has-text-right has-text-info-dark">
                                     {{ info_tooltip(id="id_liquid_means", text=gettext("Here, recurring costs from raw materials and consumables are summarized, e.g. electricity, rent for production halls, maintenance of machines etc.")) }}
                                 </div>
                                 <p class="title is-4">{{ view_model.details.resources_cost[0] }}</p>
                                 <p class="subtitle">{{ view_model.details.resources_cost[1] }}</p>
                             </article>
-                            <article class="tile is-child notification has-background-danger-light">
+                            <article class="box notification has-background-danger-light">
                                 <div class="has-text-right has-text-info-dark">
                                     {{ info_tooltip(id="id_labour", text=gettext("Planned hours of human work.")) }}
                                 </div>
@@ -149,9 +149,9 @@
         </div>
 
         <div class="box">
-            <div class="tile is-ancestor">
-                <div class="tile is-parent">
-                    <article class="tile is-child notification">
+            <div class="grid">
+                <div class="cell">
+                    <article class="box notification">
                         <div class="has-text-right has-text-info-dark">
                             {{ info_tooltip(id="id_type", text=gettext("\"Type\" can be either \"Productive\" or \"Public\". Products from the latter can be consumed for free, and are funded via the Factor of Individual Consumption (FIC).")) }}
                         </div>
@@ -159,8 +159,8 @@
                         <p class="subtitle">{{ view_model.details.type_of_plan[1] }}</p>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <div class="tile is-child notification has-background-warning-light">
+                <div class="cell">
+                    <div class="box notification has-background-warning-light">
                         <div class="has-text-right has-text-info-dark">
                             {{ info_tooltip(id="id_price_per_unit", text=gettext("This is the amount of time that is debited when the product is consumed. 0 for public plans.")) }}
                         </div>
@@ -174,8 +174,8 @@
                         </p>
                     </div>
                 </div>
-                <div class="tile is-parent">
-                    <div class="tile is-child notification has-background-warning-light">
+                <div class="cell">
+                    <div class="box notification has-background-warning-light">
                         <div class="has-text-right has-text-info-dark">
                             {{ info_tooltip(id="id_labour_per_unit", text=gettext("This field shows working hours spent per produced unit.")) }}
                         </div>

--- a/arbeitszeit_flask/templates/macros/plan_details.html
+++ b/arbeitszeit_flask/templates/macros/plan_details.html
@@ -5,183 +5,141 @@
         <h1 class="title">
             {{ gettext("Plan information") }}
         </h1>
-        <div class="box">
+        <div class="fixed-grid box has-3-cols has-1-cols-mobile">
             <div class="grid">
-                <div class="tile is-vertical is-8">
-                    <div class="tile">
-                        <div class="cell is-vertical">
-                            <article class="box notification">
-                                <div class="has-text-right has-text-info-dark">
-                                    {{ info_tooltip(id="id_plan_id", text=gettext("This plan ID identifies your plan. It is used to account for labour time by workers and companies that work on, or respectively consume, the planned product or service.")) }}
-                                </div>
-                                <p class="title is-4">{{ view_model.details.plan_id[0] }}</p>
-                                <p class="subtitle">
-                                    {{ view_model.details.plan_id[1] }}&nbsp;
-                                    <a  
-                                    role="button" 
-                                    onclick="copyTextToClipboard('{{ view_model.details.plan_id[1] }}'); 
-                                    changeElementIconToCheckIcon('changeableIcon')">
-                                        <span class="icon"><i id="changeableIcon" class="fa-regular fa-copy"></i></span>
-                                    </a>
-                                </p>
-                            </article>
-                            <div class="tile">
-                                <div class="cell">
-                                    <article class="box notification">
-                                        <p class="title is-4">{{ view_model.details.product_name[0] }}</p>
-                                        <p class="subtitle">{{ view_model.details.product_name[1] }}</p>
-                                    </article>
-                                </div>
-                                <div class="cell">
-                                    <article class="box notification">
-                                        <p class="title is-4">{{ view_model.details.planner[0] }}</p>
-                                        <p class="subtitle"><a href="{{ view_model.details.planner[2] }}">{{
-                                        view_model.details.planner[3] }}</a></p>
-                                    </article>
-                                </div>
-                            </div>
-                        </div>
+                <div class="cell notification is-col-span-2 is-col-span-1-mobile mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_plan_id", text=gettext("This plan ID identifies your plan. It is used to account for labour time by workers and companies that work on, or respectively consume, the planned product or service.")) }}
                     </div>
+                    <p class="title is-4">{{ view_model.details.plan_id[0] }}</p>
+                    <p class="subtitle">
+                        {{ view_model.details.plan_id[1] }}&nbsp;
+                        <a  
+                        role="button" 
+                        onclick="copyTextToClipboard('{{ view_model.details.plan_id[1] }}'); 
+                        changeElementIconToCheckIcon('changeableIcon')">
+                            <span class="icon"><i id="changeableIcon" class="fa-regular fa-copy"></i></span>
+                        </a>
+                    </p>
                 </div>
-                <div class="cell">
-                    <article class="box notification has-background-primary-light">
+                <div class="cell notification has-background-primary-light is-row-span-2 is-row-span-1-mobile mb-0">
+                    <div class="content">
+                        <p class="title is-4">{{ view_model.details.description[0] }}</p>
                         <div class="content">
-                            <p class="title is-4">{{ view_model.details.description[0] }}</p>
-                            <div class="content">
-                                <p>{% for paragraph in view_model.details.description[1] %}{{ paragraph
-                                    }}<br>{% endfor %}</p>
-                            </div>
+                            <p>{% for paragraph in view_model.details.description[1] %}{{ paragraph
+                                }}<br>{% endfor %}</p>
                         </div>
-                    </article>
+                    </div>
+                </div>
+                <div class="cell notification mb-0">
+                    <p class="title is-4">{{ view_model.details.product_name[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.product_name[1] }}</p>
+                </div>
+                <div class="cell notification mb-0">
+                    <p class="title is-4">{{ view_model.details.planner[0] }}</p>
+                    <p class="subtitle"><a href="{{ view_model.details.planner[2] }}">{{
+                    view_model.details.planner[3] }}</a></p>
                 </div>
             </div>
         </div>
 
-        <div class="box">
+        <div class="fixed-grid box has-3-cols has-1-cols-mobile">
             <div class="grid">
-                <div class="tile is-4">
-                    <div class="cell">
-                        <article class="box notification has-background-warning-light">
-                            <div class="has-text-right has-text-info-dark">
-                                {{ info_tooltip(id="id_plan_status", text=gettext("Status can be \"Active\", i.e. plan was approved and current date is within planning timeframe, or \"Inactive\", i.e. plan is not yet approved or it is expired.")) }}
-                            </div>
-                            <p class="title is-4">{{ view_model.details.activity_string[0] }}</p>
-                            <p class="subtitle">{{ view_model.details.activity_string[1] }}</p>
-                        </article>
+                <div class="cell notification has-background-warning-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_plan_status", text=gettext("Status can be \"Active\", i.e. plan was approved and current date is within planning timeframe, or \"Inactive\", i.e. plan is not yet approved or it is expired.")) }}
                     </div>
+                    <p class="title is-4">{{ view_model.details.activity_string[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.activity_string[1] }}</p>
                 </div>
-                <div class="cell">
-                    <div class="box notification">
-                        <p class="title is-4">{{ view_model.details.timeframe[0] }}</p>
-                        <p class="subtitle">({{ view_model.details.active_days}} / {{ view_model.details.timeframe[1]
-                            }})</p>
-                        <progress class="progress" value="{{ view_model.details.active_days}}"
-                            max="{{ view_model.details.timeframe[1] }}"></progress>
-                    </div>
+                <div class="cell notification is-col-span-2 is-col-span-1-mobile mb-0">
+                    <p class="title is-4">{{ view_model.details.timeframe[0] }}</p>
+                    <p class="subtitle">({{ view_model.details.active_days}} / {{ view_model.details.timeframe[1]
+                        }})</p>
+                    <progress class="progress" value="{{ view_model.details.active_days}}"
+                        max="{{ view_model.details.timeframe[1] }}"></progress>
                 </div>
-            </div>
-            <div class="grid">
-                <div class="cell">
-                    <article class="box notification">
-                        <div class="columns subtitle is-italic">
-                            <div class="column"><span
-                                    class="has-text-weight-semibold">{{  gettext("Plan creation") }}</span>
-                                {{ view_model.details.creation_date }}</div>
-                            <div class="column"><span
-                                    class="has-text-weight-semibold">{{  gettext("Plan approval") }}</span>
-                                {{ view_model.details.approval_date }}</div>
-                            <div class="column"><span
-                                    class="has-text-weight-semibold">{{  gettext("Plan expiration") }}</span>
-                                {{ view_model.details.expiration_date }}</div>
-                        </div>
-                    </article>
-                </div>
-            </div>
-        </div>
-
-        <div class="box">
-            <div class="grid">
-                <div class="tile is-vertical">
-                    <div class="tile">
-                        <div class="cell is-vertical">
-                            <article class="box notification">
-                                <div class="has-text-right has-text-info-dark">
-                                    {{ info_tooltip(id="id_amount", text=gettext("This is the amount you plan to deliver.")) }}
-                                </div>
-                                <p class="title is-4">{{ view_model.details.amount[0] }}</p>
-                                <p class="subtitle">{{ view_model.details.amount[1] }}</p>
-                            </article>
-                            <article class="box notification">
-                                <p class="title is-4">{{ view_model.details.production_unit[0] }}</p>
-                                <p class="subtitle">{{ view_model.details.production_unit[1] }}</p>
-                            </article>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-vertical is-8">
-                    <div class="tile">
-                        <div class="cell is-vertical">
-                            <article class="box notification has-background-danger-light">
-                                <div class="has-text-right has-text-info-dark">
-                                    {{ info_tooltip(id="id_fixed_means", text=gettext("This field is mainly to account for wear and tear of machines. E.g. if you plan to use a machine that cost 10000 hours to produce, for 10 years, and you have ten one-year-plans, then for this fixed mean of production, the value would be 1000.")) }}
-                                </div>
-                                <p class="title is-4">{{ view_model.details.means_cost[0] }}</p>
-                                <p class="subtitle">{{ view_model.details.means_cost[1] }}</p>
-                            </article>
-                            <article class="box notification has-background-danger-light">
-                                <div class="has-text-right has-text-info-dark">
-                                    {{ info_tooltip(id="id_liquid_means", text=gettext("Here, recurring costs from raw materials and consumables are summarized, e.g. electricity, rent for production halls, maintenance of machines etc.")) }}
-                                </div>
-                                <p class="title is-4">{{ view_model.details.resources_cost[0] }}</p>
-                                <p class="subtitle">{{ view_model.details.resources_cost[1] }}</p>
-                            </article>
-                            <article class="box notification has-background-danger-light">
-                                <div class="has-text-right has-text-info-dark">
-                                    {{ info_tooltip(id="id_labour", text=gettext("Planned hours of human work.")) }}
-                                </div>
-                                <p class="title is-4">{{ view_model.details.labour_cost[0] }}</p>
-                                <p class="subtitle">{{ view_model.details.labour_cost[1] }}</p>
-                            </article>
-                        </div>
+                <div class="cell notification is-col-span-3 is-col-span-1-mobile mb-0">
+                    <div class="columns subtitle is-italic">
+                        <div class="column"><span
+                                class="has-text-weight-semibold">{{  gettext("Plan creation") }}</span>
+                            {{ view_model.details.creation_date }}</div>
+                        <div class="column"><span
+                                class="has-text-weight-semibold">{{  gettext("Plan approval") }}</span>
+                            {{ view_model.details.approval_date }}</div>
+                        <div class="column"><span
+                                class="has-text-weight-semibold">{{  gettext("Plan expiration") }}</span>
+                            {{ view_model.details.expiration_date }}</div>
                     </div>
                 </div>
             </div>
         </div>
 
-        <div class="box">
+        <div class="fixed-grid box has-3-cols has-1-cols-mobile">
             <div class="grid">
-                <div class="cell">
-                    <article class="box notification">
-                        <div class="has-text-right has-text-info-dark">
-                            {{ info_tooltip(id="id_type", text=gettext("\"Type\" can be either \"Productive\" or \"Public\". Products from the latter can be consumed for free, and are funded via the Factor of Individual Consumption (FIC).")) }}
-                        </div>
-                        <p class="title is-4">{{ view_model.details.type_of_plan[0] }}</p>
-                        <p class="subtitle">{{ view_model.details.type_of_plan[1] }}</p>
-                    </article>
-                </div>
-                <div class="cell">
-                    <div class="box notification has-background-warning-light">
-                        <div class="has-text-right has-text-info-dark">
-                            {{ info_tooltip(id="id_price_per_unit", text=gettext("This is the amount of time that is debited when the product is consumed. 0 for public plans.")) }}
-                        </div>
-                        <p class="title is-4">{{ view_model.details.price_per_unit[0] }}</p>
-                        <p class="subtitle">{{ view_model.details.price_per_unit[1] }}
-                            {% if view_model.details.price_per_unit[2] %} <span>
-                                <a href="{{ view_model.details.price_per_unit[3] }}">
-                                    <i class="fas fa-hands-helping"></i></a>
-                            </span>
-                            {% endif %}
-                        </p>
+                <div class="cell box notification is-row-span-3 mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_amount", text=gettext("This is the amount you plan to deliver.")) }}
                     </div>
+                    <p class="title is-4">{{ view_model.details.amount[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.amount[1] }}</p>
                 </div>
-                <div class="cell">
-                    <div class="box notification has-background-warning-light">
-                        <div class="has-text-right has-text-info-dark">
-                            {{ info_tooltip(id="id_labour_per_unit", text=gettext("This field shows working hours spent per produced unit.")) }}
-                        </div>
-                        <p class="title is-4">{{ view_model.details.labour_cost_per_unit[0] }}</p>
-                        <p class="subtitle">{{ view_model.details.labour_cost_per_unit[1] }}</p>
+                <div class="cell box notification is-row-span-3 is-row-start-4 mb-0">
+                    <p class="title is-4">{{ view_model.details.production_unit[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.production_unit[1] }}</p>
+                </div>
+                <div class="cell box notification is-col-span-2 is-row-span-2 has-background-danger-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_fixed_means", text=gettext("This field is mainly to account for wear and tear of machines. E.g. if you plan to use a machine that cost 10000 hours to produce, for 10 years, and you have ten one-year-plans, then for this fixed mean of production, the value would be 1000.")) }}
                     </div>
+                    <p class="title is-4">{{ view_model.details.means_cost[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.means_cost[1] }}</p>
+                </div>
+                <div class="cell box notification is-col-span-2 is-row-span-2 has-background-danger-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_liquid_means", text=gettext("Here, recurring costs from raw materials and consumables are summarized, e.g. electricity, rent for production halls, maintenance of machines etc.")) }}
+                    </div>
+                    <p class="title is-4">{{ view_model.details.resources_cost[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.resources_cost[1] }}</p>
+                </div>
+                <div class="cell box notification is-col-span-2 is-row-span-2 has-background-danger-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_labour", text=gettext("Planned hours of human work.")) }}
+                    </div>
+                    <p class="title is-4">{{ view_model.details.labour_cost[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.labour_cost[1] }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="fixed-grid box has-3-cols has-1-cols-mobile">
+            <div class="grid">
+                <div class="cell box notification mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_type", text=gettext("\"Type\" can be either \"Productive\" or \"Public\". Products from the latter can be consumed for free, and are funded via the Factor of Individual Consumption (FIC).")) }}
+                    </div>
+                    <p class="title is-4">{{ view_model.details.type_of_plan[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.type_of_plan[1] }}</p>
+                </div>
+                <div class="cell box notification has-background-warning-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_price_per_unit", text=gettext("This is the amount of time that is debited when the product is consumed. 0 for public plans.")) }}
+                    </div>
+                    <p class="title is-4">{{ view_model.details.price_per_unit[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.price_per_unit[1] }}
+                        {% if view_model.details.price_per_unit[2] %} <span>
+                            <a href="{{ view_model.details.price_per_unit[3] }}">
+                                <i class="fas fa-hands-helping"></i></a>
+                        </span>
+                        {% endif %}
+                    </p>
+                </div>
+                <div class="cell box notification has-background-warning-light mb-0">
+                    <div class="has-text-right has-text-info-dark">
+                        {{ info_tooltip(id="id_labour_per_unit", text=gettext("This field shows working hours spent per produced unit.")) }}
+                    </div>
+                    <p class="title is-4">{{ view_model.details.labour_cost_per_unit[0] }}</p>
+                    <p class="subtitle">{{ view_model.details.labour_cost_per_unit[1] }}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As described here https://github.com/jgthms/bulma/issues/3730 tiles need to be replaced by grid and cells. This commit fixes the plan_details macro to use the new grid and cell classes.

Plan: b05bef9c-4dbf-4cd1-9e99-59219dfa9c4b (3x)